### PR TITLE
Add simple easing functions

### DIFF
--- a/examples/Bin.re
+++ b/examples/Bin.re
@@ -2,7 +2,6 @@ open Revery;
 open Revery.Core;
 open Revery.Math;
 open Revery.UI;
-open Revery.UI.Components;
 
 module Logo = (
   val component((render, ~children, ()) =>
@@ -21,6 +20,7 @@ module Logo = (
                   duration: Seconds(8.),
                   delay: Seconds(1.0),
                   repeat: true,
+                  easing: Animated.linear,
                 },
               );
 
@@ -32,6 +32,7 @@ module Logo = (
                   duration: Seconds(4.),
                   delay: Seconds(0.5),
                   repeat: true,
+                  easing: Animated.linear,
                 },
               );
 
@@ -68,6 +69,7 @@ module AnimatedText = (
                   duration: Seconds(1.),
                   delay: Seconds(delay),
                   repeat: false,
+                  easing: Animated.linear,
                 },
               );
 
@@ -79,6 +81,7 @@ module AnimatedText = (
                   duration: Seconds(0.5),
                   delay: Seconds(delay),
                   repeat: false,
+                  easing: Animated.linear,
                 },
               );
 
@@ -94,43 +97,6 @@ module AnimatedText = (
               );
 
             <text style=textHeaderStyle> textContent </text>;
