### PR TITLE
Memoize fontkit.fk_shape

### DIFF
--- a/src/UI/FontRenderer.re
+++ b/src/UI/FontRenderer.re
@@ -39,8 +39,9 @@ type dimensions = {
   height: int,
 };
 
-let _memoizedFontShape = Memoize.make(Fontkit.fk_shape);
-let shape = (font, text) => _memoizedFontShape(font, text);
+let shapeFont = ((font, text)) => Fontkit.fk_shape(font, text);
+let _memoizedFontShape = Memoize.make(shapeFont);
+let shape = (font, text) => _memoizedFontShape((font, text));
 
 let measure = (font: Fontkit.fk_face, text: string) => {
   let shapedText = shape(font, text);

--- a/src/UI/FontRenderer.re
+++ b/src/UI/FontRenderer.re
@@ -39,8 +39,11 @@ type dimensions = {
   height: int,
 };
 
+let _memoizedFontShape = Memoize.make(Fontkit.fk_shape);
+let shape = (font, text) => _memoizedFontShape(font, text);
+
 let measure = (font: Fontkit.fk_face, text: string) => {
-  let shapedText = Fontkit.fk_shape(font, text);
+  let shapedText = shape(font, text);
   let minY = ref(1000);
   let maxY = ref(-1000);
   let x = ref(0);

--- a/src/UI/FontRenderer.re
+++ b/src/UI/FontRenderer.re
@@ -39,8 +39,8 @@ type dimensions = {
   height: int,
 };
 
-let shapeFont = ((font, text)) => Fontkit.fk_shape(font, text);
-let _memoizedFontShape = Memoize.make(shapeFont);
+let _shapeFont = ((font, text)) => Fontkit.fk_shape(font, text);
+let _memoizedFontShape = Memoize.make(_shapeFont);
 let shape = (font, text) => _memoizedFontShape((font, text));
 
 let measure = (font: Fontkit.fk_face, text: string) => {

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -98,7 +98,7 @@ class textNode (text: string) = {
         x +. float_of_int(advance) /. 64.0;
       };
 
-      let shapedText = Fontkit.fk_shape(font, text);
+      let shapedText = FontRenderer.shape(font, text);
       let startX = ref(0.);
       Array.iter(
         s => {


### PR DESCRIPTION
fixes #115, memoizes the fn in a similar way as the `getTexture` function