### PR TITLE
Dependency: Pin to newer facebook/reason

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "resolutions": {
     "@opam/cmdliner": "1.0.2",
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
-    "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce"
+    "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
+    "@esy-ocaml/reason": "facebook/reason#ab49908"
   },
   "peerDependencies": {
     "ocaml": "~4.6.0"


### PR DESCRIPTION
__Issue:__ `ocamlmerlin-reason` crashes on Windows due to https://github.com/facebook/reason/pull/2256

__Fix:__ Bring in a newer `reason` to work around this until a new official version is released.