### PR TITLE
API: Tick.interval

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -75,6 +75,7 @@ let startWithState: startFunc('s, 'a) =
 
     let appLoop = (_t: float) => {
       Glfw.glfwPollEvents();
+      Tick.Default.pump();
 
       _checkAndCloseWindows(appInstance);
 

--- a/src/Core/Revery_Core.re
+++ b/src/Core/Revery_Core.re
@@ -21,7 +21,7 @@ module UniqueId = UniqueId;
  * Internally exposed modules, just for testing.
  */
 module Internal = {
-    module Tick = Tick;    
+  module Tick = Tick;
 };
 
 module Tick = Tick.Default;

--- a/src/Core/Revery_Core.re
+++ b/src/Core/Revery_Core.re
@@ -17,6 +17,15 @@ module Events = Events;
 module Performance = Performance;
 module UniqueId = UniqueId;
 
+/*
+ * Internally exposed modules, just for testing.
+ */
+module Internal = {
+    module Tick = Tick;    
+};
+
+module Tick = Tick.Default;
+
 module Memoize = {
   type t('a, 'b) = 'a => 'b;
 

--- a/src/Core/Tick.re
+++ b/src/Core/Tick.re
@@ -1,69 +1,61 @@
-module type Clock = {
-  let time: unit => Time.t;
-};
+module type Clock = {let time: unit => Time.t;};
 
 module DefaultClock = {
-   let time = () => Time.of_float_seconds(Unix.gettimeofday()); 
+  let time = () => Time.of_float_seconds(Unix.gettimeofday());
 };
 
 type callback = Time.t => unit;
 type dispose = unit => unit;
 
 module Make = (ClockImpl: Clock) => {
+  module TickId =
+    UniqueId.Make({});
 
-    module TickId = UniqueId.Make({});
+  type tickFunction = {
+    id: int,
+    lastExecutionTime: Time.t,
+    frequency: Time.t,
+    f: callback,
+  };
 
-    type tickFunction = {
-        id: int,
-        lastExecutionTime: Time.t,   
-        frequency: Time.t,
-        f: callback,
+  let _activeTickers: ref(list(tickFunction)) = ref([]);
+
+  let pump = () => {
+    let currentTime = Time.to_float_seconds(ClockImpl.time());
+
+    let f = (tf: tickFunction) => {
+      let lastTime = Time.to_float_seconds(tf.lastExecutionTime);
+      let frequency = Time.to_float_seconds(tf.frequency);
+      let nextTime = lastTime +. frequency;
+
+      if (nextTime <= currentTime) {
+        let elapsedTime = Time.of_float_seconds(currentTime -. lastTime);
+        tf.f(elapsedTime);
+        {...tf, lastExecutionTime: Time.of_float_seconds(currentTime)};
+      } else {
+        tf;
+      };
+    };
+    _activeTickers := List.map(f, _activeTickers^);
+  };
+
+  let _clear = (id: int, ()) => {
+    _activeTickers := List.filter(v => v.id !== id, _activeTickers^);
+  };
+
+  let interval = (f: callback, frequency: Time.t) => {
+    let id = TickId.getUniqueId();
+
+    let tf: tickFunction = {
+      id,
+      lastExecutionTime: ClockImpl.time(),
+      frequency,
+      f,
     };
 
-    let _activeTickers: ref(list(tickFunction)) = ref([]);
- 
-    let pump = () => {
-        let currentTime = Time.to_float_seconds(ClockImpl.time());
-
-        let f = (tf: tickFunction) => {
-            let lastTime = Time.to_float_seconds(tf.lastExecutionTime);
-            let frequency = Time.to_float_seconds(tf.frequency);
-            let nextTime = lastTime +. frequency;
-
-            if (nextTime <= currentTime) {
-
-                let elapsedTime = Time.of_float_seconds(currentTime -. lastTime);
-                tf.f(elapsedTime);
-                {
-                    ...tf,
-                    lastExecutionTime: Time.of_float_seconds(currentTime),
-                };
-            } else {
-                tf
-            };
-        };
-        _activeTickers := List.map(f, _activeTickers^);
-    };
-
-
-    let _clear = (id: int) => () => {
-       _activeTickers := List.filter(v => v.id !== id, _activeTickers^);
-    };
-
-    let interval = (f: callback, frequency: Time.t) => {
-
-        let id = TickId.getUniqueId();
-
-        let tf: tickFunction = {
-           id,
-           lastExecutionTime: ClockImpl.time(),
-           frequency,
-           f,
-        };
-
-        _activeTickers := List.append([tf], _activeTickers^);
-        _clear(id);
-    };
+    _activeTickers := List.append([tf], _activeTickers^);
+    _clear(id);
+  };
 };
 
 module Default = Make(DefaultClock);

--- a/src/Core/Tick.re
+++ b/src/Core/Tick.re
@@ -1,0 +1,69 @@
+module type Clock = {
+  let time: unit => Time.t;
+};
+
+module DefaultClock = {
+   let time = () => Time.of_float_seconds(Unix.gettimeofday()); 
+};
+
+type callback = Time.t => unit;
+type dispose = unit => unit;
+
+module Make = (ClockImpl: Clock) => {
+
+    module TickId = UniqueId.Make({});
+
+    type tickFunction = {
+        id: int,
+        lastExecutionTime: Time.t,   
+        frequency: Time.t,
+        f: callback,
+    };
+
+    let _activeTickers: ref(list(tickFunction)) = ref([]);
+ 
+    let pump = () => {
+        let currentTime = Time.to_float_seconds(ClockImpl.time());
+
+        let f = (tf: tickFunction) => {
+            let lastTime = Time.to_float_seconds(tf.lastExecutionTime);
+            let frequency = Time.to_float_seconds(tf.frequency);
+            let nextTime = lastTime +. frequency;
+
+            if (nextTime <= currentTime) {
+
+                let elapsedTime = Time.of_float_seconds(currentTime -. lastTime);
+                tf.f(elapsedTime);
+                {
+                    ...tf,
+                    lastExecutionTime: Time.of_float_seconds(currentTime),
+                };
+            } else {
+                tf
+            };
+        };
+        _activeTickers := List.map(f, _activeTickers^);
+    };
+
+
+    let _clear = (id: int) => () => {
+       _activeTickers := List.filter(v => v.id !== id, _activeTickers^);
+    };
+
+    let interval = (f: callback, frequency: Time.t) => {
+
+        let id = TickId.getUniqueId();
+
+        let tf: tickFunction = {
+           id,
+           lastExecutionTime: ClockImpl.time(),
+           frequency,
+           f,
+        };
+
+        _activeTickers := List.append([tf], _activeTickers^);
+        _clear(id);
+    };
+};
+
+module Default = Make(DefaultClock);

--- a/src/Core/Time.re
+++ b/src/Core/Time.re
@@ -12,9 +12,12 @@ let to_float_seconds = (v: t) =>
   | Milliseconds(x) => x /. 1000.
   };
 
-let increment: (t, t) => t = (previousTime, duration) => {
-    of_float_seconds(to_float_seconds(previousTime) +. to_float_seconds(duration));    
-};
+let increment: (t, t) => t =
+  (previousTime, duration) => {
+    of_float_seconds(
+      to_float_seconds(previousTime) +. to_float_seconds(duration),
+    );
+  };
 
 let show = (v: t) => string_of_float(to_float_seconds(v)) ++ "s";
 

--- a/src/Core/Time.re
+++ b/src/Core/Time.re
@@ -12,6 +12,10 @@ let to_float_seconds = (v: t) =>
   | Milliseconds(x) => x /. 1000.
   };
 
+let increment: (t, t) => t = (previousTime, duration) => {
+    of_float_seconds(to_float_seconds(previousTime) +. to_float_seconds(duration));    
+};
+
 let show = (v: t) => string_of_float(to_float_seconds(v)) ++ "s";
 
 let getTime = () => of_float_seconds(glfwGetTime());

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -313,8 +313,7 @@ let getFramebufferSize = (w: t) => {
   r;
 };
 
-let maximize = (w:t) =>
-    Glfw.glfwMaximizeWindow(w.glfwWindow);
+let maximize = (w: t) => Glfw.glfwMaximizeWindow(w.glfwWindow);
 
 let getDevicePixelRatio = (w: t) => {
   let windowSizeInScreenCoordinates = getSize(w);

--- a/src/UI/Animation.re
+++ b/src/UI/Animation.re
@@ -114,7 +114,7 @@ module Make = (AnimationTickerImpl: AnimationTicker) => {
       easing: animationOptions.easing,
     };
 
-    activeAnimations := List.append(activeAnimations^, [animation]);
+    activeAnimations := List.append([animation], activeAnimations^);
     animation;
   };
 

--- a/test/Core/ColorTests.re
+++ b/test/Core/ColorTests.re
@@ -3,39 +3,39 @@ open Rejest;
 open Revery_Core;
 
 let validateColor = (actual: Color.t, expected: Color.t) => {
-   expect(actual.r).toEqual(expected.r); 
-   expect(actual.g).toEqual(expected.g); 
-   expect(actual.b).toEqual(expected.b); 
-   expect(actual.a).toEqual(expected.a); 
+  expect(actual.r).toEqual(expected.r);
+  expect(actual.g).toEqual(expected.g);
+  expect(actual.b).toEqual(expected.b);
+  expect(actual.a).toEqual(expected.a);
 };
 
-test("Color", () => {
+test("Color", () =>
   test("hex parsing", () => {
     test("16-bit RGB cases", () => {
-       let color1 = Color.hex("#000"); 
-       let color2 = Color.hex("#F00"); 
-       let color3 = Color.hex("#0F0"); 
-       let color4 = Color.hex("#00F"); 
-       let color5 = Color.hex("#FFF"); 
+      let color1 = Color.hex("#000");
+      let color2 = Color.hex("#F00");
+      let color3 = Color.hex("#0F0");
+      let color4 = Color.hex("#00F");
+      let color5 = Color.hex("#FFF");
 
-       validateColor(color1, Color.rgb(0., 0., 0.));
-       validateColor(color2, Color.rgb(1., 0., 0.));
-       validateColor(color3, Color.rgb(0., 1., 0.));
-       validateColor(color4, Color.rgb(0., 0., 1.));
-       validateColor(color5, Color.rgb(1., 1., 1.));
-    })       
+      validateColor(color1, Color.rgb(0., 0., 0.));
+      validateColor(color2, Color.rgb(1., 0., 0.));
+      validateColor(color3, Color.rgb(0., 1., 0.));
+      validateColor(color4, Color.rgb(0., 0., 1.));
+      validateColor(color5, Color.rgb(1., 1., 1.));
+    });
     test("256-bit RGB cases", () => {
-       let color1 = Color.hex("#000000"); 
-       let color2 = Color.hex("#FF0000"); 
-       let color3 = Color.hex("#00FF00"); 
-       let color4 = Color.hex("#0000FF"); 
-       let color5 = Color.hex("#FFFFFF"); 
+      let color1 = Color.hex("#000000");
+      let color2 = Color.hex("#FF0000");
+      let color3 = Color.hex("#00FF00");
+      let color4 = Color.hex("#0000FF");
+      let color5 = Color.hex("#FFFFFF");
 
-       validateColor(color1, Color.rgb(0., 0., 0.));
-       validateColor(color2, Color.rgb(1., 0., 0.));
-       validateColor(color3, Color.rgb(0., 1., 0.));
-       validateColor(color4, Color.rgb(0., 0., 1.));
-       validateColor(color5, Color.rgb(1., 1., 1.));
-    })       
-  });
-});
+      validateColor(color1, Color.rgb(0., 0., 0.));
+      validateColor(color2, Color.rgb(1., 0., 0.));
+      validateColor(color3, Color.rgb(0., 1., 0.));
+      validateColor(color4, Color.rgb(0., 0., 1.));
+      validateColor(color5, Color.rgb(1., 1., 1.));
+    });
+  })
+);

