### PR TITLE
Bugfix: Remove unnecessary glfwSetWindowSize call

### DIFF
--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -130,10 +130,8 @@ let create = (name: string, options: windowCreateOptions) => {
   | _ => ()
   };
 
-  let w = Glfw.glfwCreateWindow(1, 1, name);
+  let w = Glfw.glfwCreateWindow(options.width, options.height, name);
   Glfw.glfwMakeContextCurrent(w);
-
-  Glfw.glfwSetWindowSize(w, options.width, options.height);
 
   let fbSize = Glfw.glfwGetFramebufferSize(w);
 


### PR DESCRIPTION
This was a regression caught by @jchavarri in #190 - thanks for catching that! Had an unnecessary `glfwSetWindowSize` call which is no longer necessary (was used while developing to trigger a window-size change callback), but now because we're using `glfwGetWindowSize` to get the window size explicitly, there's no need for it.