### PR TITLE
Input: Add mousewheel event

### DIFF
--- a/examples/Hello.re
+++ b/examples/Hello.re
@@ -146,6 +146,7 @@ let init = app => {
 
   let render = () =>
     <view
+      onMouseWheel={(evt) => print_endline ("onMouseWheel: " ++ string_of_float(evt.deltaY))} 
       style={Style.make(
         ~position=LayoutTypes.Absolute,
         ~justifyContent=LayoutTypes.JustifyCenter,

--- a/src/Core/Events.re
+++ b/src/Core/Events.re
@@ -18,9 +18,15 @@ type mouseMoveEvent = {
   mouseY: float,
 };
 
+type mouseWheelEvent = {
+  deltaX: float,
+  deltaY: float,
+};
+
 type mouseButtonEvent = {button: MouseButton.t};
 
 type internalMouseEvents =
   | InternalMouseDown(mouseButtonEvent)
   | InternalMouseMove(mouseMoveEvent)
-  | InternalMouseUp(mouseButtonEvent);
+  | InternalMouseUp(mouseButtonEvent)
+  | InternalMouseWheel(mouseWheelEvent);

--- a/src/Core/MouseCursors.re
+++ b/src/Core/MouseCursors.re
@@ -5,24 +5,29 @@ open Reglfw.Glfw;
    [glfwInit]. Since these are global variables, they WILL be initialized first.
    We could also return a new cursor every time, but this would cause a memory
    leak. */
-type t = [ `Arrow | `Text | `Pointer | `Crosshair | `HResize | `VResize ];
+type t = [ | `Arrow | `Text | `Pointer | `Crosshair | `HResize | `VResize];
 
-let arrow_lazy = lazy(glfwCreateStandardCursor(GLFW_ARROW_CURSOR));
-let text_lazy = lazy(glfwCreateStandardCursor(GLFW_IBEAM_CURSOR));
-let pointer_lazy = lazy(glfwCreateStandardCursor(GLFW_HAND_CURSOR));
-let crosshair_lazy = lazy(glfwCreateStandardCursor(GLFW_CROSSHAIR_CURSOR));
-let horizontalResize_lazy = lazy(glfwCreateStandardCursor(GLFW_HRESIZE_CURSOR));
-let verticalResize_lazy = lazy(glfwCreateStandardCursor(GLFW_VRESIZE_CURSOR));
+let arrow_lazy = lazy (glfwCreateStandardCursor(GLFW_ARROW_CURSOR));
+let text_lazy = lazy (glfwCreateStandardCursor(GLFW_IBEAM_CURSOR));
+let pointer_lazy = lazy (glfwCreateStandardCursor(GLFW_HAND_CURSOR));
+let crosshair_lazy = lazy (glfwCreateStandardCursor(GLFW_CROSSHAIR_CURSOR));
+let horizontalResize_lazy =
+  lazy (glfwCreateStandardCursor(GLFW_HRESIZE_CURSOR));
+let verticalResize_lazy =
+  lazy (glfwCreateStandardCursor(GLFW_VRESIZE_CURSOR));
 
-let toGlfwCursor(cursorType) { 
-  switch (cursorType) {
+let toGlfwCursor = cursorType => {
+  (
+    switch (cursorType) {
     | `Arrow => arrow_lazy
     | `Text => text_lazy
     | `Pointer => pointer_lazy
     | `Crosshair => crosshair_lazy
     | `HResize => horizontalResize_lazy
     | `VResize => verticalResize_lazy
-  } |> Lazy.force;
+    }
+  )
+  |> Lazy.force;
 };
 
 let arrow = `Arrow;

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -167,7 +167,7 @@ let create = (name: string, options: windowCreateOptions) => {
     onMouseMove: Event.create(),
     onMouseUp: Event.create(),
     onMouseDown: Event.create(),
-    onMouseWheel: Event.create()
+    onMouseWheel: Event.create(),
   };
 
   Glfw.glfwSetFramebufferSizeCallback(
@@ -273,8 +273,8 @@ let create = (name: string, options: windowCreateOptions) => {
   Glfw.glfwSetScrollCallback(
     w,
     (_w, deltaX, deltaY) => {
-        let evt: mouseWheelEvent = {deltaX: deltaX, deltaY: deltaY};   
-        Event.dispatch(ret.onMouseWheel, evt);
+      let evt: mouseWheelEvent = {deltaX, deltaY};
+      Event.dispatch(ret.onMouseWheel, evt);
     },
   );
 

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -29,6 +29,7 @@ type t = {
   onMouseUp: Event.t(mouseButtonEvent),
   onMouseMove: Event.t(mouseMoveEvent),
   onMouseDown: Event.t(mouseButtonEvent),
+  onMouseWheel: Event.t(mouseWheelEvent),
 };
 
 type windowCreateOptions = {
@@ -166,6 +167,7 @@ let create = (name: string, options: windowCreateOptions) => {
     onMouseMove: Event.create(),
     onMouseUp: Event.create(),
     onMouseDown: Event.create(),
+    onMouseWheel: Event.create()
   };
 
   Glfw.glfwSetFramebufferSizeCallback(
@@ -265,6 +267,14 @@ let create = (name: string, options: windowCreateOptions) => {
       | GLFW_REPEAT => Event.dispatch(ret.onMouseDown, evt)
       | GLFW_RELEASE => Event.dispatch(ret.onMouseUp, evt)
       };
+    },
+  );
+
+  Glfw.glfwSetScrollCallback(
+    w,
+    (_w, deltaX, deltaY) => {
+        let evt: mouseWheelEvent = {deltaX: deltaX, deltaY: deltaY};   
+        Event.dispatch(ret.onMouseWheel, evt);
     },
   );
 

--- a/src/UI/Mouse.re
+++ b/src/UI/Mouse.re
@@ -39,7 +39,8 @@ let capturedEventStateInstance: capturedEventState = {
   onMouseWheel: ref(None),
 };
 
-let setCapture = (~onMouseDown=?, ~onMouseMove=?, ~onMouseUp=?, ~onMouseWheel=?, ()) => {
+let setCapture =
+    (~onMouseDown=?, ~onMouseMove=?, ~onMouseUp=?, ~onMouseWheel=?, ()) => {
   capturedEventStateInstance.onMouseDown := onMouseDown;
   capturedEventStateInstance.onMouseMove := onMouseMove;
   capturedEventStateInstance.onMouseUp := onMouseUp;
@@ -56,7 +57,13 @@ let releaseCapture = () => {
 let handleCapture = (mouseEvent: mouseEvent) => {
   let ce = capturedEventStateInstance;
 
-  switch (ce.onMouseDown^, ce.onMouseMove^, ce.onMouseUp^, ce.onMouseWheel^, mouseEvent) {
+  switch (
+    ce.onMouseDown^,
+    ce.onMouseMove^,
+    ce.onMouseUp^,
+    ce.onMouseWheel^,
+    mouseEvent,
+  ) {
   | (Some(h), _, _, _, MouseDown(evt)) =>
     h(evt);
     true;

--- a/src/UI/Mouse.re
+++ b/src/UI/Mouse.re
@@ -29,40 +29,47 @@ type capturedEventState = {
   onMouseDown: ref(option(mouseButtonHandler)),
   onMouseMove: ref(option(mouseMoveHandler)),
   onMouseUp: ref(option(mouseButtonHandler)),
+  onMouseWheel: ref(option(mouseWheelHandler)),
 };
 
 let capturedEventStateInstance: capturedEventState = {
   onMouseDown: ref(None),
   onMouseMove: ref(None),
   onMouseUp: ref(None),
+  onMouseWheel: ref(None),
 };
 
-let setCapture = (~onMouseDown=?, ~onMouseMove=?, ~onMouseUp=?, ()) => {
+let setCapture = (~onMouseDown=?, ~onMouseMove=?, ~onMouseUp=?, ~onMouseWheel=?, ()) => {
   capturedEventStateInstance.onMouseDown := onMouseDown;
   capturedEventStateInstance.onMouseMove := onMouseMove;
   capturedEventStateInstance.onMouseUp := onMouseUp;
+  capturedEventStateInstance.onMouseWheel := onMouseWheel;
 };
 
 let releaseCapture = () => {
   capturedEventStateInstance.onMouseDown := None;
   capturedEventStateInstance.onMouseMove := None;
   capturedEventStateInstance.onMouseUp := None;
+  capturedEventStateInstance.onMouseWheel := None;
 };
 
 let handleCapture = (mouseEvent: mouseEvent) => {
   let ce = capturedEventStateInstance;
 
-  switch (ce.onMouseDown^, ce.onMouseMove^, ce.onMouseUp^, mouseEvent) {
-  | (Some(h), _, _, MouseDown(evt)) =>
+  switch (ce.onMouseDown^, ce.onMouseMove^, ce.onMouseUp^, ce.onMouseWheel^, mouseEvent) {
+  | (Some(h), _, _, _, MouseDown(evt)) =>
     h(evt);
     true;
-  | (_, Some(h), _, MouseMove(evt)) =>
+  | (_, Some(h), _, _, MouseMove(evt)) =>
     h(evt);
     true;
-  | (_, _, Some(h), MouseUp(evt)) =>
+  | (_, _, Some(h), _, MouseUp(evt)) =>
     h(evt);
     true;
-  | (_, _, _, _) => false
+  | (_, _, _, Some(h), MouseWheel(evt)) =>
+    h(evt);
+    true;
+  | (_, _, _, _, _) => false
   };
 };
 
@@ -71,6 +78,7 @@ let getPositionFromMouseEvent = (c: Cursor.t, evt: Events.internalMouseEvents) =
   | InternalMouseDown(_) => Cursor.toVec2(c)
   | InternalMouseMove(e) => Vec2.create(e.mouseX, e.mouseY)
   | InternalMouseUp(_) => Cursor.toVec2(c)
+  | InternalMouseWheel(_) => Cursor.toVec2(c)
   };
 
 let internalToExternalEvent = (c: Cursor.t, evt: Events.internalMouseEvents) =>
@@ -81,6 +89,8 @@ let internalToExternalEvent = (c: Cursor.t, evt: Events.internalMouseEvents) =>
     MouseUp({mouseX: c.x^, mouseY: c.y^, button: evt.button})
   | InternalMouseMove(evt) =>
     MouseMove({mouseX: evt.mouseX, mouseY: evt.mouseY})
+  | InternalMouseWheel(evt) =>
+    MouseWheel({deltaX: evt.deltaX, deltaY: evt.deltaY})
   };
 
 let onCursorChanged: Event.t(MouseCursors.t) = Event.create();

--- a/src/UI/Mouse.rei
+++ b/src/UI/Mouse.rei
@@ -19,6 +19,7 @@ let setCapture:
      ~onMouseDown:mouseButtonHandler=?,
      ~onMouseMove:mouseMoveHandler=?,
      ~onMouseUp:mouseButtonHandler=?,
+     ~onMouseWheel:mouseWheelHandler=?,
      unit
     ) => unit;
 

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -117,9 +117,11 @@ class node ('a) (()) = {
       | (MouseDown(c), {onMouseDown: Some(cb), _}) => cb(c)
       | (MouseMove(c), {onMouseMove: Some(cb), _}) => cb(c)
       | (MouseUp(c), {onMouseUp: Some(cb), _}) => cb(c)
+      | (MouseWheel(c), {onMouseWheel: Some(cb), _}) => cb(c)
       | (MouseDown(_), _)
       | (MouseMove(_), _)
-      | (MouseUp(_), _) => ()
+      | (MouseUp(_), _)
+      | (MouseWheel(_), _) => ()
       };
     ();
   };

--- a/src/UI/NodeEvents.re
+++ b/src/UI/NodeEvents.re
@@ -16,8 +16,8 @@ type mouseButtonEventParams = {
 };
 
 type mouseWheelEventParams = {
-    deltaX: float,
-    deltaY: float,
+  deltaX: float,
+  deltaY: float,
 };
 
 type mouseEvent =
@@ -39,7 +39,15 @@ type t('a) = {
   onMouseWheel: option(mouseWheelHandler),
 };
 
-let make = (~ref=?, ~onMouseDown=?, ~onMouseMove=?, ~onMouseUp=?, ~onMouseWheel=?, _unit: unit) => {
+let make =
+    (
+      ~ref=?,
+      ~onMouseDown=?,
+      ~onMouseMove=?,
+      ~onMouseUp=?,
+      ~onMouseWheel=?,
+      _unit: unit,
+    ) => {
   let ret: t('a) = {ref, onMouseDown, onMouseMove, onMouseUp, onMouseWheel};
   ret;
 };

--- a/src/UI/NodeEvents.re
+++ b/src/UI/NodeEvents.re
@@ -15,23 +15,31 @@ type mouseButtonEventParams = {
   button: MouseButton.t,
 };
 
+type mouseWheelEventParams = {
+    deltaX: float,
+    deltaY: float,
+};
+
 type mouseEvent =
   | MouseDown(mouseButtonEventParams)
   | MouseMove(mouseMoveEventParams)
-  | MouseUp(mouseButtonEventParams);
+  | MouseUp(mouseButtonEventParams)
+  | MouseWheel(mouseWheelEventParams);
 
 type refCallback('a) = 'a => unit;
 type mouseButtonHandler = mouseButtonEventParams => unit;
 type mouseMoveHandler = mouseMoveEventParams => unit;
+type mouseWheelHandler = mouseWheelEventParams => unit;
 
 type t('a) = {
   ref: option(refCallback('a)),
   onMouseDown: option(mouseButtonHandler),
   onMouseMove: option(mouseMoveHandler),
   onMouseUp: option(mouseButtonHandler),
+  onMouseWheel: option(mouseWheelHandler),
 };
 
-let make = (~ref=?, ~onMouseDown=?, ~onMouseMove=?, ~onMouseUp=?, _unit: unit) => {
-  let ret: t('a) = {ref, onMouseDown, onMouseMove, onMouseUp};
+let make = (~ref=?, ~onMouseDown=?, ~onMouseMove=?, ~onMouseUp=?, ~onMouseWheel=?, _unit: unit) => {
+  let ret: t('a) = {ref, onMouseDown, onMouseMove, onMouseUp, onMouseWheel};
   ret;
 };

--- a/src/UI/Primitives.re
+++ b/src/UI/Primitives.re
@@ -22,7 +22,14 @@ let view =
   UiReact.primitiveComponent(
     View(
       style,
-      NodeEvents.make(~ref?, ~onMouseDown?, ~onMouseMove?, ~onMouseUp?, ~onMouseWheel?, ()),
+      NodeEvents.make(
+        ~ref?,
+        ~onMouseDown?,
+        ~onMouseMove?,
+        ~onMouseUp?,
+        ~onMouseWheel?,
+        (),
+      ),
     ),
     ~children,
   );
@@ -43,7 +50,14 @@ let image =
     Image(
       style,
       src,
-      NodeEvents.make(~ref?, ~onMouseDown?, ~onMouseMove?, ~onMouseUp?, ~onMouseWheel?, ()),
+      NodeEvents.make(
+        ~ref?,
+        ~onMouseDown?,
+        ~onMouseMove?,
+        ~onMouseUp?,
+        ~onMouseWheel?,
+        (),
+      ),
     ),
     ~children,
   );
@@ -63,7 +77,14 @@ let text =
     Text(
       style,
       List.hd(children),
-      NodeEvents.make(~ref?, ~onMouseDown?, ~onMouseMove?, ~onMouseUp?, ~onMouseWheel?, ()),
+      NodeEvents.make(
+        ~ref?,
+        ~onMouseDown?,
+        ~onMouseMove?,
+        ~onMouseUp?,
+        ~onMouseWheel?,
+        (),
+      ),
     ),
     ~children=[],
   );

--- a/src/UI/Primitives.re
+++ b/src/UI/Primitives.re
@@ -13,6 +13,7 @@ let view =
       ~onMouseDown=?,
       ~onMouseMove=?,
       ~onMouseUp=?,
+      ~onMouseWheel=?,
       ~children,
       ~ref=?,
       ~style=Style.defaultStyle,
@@ -21,7 +22,7 @@ let view =
   UiReact.primitiveComponent(
     View(
       style,
-      NodeEvents.make(~ref?, ~onMouseDown?, ~onMouseMove?, ~onMouseUp?, ()),
+      NodeEvents.make(~ref?, ~onMouseDown?, ~onMouseMove?, ~onMouseUp?, ~onMouseWheel?, ()),
     ),
     ~children,
   );
@@ -31,6 +32,7 @@ let image =
       ~onMouseDown=?,
       ~onMouseMove=?,
       ~onMouseUp=?,
+      ~onMouseWheel=?,
       ~children,
       ~ref=?,
       ~style=Style.defaultStyle,
@@ -41,7 +43,7 @@ let image =
     Image(
       style,
       src,
-      NodeEvents.make(~ref?, ~onMouseDown?, ~onMouseMove?, ~onMouseUp?, ()),
+      NodeEvents.make(~ref?, ~onMouseDown?, ~onMouseMove?, ~onMouseUp?, ~onMouseWheel?, ()),
     ),
     ~children,
   );
@@ -51,6 +53,7 @@ let text =
       ~onMouseDown=?,
       ~onMouseMove=?,
       ~onMouseUp=?,
+      ~onMouseWheel=?,
       ~children: list(string),
       ~ref=?,
       ~style=Style.defaultStyle,
@@ -60,7 +63,7 @@ let text =
     Text(
       style,
       List.hd(children),
-      NodeEvents.make(~ref?, ~onMouseDown?, ~onMouseMove?, ~onMouseUp?, ()),
+      NodeEvents.make(~ref?, ~onMouseDown?, ~onMouseMove?, ~onMouseUp?, ~onMouseWheel?, ()),
     ),
     ~children=[],
   );

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -89,6 +89,15 @@ let start =
     );
 
   let _ =
+      Revery_Core.Event.subscribe(
+      window.onMouseWheel,
+      m => {
+        let evt = Revery_Core.Events.InternalMouseWheel(m);
+        Mouse.dispatch(mouseCursor, evt, rootNode);
+      },
+      );
+
+  let _ =
     Revery_Core.Event.subscribe(
       Mouse.onCursorChanged,
       cursor => {

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -89,13 +89,13 @@ let start =
     );
 
   let _ =
-      Revery_Core.Event.subscribe(
+    Revery_Core.Event.subscribe(
       window.onMouseWheel,
       m => {
         let evt = Revery_Core.Events.InternalMouseWheel(m);
         Mouse.dispatch(mouseCursor, evt, rootNode);
       },
-      );
+    );
 
   let _ =
     Revery_Core.Event.subscribe(


### PR DESCRIPTION
This adds an `onMouseWheel` event to the primitives. This will be helpful for some of the `<ScrollView />` work happening, like in #195 . 

This does the following:
- Subscribe a callback to the `glfwSetScroll` and add a `onMouseWheel` event to the `Window.t` object
- Listen to the `onMouseWheel` event in `Revery.UI` and dispatch an `onMouseWheel` event for the UI tree to respond to
- Hook up the `onMouseWheel` to the primitives so consumers of the API can listen to it via `<view onMouseWheel={(evt) => ...} />`