### PR TITLE
Fix borders and shadows for transparent nodes

### DIFF
--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -291,33 +291,32 @@ class viewNode (()) = {
 
       let color = Color.multiplyAlpha(opacity, style.backgroundColor);
 
+      let world = _this#getWorldTransform();
+
+      let borderedWorld =
+        renderBorders(
+          ~style,
+          ~width,
+          ~height,
+          ~opacity,
+          ~solidShader,
+          ~m,
+          ~world,
+        );
+
+      switch (style.boxShadow) {
+      | {
+          xOffset: 0.,
+          yOffset: 0.,
+          blurRadius: 0.,
+          spreadRadius: 0.,
+          color: _,
+        } => ()
+      | boxShadow => renderShadow(~boxShadow, ~width, ~height, ~world, ~m)
+      };
+
       /* Only render if _not_ transparent */
       if (color.a > 0.001) {
-        let world = _this#getWorldTransform();
-
-        let borderedWorld =
-          renderBorders(
-            ~style,
-            ~width,
-            ~height,
-            ~opacity,
-            ~solidShader,
-            ~m,
-            ~world,
-          );
-
-        switch (style.boxShadow) {
-        | {
-            xOffset: 0.,
-            yOffset: 0.,
-            blurRadius: 0.,
-            spreadRadius: 0.,
-            color: _,
-          } =>
-          ()
-        | boxShadow => renderShadow(~boxShadow, ~width, ~height, ~world, ~m)
-        };
-
         Shaders.CompiledShader.use(solidShader);
         Shaders.CompiledShader.setUniformMatrix4fv(
           solidShader,


### PR DESCRIPTION
Just moved the world/border/shadow out of `if (color.a > 0.001)`. Tested it and it worked when I changed the alpha to 0 in Bin.re.