--- a/test/Core/TickTest.re
+++ b/test/Core/TickTest.re
@@ -1,0 +1,64 @@
+open Rejest;
+
+open Revery_Core;
+open Revery_Core.Time;
+
+module TestTicker = {
+    let _time: ref(Time.t) = ref(Seconds(0.));
+
+    let incrementTime = (time: Time.t) => {
+        _time := Time.increment(_time^, time);
+    };
+
+    let time = () => _time^;
+};
+
+module Tick = Revery_Core.Internal.Tick.Make(TestTicker);
+
+test("Ticker", () => {
+    test("calls after tick time", () => {
+        let callCount = ref(0);
+      
+        let _ = Tick.interval((_) => {
+           callCount := callCount^ + 1; 
+        }, Seconds(1.));
+
+        TestTicker.incrementTime(Seconds(1.01));
+
+        expect(callCount^).toBe(0);
+        Tick.pump();
+        expect(callCount^).toBe(1);
+
+        Tick.pump();
+        expect(callCount^).toBe(1);
+
+        TestTicker.incrementTime(Seconds(0.9));
+        Tick.pump();
+        expect(callCount^).toBe(1);
+
+        TestTicker.incrementTime(Seconds(0.11));
+        Tick.pump();
+        expect(callCount^).toBe(2);
+    });
+
+    test("disposing tick subscription stops the tick", () => {
+        let callCount = ref(0);
+      
+        let stop = Tick.interval((_) => {
+           callCount := callCount^ + 1; 
+        }, Seconds(1.));
+
+        TestTicker.incrementTime(Seconds(1.01));
+
+        expect(callCount^).toBe(0);
+        Tick.pump();
+        expect(callCount^).toBe(1);
+
+        stop();
+
+        TestTicker.incrementTime(Seconds(2.));
+        Tick.pump();
+        expect(callCount^).toBe(1);
+    });
+});
+

