### PR TITLE
Bugfix: Add missed install step for Revery_UI_Components

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "esy-installer Revery_Geometry.install",
         "esy-installer Revery_Math.install",
         "esy-installer Revery_Shaders.install",
-        "esy-installer Revery_UI.install"
+        "esy-installer Revery_UI.install",
+        "esy-installer Revery_UI_Coimponents.install"
     ]
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "esy-installer Revery_Math.install",
         "esy-installer Revery_Shaders.install",
         "esy-installer Revery_UI.install",
-        "esy-installer Revery_UI_Coimponents.install"
+        "esy-installer Revery_UI_Components.install"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
__Issue:__ When using `revery` as a dependency, this error is hit:

```
# Unformatted Error Output:
# File "D:/oni2/_esy/default/store/i/revery-57c779ff/lib\Revery\META", line 1, characters 0-0:
# Error: Library "Revery_UI_Components" not found.
```

__Fix:__ Add `esy-installer` step for `Revery_UI_Components`
