### PR TITLE
Fix #170 - set a 'dirty' flag in response to reconciliation

### DIFF
--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -39,7 +39,7 @@ let start =
     ) => {
   let uiDirty = ref(false);
 
-  let onEndReconcile = (_node) => uiDirty := true;
+  let onEndReconcile = _node => uiDirty := true;
 
   let rootNode = (new viewNode)();
   let container = UiReact.createContainer(~onEndReconcile, rootNode);
@@ -85,11 +85,14 @@ let start =
       },
     );
 
-  let _ = Reactify.Event.subscribe(FontCache.onFontLoaded, () => {
-    Window.render(window);
-  });
+  let _ =
+    Reactify.Event.subscribe(FontCache.onFontLoaded, () =>
+      Window.render(window)
+    );
 
-  Window.setShouldRenderCallback(window, () => uiDirty^ || Animated.anyActiveAnimations());
+  Window.setShouldRenderCallback(window, () =>
+    uiDirty^ || Animated.anyActiveAnimations()
+  );
   Window.setRenderCallback(
     window,
     () => {

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -37,8 +37,12 @@ let start =
       window: Window.t,
       render: renderFunction,
     ) => {
+  let uiDirty = ref(false);
+
+  let onEndReconcile = (_node) => uiDirty := true;
+
   let rootNode = (new viewNode)();
-  let container = UiReact.createContainer(rootNode);
+  let container = UiReact.createContainer(~onEndReconcile, rootNode);
   let mouseCursor: Mouse.Cursor.t = Mouse.Cursor.make();
   let ui =
     UiContainer.create(
@@ -85,12 +89,13 @@ let start =
     Window.render(window);
   });
 
-  Window.setShouldRenderCallback(window, () => Animated.anyActiveAnimations());
+  Window.setShouldRenderCallback(window, () => uiDirty^ || Animated.anyActiveAnimations());
   Window.setRenderCallback(
     window,
     () => {
       let component = render();
       UiRender.render(ui, component);
+      uiDirty := false;
     },
   );
 };


### PR DESCRIPTION
__Issue:__ If a component calls `setState`, the UI does not get refreshed in response. This is very problematic for a UI, since the interesting interactivity will occur duet o state transitions.

__Defect:__ Our `setShouldRenderCallback` should be smarter - as pointed out in #170 by @OhadRau , there are additional cases we need to handle here.

__Fix:__ The `reason-reactify` reconciler was intended to help with this. It exposes both a `onBeginReconcile` and `onEndReconcile` events that are dispatched whenever a sub-tree is updated. For example, if you call `setState(...)` from some component, that event will be dispatched with the target node as the first argument. For now, we set a `dirty` flag to `true`, and clear that `dirty` flag on render.

There's a test case in `reason-reactify` that show how this functionality is intended to work:
https://github.com/revery-ui/reason-reactify/blob/cc0dbb453068f3693fc7fb692626c7d2f4ececcb/test/ContainerTest.re#L58

This PR addresses the particular case of updating the UI in response to nodes changing (which handles the style changing case, parent changing, an event happening, etc - as they all go through the reconciler).

__Future work:__
- As called out in #170 - there may be other cases where we need to leverage such a flag, like when a window loses focus.
- Incremental rendering - today, we always render the _full screen_. However, especially with something like #54 , we may be able to do much better in terms of just rendering a subtree.
- I suspect there are still _reconciler_ (`reason-reactify`) bugs we will run into - but that is good, it's expected we'll shake out the bugs in that space as we build out more real-world scenarios. 

Fixes #170 , but we may want to track some of the corollary work called out (ie, re-rendering on window losing focus) in a separate issue.