### PR TITLE
CI: Enforce lock directory is up-to-date in CI

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -8,12 +8,8 @@ steps:
     displayName: 'npm install -g esy@0.4.9'
   - script: esy install
     displayName: 'esy install'
-    continueOnError: true
-  - script: esy install
-    displayName: 'esy install'
-    continueOnError: true
-  - script: esy install
-    displayName: 'esy install'
+  - script: git diff --exit-code
+    displayName: 'check that `esy.lock` is up-to-date'
   - script: esy build
     displayName: 'esy build'
   - script: esy b dune runtest


### PR DESCRIPTION
This adds a quick check after `esy install` that there are no unstaged changes - if there are, it means the lockfile needs to be updated. This will help keep the `esy.lock` dir from getting too far out-of-date.