-          },
-          ~children,
-        )
-      )
-);
-
-module SimpleButton = (
-  val component((render, ~children, ()) =>
-        render(
-          () => {
-            let (count, setCount) = useState(0);
-
-            let increment = () => setCount(count + 1);
-
-            let wrapperStyle =
-              Style.make(
-                ~backgroundColor=Color.rgba(1., 1., 1., 0.1),
-                ~border=Style.Border.make(~width=2, ~color=Colors.white, ()),
-                ~margin=16,
-                (),
-              );
-
-            let textHeaderStyle =
-              Style.make(
-                ~color=Colors.white,
-                ~fontFamily="Roboto-Regular.ttf",
-                ~fontSize=20,
-                ~margin=4,
-                (),
-              );
-
-            let textContent = "Click me: " ++ string_of_int(count);
-            <Clickable onClick=increment>
-              <view style=wrapperStyle>
-                <text style=textHeaderStyle> textContent </text>
-              </view>
-            </Clickable>;
           },
           ~children,
         )
@@ -159,7 +125,6 @@ let init = app => {
         <AnimatedText delay=0.5 textContent="to" />
         <AnimatedText delay=1. textContent="Revery" />
       </view>
-      <SimpleButton />
     </view>;
 
   UI.start(win, render);

--- a/examples/Bin.re
+++ b/examples/Bin.re
@@ -2,6 +2,7 @@ open Revery;
 open Revery.Core;
 open Revery.Math;
 open Revery.UI;
+open Revery.UI.Components;
 
 module Logo = (
   val component((render, ~children, ()) =>
@@ -103,6 +104,43 @@ module AnimatedText = (
       )
 );
 
+module SimpleButton = (
+  val component((render, ~children, ()) =>
+        render(
+          () => {
+            let (count, setCount) = useState(0);
+
+            let increment = () => setCount(count + 1);
+
+            let wrapperStyle =
+              Style.make(
+                ~backgroundColor=Color.rgba(1., 1., 1., 0.1),
+                ~border=Style.Border.make(~width=2, ~color=Colors.white, ()),
+                ~margin=16,
+                (),
+              );
+
+            let textHeaderStyle =
+              Style.make(
+                ~color=Colors.white,
+                ~fontFamily="Roboto-Regular.ttf",
+                ~fontSize=20,
+                ~margin=4,
+                (),
+              );
+
+            let textContent = "Click me: " ++ string_of_int(count);
+            <Clickable onClick=increment>
+              <view style=wrapperStyle>
+                <text style=textHeaderStyle> textContent </text>
+              </view>
+            </Clickable>;
+          },
+          ~children,
+        )
+      )
+);
+
 let init = app => {
   let win = App.createWindow(app, "Welcome to Revery!");
 
@@ -125,6 +163,7 @@ let init = app => {
         <AnimatedText delay=0.5 textContent="to" />
         <AnimatedText delay=1. textContent="Revery" />
       </view>
+      <SimpleButton />
     </view>;
 
   UI.start(win, render);

--- a/src/UI/Animation.re
+++ b/src/UI/Animation.re
@@ -34,19 +34,25 @@ module Make = (AnimationTickerImpl: AnimationTicker) => {
   };
 
   /*y=u0(1−t)3+3u1(1−t)2t+3u2(1−t)t2+u3t3
-    u0, u3 = 0,1; t in [0,1] */
-  let oneDimBezier = (u1:float, u2:float, t:float) => {
-      let term1 = u1 *. (((1. -. t) ** 2.) *. t);
-      let term2 = u2 *. ((1. -. t) *. (t ** 2.));
-      let term3 = t ** 3.;
-      (term1 +. term2) *. 3. +. term3;
+    u0, u3 = 0,1; t in [0,1] 
+    equivalent to a normal bezier curve where p1x = 1/3 and p2x = 2/3
+   */
+  let genOneDimBezierFunc = (u1:float, u2:float) => {
+    let a = (3. *. (u1 -. u2) +. 1.);
+    let b = (-6. *. u1 +. 3. *. u2);
+    let c = (3. *. u1);
+    let ret = (t: float) => {
+        let t2 = t ** 2.;
+        a *. t2 *. t +. b *. t2 +. c *. t;
+    }
+    ret;
   };
   let linear = (t: float) => t;
   let quadratic = (t: float) => t *.t;
   let cubic = (t: float) => t *. t *. t;
-  let easeIn = oneDimBezier(0., 0.45);
-  let easeOut = oneDimBezier(0.45, 1.);
-  let easeInOut = oneDimBezier(0., 1.);
+  let easeIn = genOneDimBezierFunc(0., 0.45);
+  let easeOut = genOneDimBezierFunc(0.45, 1.);
+  let easeInOut = genOneDimBezierFunc(0., 1.);
 
   let floatValue = (v: float) => {
     let ret = {current: v};

--- a/test/UI/AnimationTest.re
+++ b/test/UI/AnimationTest.re
@@ -27,6 +27,7 @@ test("Animation", () => {
       expect(myTestValue.current).toBe(0.1);
     })
   );
+
   test("simple animation", () => {
     module TestTicker =
       MakeTicker({});
@@ -40,11 +41,33 @@ test("Animation", () => {
           delay: Time.Seconds(0.),
           toValue: 10.,
           repeat: false,
+          easing: Animated.linear,
         },
       );
 
     TestTicker.simulateTick(Time.Seconds(1.));
     expect(myAnimation.value.current).toBe(5.);
+  });
+
+  test("animation with quadratic easing", () => {
+    module TestTicker =
+      MakeTicker({});
+    module Animated = Animation.Make(TestTicker);
+
+    let myAnimation =
+      Animated.start(
+        Animated.floatValue(0.),
+        {
+          duration: Time.Seconds(1.),
+          delay: Time.Seconds(0.),
+          toValue: 1.,
+          repeat: false,
+          easing: Animated.quadratic,
+        },
+      );
+
+    TestTicker.simulateTick(Time.Seconds(0.5));
+    expect(myAnimation.value.current).toBe(0.25);
   });
 
   test("animation that repeats", () => {
@@ -60,6 +83,7 @@ test("Animation", () => {
           delay: Time.Seconds(0.),
           toValue: 10.,
           repeat: true,
+          easing: Animated.linear,
         },
       );
 
@@ -80,6 +104,7 @@ test("Animation", () => {
           delay: Time.Seconds(1.),
           toValue: 10.,
           repeat: false,
+          easing: Animated.linear,
         },
       );
 
@@ -100,6 +125,7 @@ test("Animation", () => {
           delay: Time.Seconds(0.),
           toValue: 10.,
           repeat: false,
+          easing: Animated.linear,
         },
       );
 


### PR DESCRIPTION
@bryphe 
Progress update:
1) Test in AnimationTest.re does not actually change any of the other tests, only adds the quadratic one. I went back and checked this twice myself.
2) oneDimBezier alone is not enough to fully recreate the variety of css easing functions, but I'm 98% certain that a true bezier cubic could be made using [x,y] as a pair of oneDimBezier, then some math, then we can copy every CSS easing function offered.

3) New PR to get this all off of master and on to a feature branch :)