--- a/test/Core/TickTest.re
+++ b/test/Core/TickTest.re
@@ -4,61 +4,56 @@ open Revery_Core;
 open Revery_Core.Time;
 
 module TestTicker = {
-    let _time: ref(Time.t) = ref(Seconds(0.));
+  let _time: ref(Time.t) = ref(Seconds(0.));
 
-    let incrementTime = (time: Time.t) => {
-        _time := Time.increment(_time^, time);
-    };
+  let incrementTime = (time: Time.t) => {
+    _time := Time.increment(_time^, time);
+  };
 
-    let time = () => _time^;
+  let time = () => _time^;
 };
 
 module Tick = Revery_Core.Internal.Tick.Make(TestTicker);
 
 test("Ticker", () => {
-    test("calls after tick time", () => {
-        let callCount = ref(0);
-      
-        let _ = Tick.interval((_) => {
-           callCount := callCount^ + 1; 
-        }, Seconds(1.));
+  test("calls after tick time", () => {
+    let callCount = ref(0);
 
-        TestTicker.incrementTime(Seconds(1.01));
+    let _ = Tick.interval(_ => callCount := callCount^ + 1, Seconds(1.));
 
-        expect(callCount^).toBe(0);
-        Tick.pump();
-        expect(callCount^).toBe(1);
+    TestTicker.incrementTime(Seconds(1.01));
 
-        Tick.pump();
-        expect(callCount^).toBe(1);
+    expect(callCount^).toBe(0);
+    Tick.pump();
+    expect(callCount^).toBe(1);
 
-        TestTicker.incrementTime(Seconds(0.9));
-        Tick.pump();
-        expect(callCount^).toBe(1);
+    Tick.pump();
+    expect(callCount^).toBe(1);
 
-        TestTicker.incrementTime(Seconds(0.11));
-        Tick.pump();
-        expect(callCount^).toBe(2);
-    });
+    TestTicker.incrementTime(Seconds(0.9));
+    Tick.pump();
+    expect(callCount^).toBe(1);
 
-    test("disposing tick subscription stops the tick", () => {
-        let callCount = ref(0);
-      
-        let stop = Tick.interval((_) => {
-           callCount := callCount^ + 1; 
-        }, Seconds(1.));
+    TestTicker.incrementTime(Seconds(0.11));
+    Tick.pump();
+    expect(callCount^).toBe(2);
+  });
 
-        TestTicker.incrementTime(Seconds(1.01));
+  test("disposing tick subscription stops the tick", () => {
+    let callCount = ref(0);
 
-        expect(callCount^).toBe(0);
-        Tick.pump();
-        expect(callCount^).toBe(1);
+    let stop = Tick.interval(_ => callCount := callCount^ + 1, Seconds(1.));
 
-        stop();
+    TestTicker.incrementTime(Seconds(1.01));
 
-        TestTicker.incrementTime(Seconds(2.));
-        Tick.pump();
-        expect(callCount^).toBe(1);
-    });
+    expect(callCount^).toBe(0);
+    Tick.pump();
+    expect(callCount^).toBe(1);
+
+    stop();
+
+    TestTicker.incrementTime(Seconds(2.));
+    Tick.pump();
+    expect(callCount^).toBe(1);
+  });
 });
-


### PR DESCRIPTION
This adds a new API `Tick.interval` which is loosely inspired by `window.setInterval` in the JavaScript world.

This is an important primitve for apps that need to live-update or for simple games that need an 'update' loop. There is no concurrency here; the ticks are 'pumped' in the app loop.

One important aspect / limitation is that these ticks will run no faster than the current render speed. By default vsync is active, so an interval would not be executed more frequently than ~16ms (depending on vsync settings / hardware settings).

__TODO:__
- [ ] Add example usage