### PR TITLE
Feature/Update Style API

### DIFF
--- a/examples/Border.re
+++ b/examples/Border.re
@@ -2,39 +2,36 @@ open Revery.UI;
 open Revery.Core;
 
 let defaultStyle =
-  Style.make(
-    ~backgroundColor=Colors.white,
-    ~position=LayoutTypes.Relative,
-    ~left=100,
-    ~top=100,
-    ~width=200,
-    ~height=200,
-    ~border=Style.Border.make(~width=15, ~color=Colors.red, ()),
-    ~borderHorizontal=Style.Border.make(~width=8, ~color=Colors.blue, ()),
-    ~borderTop=Style.Border.make(~width=15, ~color=Colors.red, ()),
-    ~borderLeft=Style.Border.make(~width=30, ~color=Colors.green, ()),
-    (),
-  );
+  Style.[
+    backgroundColor(Colors.white),
+    position(`Relative),
+    left(100),
+    top(100),
+    width(200),
+    height(200),
+    border({width: 15, color: Colors.red}),
+    borderHorizontal({width: 8, color: Colors.blue}),
+    borderTop({width: 15, color: Colors.red}),
+    borderLeft({width: 30, color: Colors.green}),
+  ];
 
 let innerStyle =
-  Style.make(
-    ~backgroundColor=Colors.yellow,
-    ~position=LayoutTypes.Relative,
-    ~left=0,
-    ~top=0,
-    ~width=30,
-    ~height=30,
-    ~borderHorizontal=Style.Border.make(~color=Colors.black, ~width=3, ()),
-    (),
-  );
+  Style.[
+    backgroundColor(Colors.yellow),
+    position(`Relative),
+    left(0),
+    top(0),
+    width(30),
+    height(30),
+    borderHorizontal({color: Colors.black, width: 3}),
+  ];
 
 let textStyle =
-  Style.make(
-    ~fontSize=20,
-    ~fontFamily="Roboto-Regular.ttf",
-    ~color=Colors.black,
-    (),
-  );
+  Style.[
+    fontSize(20),
+    fontFamily("Roboto-Regular.ttf"),
+    color(Colors.black),
+  ];
 
 let render = () =>
   <View style=defaultStyle>

--- a/examples/Border.re
+++ b/examples/Border.re
@@ -9,10 +9,10 @@ let defaultStyle =
     top(100),
     width(200),
     height(200),
-    border({width: 15, color: Colors.red}),
-    borderHorizontal({width: 8, color: Colors.blue}),
-    borderTop({width: 15, color: Colors.red}),
-    borderLeft({width: 30, color: Colors.green}),
+    border(~width=15, ~color=Colors.red),
+    borderHorizontal(~width=8, ~color=Colors.blue),
+    borderTop(~width=15, ~color=Colors.red),
+    borderLeft(~width=30, ~color=Colors.green),
   ];
 
 let innerStyle =
@@ -23,7 +23,7 @@ let innerStyle =
     top(0),
     width(30),
     height(30),
-    borderHorizontal({color: Colors.black, width: 3}),
+    borderHorizontal(~color=Colors.black, ~width=3),
   ];
 
 let textStyle =

--- a/examples/Boxshadow.re
+++ b/examples/Boxshadow.re
@@ -2,14 +2,13 @@ open Revery.UI;
 open Revery.Core;
 
 let parentStyles =
-  Style.make(
-    ~position=LayoutTypes.Relative,
-    ~flexGrow=1,
-    ~alignItems=LayoutTypes.AlignCenter,
-    ~justifyContent=LayoutTypes.JustifyCenter,
-    ~flexDirection=LayoutTypes.Column,
-    (),
-  );
+  Style.[
+    position(`Relative),
+    flexGrow(1),
+    alignItems(`Center),
+    justifyContent(`Center),
+    flexDirection(`Column),
+  ];
 
 let shadowOne =
   Style.BoxShadow.make(
@@ -32,30 +31,27 @@ let shadowTwo =
   );
 
 let firstShadow =
-  Style.make(
-    ~backgroundColor=Colors.blue,
-    ~position=LayoutTypes.Relative,
-    ~width=100,
-    ~height=100,
-    ~boxShadow=shadowOne,
-    ~marginVertical=30,
-    (),
-  );
+  Style.[
+    backgroundColor(Colors.blue),
+    position(`Relative),
+    width(100),
+    height(100),
+    boxShadow(shadowOne),
+    marginVertical(30),
+  ];
 
 let secondShadow =
-  Style.make(
-    ~backgroundColor=Colors.red,
-    ~position=LayoutTypes.Relative,
-    ~width=100,
-    ~height=100,
-    ~boxShadow=shadowTwo,
-    ~marginVertical=30,
-    (),
-  );
+  Style.[
+    backgroundColor(Colors.red),
+    position(`Relative),
+    width(100),
+    height(100),
+    boxShadow(shadowTwo),
+    marginVertical(30),
+  ];
 
-let render = () => {
+let render = () =>
   <View style=parentStyles>
     <View style=firstShadow />
     <View style=secondShadow />
   </View>;
-};

--- a/examples/Boxshadow.re
+++ b/examples/Boxshadow.re
@@ -10,33 +10,19 @@ let parentStyles =
     flexDirection(`Column),
   ];
 
-let shadowOne =
-  Style.BoxShadow.make(
-    ~yOffset=-10.,
-    ~xOffset=10.,
-    ~blurRadius=40.,
-    ~color=Colors.black,
-    ~spreadRadius=20.,
-    (),
-  );
-
-let shadowTwo =
-  Style.BoxShadow.make(
-    ~yOffset=10.,
-    ~xOffset=-30.,
-    ~blurRadius=50.,
-    ~color=Colors.green,
-    ~spreadRadius=0.,
-    (),
-  );
-
 let firstShadow =
   Style.[
     backgroundColor(Colors.blue),
     position(`Relative),
     width(100),
     height(100),
-    boxShadow(shadowOne),
+    boxShadow({
+      yOffset: (-10.),
+      xOffset: 0.,
+      blurRadius: 15.,
+      color: Colors.black,
+      spreadRadius: 10.,
+    }),
     marginVertical(30),
   ];
 
@@ -46,7 +32,13 @@ let secondShadow =
     position(`Relative),
     width(100),
     height(100),
-    boxShadow(shadowTwo),
+    boxShadow({
+      yOffset: 10.,
+      xOffset: (-30.),
+      blurRadius: 20.,
+      color: Colors.green,
+      spreadRadius: 0.,
+    }),
     marginVertical(30),
   ];
 

--- a/examples/Calculator.re
+++ b/examples/Calculator.re
@@ -11,13 +11,12 @@ module Row = {
   let make = children =>
     component((_slots: React.Hooks.empty) => {
       let style =
-        Style.make(
-          ~flexDirection=LayoutTypes.Row,
-          ~alignItems=LayoutTypes.AlignStretch,
-          ~justifyContent=LayoutTypes.JustifyCenter,
-          ~flexGrow=1,
-          (),
-        );
+        Style.[
+          flexDirection(`Row),
+          alignItems(`Stretch),
+          justifyContent(`Center),
+          flexGrow(1),
+        ];
       <View style> ...children </View>;
     });
 
@@ -30,14 +29,13 @@ module Column = {
   let make = children =>
     component((_slots: React.Hooks.empty) => {
       let style =
-        Style.make(
-          ~flexDirection=LayoutTypes.Column,
-          ~alignItems=LayoutTypes.AlignStretch,
-          ~justifyContent=LayoutTypes.JustifyCenter,
-          ~backgroundColor=Colors.darkGrey,
-          ~flexGrow=1,
-          (),
-        );
+        Style.[
+          flexDirection(`Column),
+          alignItems(`Stretch),
+          justifyContent(`Center),
+          backgroundColor(Colors.darkGrey),
+          flexGrow(1),
+        ];
       <View style> ...children </View>;
     });
 
@@ -48,29 +46,32 @@ module Button = {
   let component = React.component("Button");
 
   let make =
-      (~fontFamily="Roboto-Regular.ttf", ~contents: string, ~onClick, ()) =>
+      (
+        ~fontFamily as family="Roboto-Regular.ttf",
+        ~contents: string,
+        ~onClick,
+        (),
+      ) =>
     component((_slots: React.Hooks.empty) => {
       let clickableStyle =
-        Style.make(
-          ~position=LayoutTypes.Relative,
-          ~backgroundColor=Colors.lightGrey,
-          ~justifyContent=LayoutTypes.JustifyCenter,
-          ~alignItems=LayoutTypes.AlignCenter,
-          ~flexGrow=1,
+        Style.[
+          position(`Relative),
+          backgroundColor(Colors.lightGrey),
+          justifyContent(`Center),
+          alignItems(`Center),
+          flexGrow(1),
           /* Min width */
-          ~width=125,
-          ~margin=10,
-          (),
-        );
+          width(125),
+          margin(10),
+        ];
       let viewStyle =
-        Style.make(
-          ~position=LayoutTypes.Relative,
-          ~justifyContent=LayoutTypes.JustifyCenter,
-          ~alignItems=LayoutTypes.AlignCenter,
-          (),
-        );
+        Style.[
+          position(`Relative),
+          justifyContent(`Center),
+          alignItems(`Center),
+        ];
       let textStyle =
-        Style.make(~color=Colors.black, ~fontFamily, ~fontSize=32, ());
+        Style.[color(Colors.black), fontFamily(family), fontSize(32)];
 
       <Clickable style=clickableStyle onClick>
         <View style=viewStyle> <Text style=textStyle text=contents /> </View>
@@ -84,9 +85,8 @@ module Button = {
         ~onClick,
         ~children as _,
         (),
-      ) => {
+      ) =>
     React.element(make(~fontFamily, ~contents, ~onClick, ()));
-  };
 };
 module Display = {
   let component = React.component("Display");
@@ -94,31 +94,28 @@ module Display = {
   let make = (~display: string, ~curNum: string, ()) =>
     component((_slots: React.Hooks.empty) => {
       let viewStyle =
-        Style.make(
-          ~backgroundColor=Colors.white,
-          ~height=120,
-          ~flexDirection=LayoutTypes.Column,
-          ~alignItems=LayoutTypes.AlignStretch,
-          ~justifyContent=LayoutTypes.JustifyFlexStart,
-          ~flexGrow=2,
-          (),
-        );
+        Style.[
+          backgroundColor(Colors.white),
+          height(120),
+          flexDirection(`Column),
+          alignItems(`Stretch),
+          justifyContent(`FlexStart),
+          flexGrow(2),
+        ];
       let displayStyle =
-        Style.make(
-          ~color=Colors.black,
-          ~fontFamily="Roboto-Regular.ttf",
-          ~fontSize=20,
-          ~margin=15,
-          (),
-        );
+        Style.[
+          color(Colors.black),
+          fontFamily("Roboto-Regular.ttf"),
+          fontSize(20),
+          margin(15),
+        ];
       let numStyle =
-        Style.make(
-          ~color=Colors.black,
-          ~fontFamily="Roboto-Regular.ttf",
-          ~fontSize=32,
-          ~margin=15,
-          (),
-        );
+        Style.[
+          color(Colors.black),
+          fontFamily("Roboto-Regular.ttf"),
+          fontSize(32),
+          margin(15),
+        ];
 
       <View style=viewStyle>
         <Text style=displayStyle text=display />
@@ -205,19 +202,19 @@ let eval = (state, newOp) => {
 let reducer = (action, state) =>
   switch (action) {
   | BackspaceKeyPressed =>
-    state.number == ""
-      ? state
-      : {
+    state.number == "" ?
+      state :
+      {
         ...state,
         number: String.sub(state.number, 0, String.length(state.number) - 1),
       }
   | ClearKeyPressed(ac) =>
-    ac
-      ? {operator: `Nop, result: 0., display: "", number: ""}
-      : {...state, number: ""}
+    ac ?
+      {operator: `Nop, result: 0., display: "", number: ""} :
+      {...state, number: ""}
   | DotKeyPressed =>
-    String.contains(state.number, '.')
-      ? state : {...state, number: state.number ++ "."}
+    String.contains(state.number, '.') ?
+      state : {...state, number: state.number ++ "."}
   | NumberKeyPressed(n) => {...state, number: state.number ++ n}
   | OperationKeyPressed(o) =>
     let (result, display) = eval(state, o);
@@ -388,6 +385,4 @@ module Calculator = {
     React.element(make(window));
 };
 
-let render = window => {
-  <Calculator window />;
-};
+let render = window => <Calculator window />;

--- a/examples/DefaultButton.re
+++ b/examples/DefaultButton.re
@@ -5,36 +5,30 @@ open Revery.Core;
 module DefaultButtonWithCounter = {
   let component = React.component("DefaultButtonWithCounter");
 
-  let make = () => {
+  let make = () =>
     component(slots => {
       let (count, setCount, _slots: React.Hooks.empty) =
         React.Hooks.state(0, slots);
       let increment = () => setCount(count + 1);
 
       let containerStyle =
-        Style.make(
-          ~justifyContent=JustifyCenter,
-          ~alignItems=AlignCenter,
-          (),
-        );
+        Style.[justifyContent(`Center), alignItems(`Center)];
 
       let countContainer =
-        Style.make(
-          ~width=300,
-          ~height=300,
-          ~alignItems=LayoutTypes.AlignCenter,
-          ~justifyContent=LayoutTypes.JustifyCenter,
-          (),
-        );
+        Style.[
+          width(300),
+          height(300),
+          alignItems(`Center),
+          justifyContent(`Center),
+        ];
 
       let countStyle =
-        Style.make(
-          ~fontSize=50,
-          ~margin=24,
-          ~color=Colors.black,
-          ~fontFamily="Roboto-Regular.ttf",
-          (),
-        );
+        Style.[
+          fontSize(50),
+          margin(24),
+          color(Colors.black),
+          fontFamily("Roboto-Regular.ttf"),
+        ];
 
       let countStr = string_of_int(count);
       <View style=containerStyle>
@@ -45,7 +39,6 @@ module DefaultButtonWithCounter = {
         <Button disabled=true title="(disabled)" onClick=increment />
       </View>;
     });
-  };
 
   let createElement = (~children as _, ()) => React.element(make());
 };

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -62,7 +62,7 @@ module ExampleButton = {
       let wrapperStyle =
         Style.[
           opacity(buttonOpacity),
-          borderLeft({width: 4, color: highlightColor}),
+          borderLeft(~width=4, ~color=highlightColor),
           backgroundColor(bgColor),
         ];
 

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -7,7 +7,7 @@ module SliderExample = Slider;
 open Revery.UI;
 open Revery.UI.Components;
 
-let backgroundColor = Color.hex("#212733");
+let bgColor = Color.hex("#212733");
 let activeBackgroundColor = Color.hex("#2E3440");
 let inactiveBackgroundColor = Color.hex("#272d39");
 let selectionHighlight = Color.hex("#90f7ff");
@@ -56,29 +56,26 @@ module ExampleButton = {
       let highlightColor =
         isActive ? selectionHighlight : Colors.transparentWhite;
 
-      let opacity = 1.0;
-      let backgroundColor =
-        isActive ? activeBackgroundColor : inactiveBackgroundColor;
+      let buttonOpacity = 1.0;
+      let bgColor = isActive ? activeBackgroundColor : inactiveBackgroundColor;
 
       let wrapperStyle =
-        Style.make(
-          ~opacity,
-          ~borderLeft=Style.Border.make(~width=4, ~color=highlightColor, ()),
-          ~backgroundColor,
-          (),
-        );
+        Style.[
+          opacity(buttonOpacity),
+          borderLeft({width: 4, color: highlightColor}),
+          backgroundColor(bgColor),
+        ];
 
       let textColor = isActive ? Colors.white : Colors.grey;
       let textHeaderStyle =
-        Style.make(
-          ~color=textColor,
-          ~fontFamily="Roboto-Regular.ttf",
-          ~fontSize=14,
-          ~margin=16,
-          (),
-        );
+        Style.[
+          color(textColor),
+          fontFamily("Roboto-Regular.ttf"),
+          fontSize(14),
+          margin(16),
+        ];
 
-      <View style={Style.make(~opacity, ())}>
+      <View style=[Style.opacity(buttonOpacity)]>
         <Clickable style=wrapperStyle onClick>
           <Text style=textHeaderStyle text=name />
         </Clickable>
@@ -130,40 +127,37 @@ let init = app => {
       onMouseWheel={evt =>
         print_endline("onMouseWheel: " ++ string_of_float(evt.deltaY))
       }
-      style={Style.make(
-        ~position=LayoutTypes.Absolute,
-        ~justifyContent=LayoutTypes.JustifyCenter,
-        ~alignItems=LayoutTypes.AlignCenter,
-        ~backgroundColor,
-        ~bottom=0,
-        ~top=0,
-        ~left=0,
-        ~right=0,
-        ~flexDirection=LayoutTypes.Row,
-        (),
-      )}>
+      style=Style.[
+        position(`Absolute),
+        justifyContent(`Center),
+        alignItems(`Center),
+        backgroundColor(bgColor),
+        bottom(0),
+        top(0),
+        left(0),
+        right(0),
+        flexDirection(`Row),
+      ]>
       <View
-        style={Style.make(
-          ~position=LayoutTypes.Absolute,
-          ~top=0,
-          ~left=0,
-          ~width=175,
-          ~bottom=0,
-          ~backgroundColor,
-          (),
-        )}>
+        style=Style.[
+          position(`Absolute),
+          top(0),
+          left(0),
+          width(175),
+          bottom(0),
+          backgroundColor(bgColor),
+        ]>
         ...buttons
       </View>
       <View
-        style={Style.make(
-          ~position=LayoutTypes.Absolute,
-          ~top=0,
-          ~left=175,
-          ~right=0,
-          ~bottom=0,
-          ~backgroundColor=activeBackgroundColor,
-          (),
-        )}>
+        style=Style.[
+          position(`Absolute),
+          top(0),
+          left(175),
+          right(0),
+          bottom(0),
+          backgroundColor(activeBackgroundColor),
+        ]>
         example
       </View>
     </View>;

--- a/examples/Flexbox.re
+++ b/examples/Flexbox.re
@@ -5,77 +5,67 @@ let parentWidth = 400;
 let childWidth = 300;
 
 let parentStyles =
-    (
-      ~alignment=LayoutTypes.AlignAuto,
-      ~direction=LayoutTypes.Row,
-      ~justify=LayoutTypes.JustifyCenter,
-      (),
-    ) =>
-  Style.make(
-    ~backgroundColor=Colors.green,
-    ~position=LayoutTypes.Relative,
-    ~width=parentWidth,
-    ~height=100,
-    ~alignItems=alignment,
-    ~justifyContent=justify,
-    ~flexDirection=direction,
-    (),
-  );
+    (~alignment as a=`Auto, ~direction as d=`Row, ~justify as j=`Center, ()) =>
+  Style.[
+    backgroundColor(Colors.green),
+    position(`Relative),
+    width(parentWidth),
+    height(100),
+    alignItems(a),
+    justifyContent(j),
+    flexDirection(d),
+  ];
 
 let childStyles =
-  Style.make(
-    ~backgroundColor=Colors.blue,
-    ~position=LayoutTypes.Relative,
-    ~width=childWidth,
-    ~height=40,
-    (),
-  );
+  Style.[
+    backgroundColor(Colors.blue),
+    position(`Relative),
+    width(childWidth),
+    height(40),
+  ];
 
 let defaultTextStyles =
-  Style.make(
-    ~fontSize=20,
-    ~fontFamily="Roboto-Regular.ttf",
-    ~color=Colors.white,
-    ~backgroundColor=Colors.blue,
-    (),
-  );
+  Style.[
+    fontSize(20),
+    fontFamily("Roboto-Regular.ttf"),
+    color(Colors.white),
+    backgroundColor(Colors.blue),
+  ];
 
-let parentColumnStyle = parentStyles(~direction=LayoutTypes.Column);
+let parentColumnStyle = parentStyles(~direction=`Column);
 let headerStyle =
-  Style.make(
-    ~marginTop=25,
-    ~marginBottom=25,
-    ~fontSize=30,
-    ~fontFamily="Roboto-Regular.ttf",
-    ~color=Colors.white,
-    (),
-  );
+  Style.[
+    marginTop(25),
+    marginBottom(25),
+    fontSize(30),
+    fontFamily("Roboto-Regular.ttf"),
+    color(Colors.white),
+  ];
 
 let horizontalStyles =
   <View>
     <Text style=headerStyle text="Flex Direction Row" />
-    <View style={parentColumnStyle(~alignment=LayoutTypes.AlignAuto, ())}>
+    <View style={parentColumnStyle(~alignment=`Auto, ())}>
       <View style=childStyles>
         <Text style=defaultTextStyles text="Default Flex" />
       </View>
     </View>
-    <View style={parentColumnStyle(~alignment=LayoutTypes.AlignCenter, ())}>
+    <View style={parentColumnStyle(~alignment=`Center, ())}>
       <View style=childStyles>
         <Text style=defaultTextStyles text="Center" />
       </View>
     </View>
-    <View
-      style={parentColumnStyle(~alignment=LayoutTypes.AlignFlexStart, ())}>
+    <View style={parentColumnStyle(~alignment=`FlexStart, ())}>
       <View style=childStyles>
         <Text style=defaultTextStyles text="Flex Start" />
       </View>
     </View>
-    <View style={parentColumnStyle(~alignment=LayoutTypes.AlignFlexEnd, ())}>
+    <View style={parentColumnStyle(~alignment=`FlexEnd, ())}>
       <View style=childStyles>
         <Text style=defaultTextStyles text="Flex End" />
       </View>
     </View>
-    <View style={parentColumnStyle(~alignment=LayoutTypes.AlignStretch, ())}>
+    <View style={parentColumnStyle(~alignment=`Stretch, ())}>
       <View style=childStyles>
         <Text style=defaultTextStyles text="Flex Stretch" />
       </View>
@@ -85,32 +75,17 @@ let horizontalStyles =
 let verticalStyles =
   <View>
     <Text style=headerStyle text="Flex Direction Column" />
-    <View
-      style={parentStyles(
-        ~direction=LayoutTypes.Column,
-        ~justify=LayoutTypes.JustifyFlexStart,
-        (),
-      )}>
+    <View style={parentStyles(~direction=`Column, ~justify=`FlexStart, ())}>
       <View style=childStyles>
         <Text style=defaultTextStyles text="Align Flex Start" />
       </View>
     </View>
-    <View
-      style={parentStyles(
-        ~direction=LayoutTypes.Column,
-        ~justify=LayoutTypes.JustifyCenter,
-        (),
-      )}>
+    <View style={parentStyles(~direction=`Column, ~justify=`Center, ())}>
       <View style=childStyles>
         <Text style=defaultTextStyles text="Align Flex Center" />
       </View>
     </View>
-    <View
-      style={parentStyles(
-        ~direction=LayoutTypes.Column,
-        ~justify=LayoutTypes.JustifyFlexEnd,
-        (),
-      )}>
+    <View style={parentStyles(~direction=`Column, ~justify=`FlexEnd, ())}>
       <View style=childStyles>
         <Text style=defaultTextStyles text="Align Flex End" />
       </View>

--- a/examples/Focus.re
+++ b/examples/Focus.re
@@ -13,22 +13,6 @@ module SimpleButton = {
 
       let increment = () => setCount(count + 1);
 
-      let wrapperStyle =
-        Style.make(
-          ~backgroundColor=Color.rgba(1., 1., 1., 0.1),
-          ~border=Style.Border.make(~width=2, ~color=Colors.white, ()),
-          ~margin=16,
-          (),
-        );
-
-      let textHeaderStyle =
-        Style.make(
-          ~color=Colors.white,
-          ~fontFamily="Roboto-Regular.ttf",
-          ~fontSize=20,
-          ~margin=4,
-          (),
-        );
       let txt = focused ? "Focused" : "Unfocused";
       let textContent = txt ++ " me: " ++ string_of_int(count);
       <Clickable
@@ -36,8 +20,21 @@ module SimpleButton = {
         tabindex=0
         onFocus={() => setFocus(true)}
         onBlur={() => setFocus(false)}>
-        <View style=wrapperStyle>
-          <Text style=textHeaderStyle text=textContent />
+        <View
+          style=Style.[
+            backgroundColor(Color.rgba(1., 1., 1., 0.1)),
+            border({width: 2, color: Colors.white}),
+            margin(16),
+          ]>
+          <Text
+            style=Style.[
+              color(Colors.white),
+              fontFamily("Roboto-Regular.ttf"),
+              fontSize(20),
+              margin(4),
+            ]
+            text=textContent
+          />
         </View>
       </Clickable>;
     });
@@ -47,15 +44,14 @@ module SimpleButton = {
 
 let render = () =>
   <View
-    style={Style.make(
-      ~position=LayoutTypes.Absolute,
-      ~justifyContent=LayoutTypes.JustifyCenter,
-      ~alignItems=LayoutTypes.AlignCenter,
-      ~bottom=0,
-      ~top=0,
-      ~left=0,
-      ~right=0,
-      (),
-    )}>
+    style=Style.[
+      position(`Absolute),
+      justifyContent(`Center),
+      alignItems(`Center),
+      bottom(0),
+      top(0),
+      left(0),
+      right(0),
+    ]>
     <SimpleButton />
   </View>;

--- a/examples/Focus.re
+++ b/examples/Focus.re
@@ -23,7 +23,7 @@ module SimpleButton = {
         <View
           style=Style.[
             backgroundColor(Color.rgba(1., 1., 1., 0.1)),
-            border({width: 2, color: Colors.white}),
+            border(~width=2, ~color=Colors.white),
             margin(16),
           ]>
           <Text

--- a/examples/GameOfLife.re
+++ b/examples/GameOfLife.re
@@ -61,13 +61,12 @@ module Universe = {
       let compare = compare;
     });
   include T;
-  let universeFromList = positions => {
+  let universeFromList = positions =>
     List.fold_left(
       (acc, pos) => T.add(pos, Alive, acc),
       T.empty,
       positions,
     );
-  };
 };
 
 module Examples = {
@@ -133,11 +132,10 @@ module GameOfLife = {
     | None => default
     };
 
-  let findCell = (universe, position) => {
+  let findCell = (universe, position) =>
     Universe.find_opt(position, universe)
     |> withDefault(~default=Dead)
     |> (cell => (position, cell));
-  };
 
   let numberOfLive = neighbours =>
     neighbours
@@ -266,14 +264,13 @@ module Row = {
   let component = React.component("Row");
 
   let style =
-    Style.make(
-      ~flexDirection=LayoutTypes.Row,
-      ~alignItems=LayoutTypes.AlignStretch,
-      ~justifyContent=LayoutTypes.JustifyCenter,
-      ~backgroundColor=Colors.darkGrey,
-      ~flexGrow=1,
-      (),
-    );
+    Style.[
+      flexDirection(`Row),
+      alignItems(`Stretch),
+      justifyContent(`Center),
+      backgroundColor(Colors.darkGrey),
+      flexGrow(1),
+    ];
 
   let make = children =>
     component((_slots: React.Hooks.empty) =>
@@ -287,13 +284,12 @@ module Column = {
   let component = React.component("Column");
 
   let style =
-    Style.make(
-      ~flexDirection=LayoutTypes.Column,
-      ~alignItems=LayoutTypes.AlignStretch,
-      ~justifyContent=LayoutTypes.JustifyCenter,
-      ~flexGrow=1,
-      (),
-    );
+    Style.[
+      flexDirection(`Column),
+      alignItems(`Stretch),
+      justifyContent(`Center),
+      flexGrow(1),
+    ];
 
   let make = children =>
     component((_slots: React.Hooks.empty) =>
@@ -306,25 +302,27 @@ module Cell = {
   let component = React.component("Column");
 
   let clickableStyle =
-    Style.make(
-      ~position=LayoutTypes.Relative,
-      ~backgroundColor=Colors.transparentWhite,
-      ~justifyContent=LayoutTypes.JustifyCenter,
-      ~alignItems=LayoutTypes.AlignStretch,
-      ~flexGrow=1,
-      ~margin=0,
-      (),
-    );
+    Style.[
+      position(`Relative),
+      backgroundColor(Colors.transparentWhite),
+      justifyContent(`Center),
+      alignItems(`Stretch),
+      flexGrow(1),
+      margin(0),
+    ];
   let baseStyle =
-    Style.make(
-      ~flexDirection=LayoutTypes.Column,
-      ~alignItems=LayoutTypes.AlignStretch,
-      ~justifyContent=LayoutTypes.JustifyCenter,
-      ~flexGrow=1,
-      (),
+    Style.[
+      flexDirection(`Column),
+      alignItems(`Stretch),
+      justifyContent(`Center),
+      flexGrow(1),
+    ];
+  let aliveStyle =
+    Style.(merge(~source=baseStyle, ~target=[backgroundColor(Colors.red)]));
+  let deadStyle =
+    Style.(
+      merge(~source=baseStyle, ~target=[backgroundColor(Colors.black)])
     );
-  let aliveStyle = Style.extend(baseStyle, ~backgroundColor=Colors.red, ());
-  let deadStyle = Style.extend(baseStyle, ~backgroundColor=Colors.black, ());
 
   let make = (~cell, ~onClick, ()) =>
     component((_slots: React.Hooks.empty) => {
@@ -426,8 +424,7 @@ let reducer = (action, state) =>
 module GameOfLiveComponent = {
   let component = React.component("GameOfLiveComponent");
 
-  let controlsStyle =
-    Style.make(~height=120, ~flexDirection=LayoutTypes.Row, ());
+  let controlsStyle = Style.[height(120), flexDirection(`Row)];
 
   let make = (~state: state, ()) =>
     component(slots => {
@@ -443,7 +440,7 @@ module GameOfLiveComponent = {
 
       let toggleAlive = pos => dispatch(ToggleAlive(pos));
 
-      let startStop = () => {
+      let startStop = () =>
         state.isRunning
           ? dispatch(StopTimer)
           : {
@@ -451,7 +448,6 @@ module GameOfLiveComponent = {
               Tick.interval(t => dispatch(TimerTick(t)), Seconds(0.));
             dispatch(StartTimer(dispose));
           };
-      };
 
       <Column>
         <Row>
@@ -497,9 +493,8 @@ module GameOfLiveComponent = {
       </Column>;
     });
 
-  let createElement = (~state, ~children as _, ()) => {
+  let createElement = (~state, ~children as _, ()) =>
     React.element(make(~state, ()));
-  };
 };
 
 let render = () => {

--- a/examples/Hello.re
+++ b/examples/Hello.re
@@ -35,13 +35,9 @@ module Logo = {
           slots,
         );
 
-      let onMouseDown = _ => {
-        setOpacity(0.5);
-      };
+      let onMouseDown = _ => setOpacity(0.5);
 
-      let onMouseUp = _ => {
-        setOpacity(1.0);
-      };
+      let onMouseUp = _ => setOpacity(1.0);
 
       <View onMouseDown onMouseUp>
         <Image
@@ -68,7 +64,7 @@ module AnimatedText = {
 
   let make = (~text, ~delay, ()) =>
     component(slots => {
-      let (opacity, slots) =
+      let (animatedOpacity, slots) =
         Hooks.animation(
           Animated.floatValue(0.),
           {
@@ -95,15 +91,14 @@ module AnimatedText = {
         );
 
       let textHeaderStyle =
-        Style.make(
-          ~color=Colors.white,
-          ~fontFamily="Roboto-Regular.ttf",
-          ~fontSize=24,
-          ~marginHorizontal=8,
-          ~opacity,
-          ~transform=[TranslateY(translate)],
-          (),
-        );
+        Style.[
+          color(Colors.white),
+          fontFamily("Roboto-Regular.ttf"),
+          fontSize(24),
+          marginHorizontal(8),
+          opacity(animatedOpacity),
+          transform([Transform.TranslateY(translate)]),
+        ];
 
       <Text style=textHeaderStyle text />;
     });
@@ -117,16 +112,15 @@ let render = () =>
     onMouseWheel={evt =>
       print_endline("onMouseWheel: " ++ string_of_float(evt.deltaY))
     }
-    style={Style.make(
-      ~position=LayoutTypes.Absolute,
-      ~justifyContent=LayoutTypes.JustifyCenter,
-      ~alignItems=LayoutTypes.AlignCenter,
-      ~bottom=0,
-      ~top=0,
-      ~left=0,
-      ~right=0,
-      (),
-    )}>
+    style=Style.[
+      position(`Absolute),
+      justifyContent(`Center),
+      alignItems(`Center),
+      bottom(0),
+      top(0),
+      left(0),
+      right(0),
+    ]>
     <Logo />
     <View
       ref={r =>
@@ -134,7 +128,7 @@ let render = () =>
           "View internal id:" ++ string_of_int(r#getInternalId()),
         )
       }
-      style={Style.make(~flexDirection=Row, ~alignItems=AlignFlexEnd, ())}>
+      style=Style.[flexDirection(`Row), alignItems(`FlexEnd)]>
       <AnimatedText delay=0.0 text="Welcome" />
       <AnimatedText delay=0.5 text="to" />
       <AnimatedText delay=1. text="Revery" />

--- a/examples/InputExample.re
+++ b/examples/InputExample.re
@@ -42,7 +42,6 @@ module Example = {
         />
         <Input
           window
-          boxShadow=customShadow
           placeholder="custom input"
           placeholderColor=Colors.plum
           cursorColor=Colors.white
@@ -56,6 +55,7 @@ module Example = {
               yOffset: 2.,
               color: Colors.black,
               blurRadius: 20.,
+              spreadRadius: 0.,
             }),
           ]
         />

--- a/examples/InputExample.re
+++ b/examples/InputExample.re
@@ -3,18 +3,17 @@ open Revery.Core;
 open Revery.UI.Components;
 
 let containerStyle =
-  Style.make(
-    ~position=LayoutTypes.Absolute,
-    ~top=0,
-    ~bottom=0,
-    ~left=0,
-    ~right=0,
-    ~alignItems=LayoutTypes.AlignCenter,
-    ~justifyContent=LayoutTypes.JustifyCenter,
-    ~flexDirection=LayoutTypes.Column,
-    ~backgroundColor=Colors.white,
-    (),
-  );
+  Style.[
+    position(`Absolute),
+    top(0),
+    bottom(0),
+    left(0),
+    right(0),
+    alignItems(`Center),
+    justifyContent(`Center),
+    flexDirection(`Column),
+    backgroundColor(Colors.white),
+  ];
 
 module Example = {
   type inputFields = {
@@ -22,27 +21,18 @@ module Example = {
     second: string,
   };
   let textStyles =
-    Style.make(
-      ~fontSize=30,
-      ~fontFamily="Roboto-Regular.ttf",
-      ~color=Colors.black,
-      ~marginBottom=30,
-      (),
-    );
+    Style.[
+      fontSize(30),
+      fontFamily("Roboto-Regular.ttf"),
+      color(Colors.black),
+      marginBottom(30),
+    ];
   let component = React.component("Example");
 
   let make = window =>
     component(slots => {
       let ({first, second}, setValue, _slots: React.Hooks.empty) =
         React.Hooks.state({first: "", second: ""}, slots);
-      let customShadow =
-        Style.BoxShadow.make(
-          ~xOffset=-5.,
-          ~yOffset=2.,
-          ~color=Colors.black,
-          ~blurRadius=20.,
-          (),
-        );
 
       <View style=containerStyle>
         <Input
@@ -51,14 +41,23 @@ module Example = {
           onChange={(~value) => setValue({first: value, second})}
         />
         <Input
-          backgroundColor=Colors.paleVioletRed
-          color=Colors.white
-          margin=20
-          boxShadow=customShadow
           window
+          boxShadow=customShadow
           placeholder="custom input"
           placeholderColor=Colors.plum
+          cursorColor=Colors.white
           onChange={(~value) => setValue({first, second: value})}
+          style=Style.[
+            backgroundColor(Colors.paleVioletRed),
+            color(Colors.white),
+            margin(20),
+            boxShadow({
+              xOffset: (-5.),
+              yOffset: 2.,
+              color: Colors.black,
+              blurRadius: 20.,
+            }),
+          ]
         />
       </View>;
     });

--- a/examples/Overflow.re
+++ b/examples/Overflow.re
@@ -3,35 +3,32 @@ open Revery.Core;
 open Revery.UI.Components;
 
 let containerStyle =
-  Style.make(
-    ~position=LayoutTypes.Absolute,
-    ~top=0,
-    ~bottom=0,
-    ~left=0,
-    ~right=0,
-    ~alignItems=LayoutTypes.AlignCenter,
-    ~justifyContent=LayoutTypes.JustifyCenter,
-    ~flexDirection=LayoutTypes.Column,
-    ~backgroundColor=Colors.black,
-    (),
-  );
+  Style.[
+    position(`Absolute),
+    top(0),
+    bottom(0),
+    left(0),
+    right(0),
+    alignItems(`Center),
+    justifyContent(`Center),
+    flexDirection(`Column),
+    backgroundColor(Colors.black),
+  ];
 
 let outerBox =
-  Style.make(
-    ~width=75,
-    ~height=75,
-    ~overflow=LayoutTypes.Hidden,
-    ~backgroundColor=Colors.red,
-    (),
-  );
+  Style.[
+    width(75),
+    height(75),
+    overflow(LayoutTypes.Hidden),
+    backgroundColor(Colors.red),
+  ];
 
 let innerBox =
-  Style.make(
-    ~width=150,
-    ~height=150,
-    ~backgroundColor=Color.rgba(0., 1.0, 0., 0.5),
-    (),
-  );
+  Style.[
+    width(150),
+    height(150),
+    backgroundColor(Color.rgba(0., 1.0, 0., 0.5)),
+  ];
 
 module Sample = {
   let component = React.component("Sample");
@@ -41,18 +38,19 @@ module Sample = {
       let (hidden, setHidden, _slots: React.Hooks.empty) =
         React.Hooks.state(false, slots);
 
-      let outerStyle = {
-        ...outerBox,
-        overflow: hidden ? LayoutTypes.Hidden : LayoutTypes.Visible,
-      };
+      let outerStyle =
+        List.append(
+          outerBox,
+          [
+            Style.overflow(hidden ? LayoutTypes.Hidden : LayoutTypes.Visible),
+          ],
+        );
 
-      let onClick = _ => {
-        setHidden(!hidden);
-      };
+      let onClick = _ => setHidden(!hidden);
 
       <View style=containerStyle>
         <View style=outerStyle> <View style=innerBox /> </View>
-        <View style={Style.make(~marginTop=80, ())}>
+        <View style=Style.[marginTop(80)]>
           <Button fontSize=20 height=45 title="Toggle overflow" onClick />
         </View>
       </View>;

--- a/examples/Slider.re
+++ b/examples/Slider.re
@@ -14,53 +14,47 @@ module AdjustableLogo = {
         React.Hooks.state(0., slots);
 
       let containerStyle =
-        Style.make(
-          ~flexGrow=1,
-          ~justifyContent=LayoutTypes.JustifyCenter,
-          ~alignItems=LayoutTypes.AlignCenter,
-          ~flexDirection=LayoutTypes.Column,
-          (),
-        );
+        Style.[
+          flexGrow(1),
+          justifyContent(`Center),
+          alignItems(`Center),
+          flexDirection(`Column),
+        ];
 
       let textStyle =
-        Style.make(
-          ~color=Colors.white,
-          ~width=100,
-          ~fontFamily="Roboto-Regular.ttf",
-          ~fontSize=16,
-          ~margin=14,
-          (),
-        );
+        Style.[
+          color(Colors.white),
+          width(100),
+          fontFamily("Roboto-Regular.ttf"),
+          fontSize(16),
+          margin(14),
+        ];
+
       let controlsStyle =
-        Style.make(
-          ~margin=10,
-          ~flexDirection=LayoutTypes.Row,
-          ~justifyContent=LayoutTypes.JustifyCenter,
-          ~alignItems=LayoutTypes.AlignCenter,
-          (),
-        );
+        Style.[
+          margin(10),
+          flexDirection(`Row),
+          justifyContent(`Center),
+          alignItems(`Center),
+        ];
 
       let sliderContainerStyle =
-        Style.make(
-          ~margin=10,
-          ~borderBottom=
-            Style.Border.make(~width=1, ~color=Colors.darkGray, ()),
-          ~flexDirection=LayoutTypes.Row,
-          ~justifyContent=LayoutTypes.JustifyCenter,
-          ~alignItems=LayoutTypes.AlignCenter,
-          (),
-        );
+        Style.[
+          margin(10),
+          borderBottom(~width=1, ~color=Colors.darkGray),
+          flexDirection(`Row),
+          justifyContent(`Center),
+          alignItems(`Center),
+        ];
 
       let verticalSliderContainerStyle =
-        Style.make(
-          ~margin=10,
-          ~borderRight=
-            Style.Border.make(~width=1, ~color=Colors.darkGray, ()),
-          ~flexDirection=LayoutTypes.Column,
-          ~justifyContent=LayoutTypes.JustifyCenter,
-          ~alignItems=LayoutTypes.AlignCenter,
-          (),
-        );
+        Style.[
+          margin(10),
+          borderRight(~width=1, ~color=Colors.darkGray),
+          flexDirection(`Column),
+          justifyContent(`Center),
+          alignItems(`Center),
+        ];
 
       let toDeg = r => 180. *. r /. pi;
 

--- a/examples/Stopwatch.re
+++ b/examples/Stopwatch.re
@@ -95,7 +95,7 @@ module Clock = {
           style=Style.[
             margin(20),
             width(150),
-            borderBottom({color: Colors.gray, width: 2}),
+            borderBottom(~color=Colors.gray, ~width=2),
           ]>
           <Text
             style=Style.[

--- a/examples/Stopwatch.re
+++ b/examples/Stopwatch.re
@@ -60,14 +60,6 @@ module Clock = {
           slots,
         );
 
-      let clockWrapperStyle =
-        Style.make(
-          ~margin=20,
-          ~width=150,
-          ~borderBottom=Style.Border.make(~color=Colors.gray, ~width=2, ()),
-          (),
-        );
-
       let startStop = () =>
         state.isRunning ?
           dispatch(Stop) :
@@ -83,37 +75,15 @@ module Clock = {
             dispatch(Start(dispose));
           };
 
-      let style =
-        Style.make(
-          ~color=Colors.white,
-          ~fontFamily="Roboto-Regular.ttf",
-          ~fontSize=24,
-          ~marginVertical=20,
-          ~width=200,
-          (),
-        );
-
       let buttonText = state.isRunning ? "STOP" : "START";
 
       let marcherOpacity = state.isRunning ? 1.0 : 0.0;
       let getMarcherPosition = t =>
         sin(Time.to_float_seconds(t) *. 2. *. pi) /. 2. +. 0.5;
 
-      let marcherStyle =
-        Style.make(
-          ~position=LayoutTypes.Absolute,
-          ~bottom=0,
-          ~opacity=marcherOpacity,
-          ~left=int_of_float(getMarcherPosition(state.elapsedTime) *. 146.),
-          ~width=4,
-          ~height=4,
-          ~backgroundColor=Color.hex("#90f7ff"),
-          (),
-        );
-
       <View
         style=Style.[
-          position(LayoutTypes.Absolute),
+          position(`Absolute),
           justifyContent(`Center),
           alignItems(`Center),
           bottom(0),
@@ -121,12 +91,35 @@ module Clock = {
           left(0),
           right(0),
         ]>
-        <View style=clockWrapperStyle>
+        <View
+          style=Style.[
+            margin(20),
+            width(150),
+            borderBottom({color: Colors.gray, width: 2}),
+          ]>
           <Text
-            style
+            style=Style.[
+              color(Colors.white),
+              fontFamily("Roboto-Regular.ttf"),
+              fontSize(24),
+              marginVertical(20),
+              width(200),
+            ]
             text={string_of_float(state.elapsedTime |> Time.to_float_seconds)}
           />
-          <View style=marcherStyle />
+          <View
+            style=Style.[
+              position(`Absolute),
+              bottom(0),
+              opacity(marcherOpacity),
+              left(
+                int_of_float(getMarcherPosition(state.elapsedTime) *. 146.),
+              ),
+              width(4),
+              height(4),
+              backgroundColor(Color.hex("#90f7ff")),
+            ]
+          />
         </View>
         <Button title=buttonText onClick=startStop />
       </View>;

--- a/examples/Stopwatch.re
+++ b/examples/Stopwatch.re
@@ -68,21 +68,20 @@ module Clock = {
           (),
         );
 
-      let startStop = () => {
-        state.isRunning
-          ? dispatch(Stop)
-          /*
-           * If we're not already running, we'll start a timer job
-           * and use the delta time it passes to update our reducer.
-           */
-          : {
+      let startStop = () =>
+        state.isRunning ?
+          dispatch(Stop) :
+          {
+            /*
+             * If we're not already running, we'll start a timer job
+             * and use the delta time it passes to update our reducer.
+             */
             let dispose =
               Tick.interval(t => dispatch(TimerTick(t)), Seconds(0.));
 
             /* We'll also keep a handle on the dispose function so we can make sure its called on stop*/
             dispatch(Start(dispose));
           };
-      };
 
       let style =
         Style.make(
@@ -113,16 +112,15 @@ module Clock = {
         );
 
       <View
-        style={Style.make(
-          ~position=LayoutTypes.Absolute,
-          ~justifyContent=LayoutTypes.JustifyCenter,
-          ~alignItems=LayoutTypes.AlignCenter,
-          ~bottom=0,
-          ~top=0,
-          ~left=0,
-          ~right=0,
-          (),
-        )}>
+        style=Style.[
+          position(LayoutTypes.Absolute),
+          justifyContent(`Center),
+          alignItems(`Center),
+          bottom(0),
+          top(0),
+          left(0),
+          right(0),
+        ]>
         <View style=clockWrapperStyle>
           <Text
             style

--- a/src/UI/Primitives.re
+++ b/src/UI/Primitives.re
@@ -21,12 +21,13 @@ module View = {
         ~onFocus=?,
         ~tabindex=?,
         ~ref=?,
-        ~style=Style.defaultStyle,
+        ~style=[],
         children,
-      ) => {
+      ) =>
     component((_: UiReact.Hooks.empty) =>
       {
         make: () => {
+          let styles = Style.create(~style, ());
           let events =
             NodeEvents.make(
               ~ref?,
@@ -40,11 +41,12 @@ module View = {
             );
           let node = (new ViewNode.viewNode)();
           node#setEvents(events);
-          node#setStyle(style);
+          node#setStyle(styles);
           node#setTabIndex(tabindex);
           node;
         },
         configureInstance: (~isFirstRender as _, node) => {
+          let styles = Style.create(~style, ());
           let events =
             NodeEvents.make(
               ~ref?,
@@ -57,14 +59,13 @@ module View = {
               (),
             );
           node#setEvents(events);
-          node#setStyle(style);
+          node#setStyle(styles);
           node#setTabIndex(tabindex);
           node;
         },
         children,
       }
     );
-  };
 
   let createElement =
       (
@@ -75,11 +76,11 @@ module View = {
         ~onBlur=?,
         ~onFocus=?,
         ~ref=?,
-        ~style=Style.defaultStyle,
+        ~style=[],
         ~tabindex=None,
         ~children,
         (),
-      ) => {
+      ) =>
     UiReact.element(
       make(
         ~onMouseDown?,
@@ -94,7 +95,6 @@ module View = {
         UiReact.listToElement(children),
       ),
     );
-  };
 };
 
 module Text = {
@@ -107,13 +107,14 @@ module Text = {
         ~onMouseUp=?,
         ~onMouseWheel=?,
         ~ref=?,
-        ~style=Style.defaultStyle,
+        ~style=[],
         ~text="",
         children,
-      ) => {
+      ) =>
     component((_: UiReact.Hooks.empty) =>
       {
         make: () => {
+          let styles = Style.create(~style, ());
           let events =
             NodeEvents.make(
               ~ref?,
@@ -125,10 +126,11 @@ module Text = {
             );
           let node = (new TextNode.textNode)(text);
           node#setEvents(events);
-          node#setStyle(style);
+          node#setStyle(styles);
           Obj.magic(node);
         },
         configureInstance: (~isFirstRender as _, node) => {
+          let styles = Style.create(~style, ());
           let events =
             NodeEvents.make(
               ~ref?,
@@ -142,14 +144,13 @@ module Text = {
           /* TODO: Proper way to downcast? */
           let tn: TextNode.textNode = Obj.magic(node);
           tn#setEvents(events);
-          tn#setStyle(style);
+          tn#setStyle(styles);
           tn#setText(text);
           node;
         },
         children,
       }
     );
-  };
 
   let createElement =
       (
@@ -158,11 +159,11 @@ module Text = {
         ~onMouseUp=?,
         ~onMouseWheel=?,
         ~ref=?,
-        ~style=Style.defaultStyle,
+        ~style=[],
         ~text="",
         ~children,
         (),
-      ) => {
+      ) =>
     UiReact.element(
       make(
         ~onMouseDown?,
@@ -175,7 +176,6 @@ module Text = {
         UiReact.listToElement(children),
       ),
     );
-  };
 };
 
 module Image = {
@@ -191,7 +191,7 @@ module Image = {
         ~style=Style.defaultStyle,
         ~src="",
         children,
-      ) => {
+      ) =>
     component((_: UiReact.Hooks.empty) =>
       {
         make: () => {
@@ -226,7 +226,6 @@ module Image = {
         children,
       }
     );
-  };
 
   let createElement =
       (
@@ -239,7 +238,7 @@ module Image = {
         ~src="",
         ~children,
         (),
-      ) => {
+      ) =>
     UiReact.element(
       make(
         ~onMouseDown?,
@@ -252,5 +251,4 @@ module Image = {
         UiReact.listToElement(children),
       ),
     );
-  };
 };

--- a/src/UI/Primitives.re
+++ b/src/UI/Primitives.re
@@ -21,7 +21,7 @@ module View = {
         ~onFocus=?,
         ~tabindex=?,
         ~ref=?,
-        ~style=[],
+        ~style=Style.emptyViewStyle,
         children,
       ) =>
     component((_: UiReact.Hooks.empty) =>
@@ -76,7 +76,7 @@ module View = {
         ~onBlur=?,
         ~onFocus=?,
         ~ref=?,
-        ~style=[],
+        ~style=Style.emptyViewStyle,
         ~tabindex=None,
         ~children,
         (),
@@ -98,6 +98,7 @@ module View = {
 };
 
 module Text = {
+  open Style;
   let component = UiReact.nativeComponent("Text");
 
   let make =
@@ -107,14 +108,14 @@ module Text = {
         ~onMouseUp=?,
         ~onMouseWheel=?,
         ~ref=?,
-        ~style=[],
+        ~style=emptyTextStyle,
         ~text="",
         children,
       ) =>
     component((_: UiReact.Hooks.empty) =>
       {
         make: () => {
-          let styles = Style.create(~style, ());
+          let styles = create(~style, ());
           let events =
             NodeEvents.make(
               ~ref?,
@@ -130,7 +131,7 @@ module Text = {
           Obj.magic(node);
         },
         configureInstance: (~isFirstRender as _, node) => {
-          let styles = Style.create(~style, ());
+          let styles = create(~style, ());
           let events =
             NodeEvents.make(
               ~ref?,
@@ -159,7 +160,7 @@ module Text = {
         ~onMouseUp=?,
         ~onMouseWheel=?,
         ~ref=?,
-        ~style=[],
+        ~style=emptyTextStyle,
         ~text="",
         ~children,
         (),

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -65,88 +65,6 @@ type t = {
   cursor: option(MouseCursors.t),
 };
 
-let extend =
-    (
-      style: t,
-      ~backgroundColor=style.backgroundColor,
-      ~color=style.color,
-      ~width=style.width,
-      ~height=style.height,
-      ~flexBasis=style.flexBasis,
-      ~flexDirection=style.flexDirection,
-      ~flexGrow=style.flexGrow,
-      ~flexShrink=style.flexShrink,
-      ~alignItems=style.alignItems,
-      ~justifyContent=style.justifyContent,
-      ~position=style.position,
-      ~top=style.top,
-      ~bottom=style.bottom,
-      ~left=style.left,
-      ~right=style.right,
-      ~fontFamily=style.fontFamily,
-      ~fontSize=style.fontSize,
-      ~marginTop=style.marginTop,
-      ~marginLeft=style.marginLeft,
-      ~marginRight=style.marginRight,
-      ~marginBottom=style.marginBottom,
-      ~margin=style.margin,
-      ~marginVertical=style.marginVertical,
-      ~marginHorizontal=style.marginHorizontal,
-      ~borderTop=style.borderTop,
-      ~borderLeft=style.borderLeft,
-      ~borderRight=style.borderRight,
-      ~borderBottom=style.borderBottom,
-      ~border=style.border,
-      ~borderHorizontal=style.borderHorizontal,
-      ~borderVertical=style.borderVertical,
-      ~transform=style.transform,
-      ~opacity=style.opacity,
-      ~overflow=style.overflow,
-      ~boxShadow=style.boxShadow,
-      ~cursor=?,
-      _unit: unit,
-    ) => {
-  let ret: t = {
-    backgroundColor,
-    color,
-    width,
-    height,
-    flexBasis,
-    flexDirection,
-    flexGrow,
-    flexShrink,
-    justifyContent,
-    alignItems,
-    position,
-    top,
-    bottom,
-    left,
-    right,
-    fontFamily,
-    fontSize,
-    transform,
-    marginTop,
-    marginLeft,
-    marginRight,
-    marginBottom,
-    margin,
-    marginVertical,
-    marginHorizontal,
-    borderTop,
-    borderLeft,
-    borderRight,
-    borderBottom,
-    border,
-    borderHorizontal,
-    borderVertical,
-    opacity,
-    overflow,
-    boxShadow,
-    cursor,
-  };
-  ret;
-};
-
 let make =
     (
       ~backgroundColor: Color.t=Colors.transparentBlack,
@@ -327,7 +245,7 @@ type props = [
 type fontProps = [ | `FontFamily(string) | `FontSize(int)];
 /*
    Text and View props take different style properties as such
-   these nodes are types to only allow styles to be specified
+   these nodes are typed to only allow styles to be specified
    which are relevant to each
  */
 type textStyleProps = [ fontProps | props];
@@ -424,7 +342,7 @@ let color = o => `Color(o);
 let backgroundColor = o => `BackgroundColor(o);
 
 /*
-   Apply style takes all style props and maps the correct style
+   Apply style takes all style props and maps each to the correct style
    and is used to build up the style record, which is eventually
    used to apply styling to elements.
  */
@@ -482,8 +400,8 @@ let create = (~style, ~default=make(), ()) =>
   List.fold_left(applyStyle, default, style);
 
 /*
-   This function merges two lists of type styleprops
-   the target values override any similar source, values
+   This function merges two lists of type styleProps
+   the target values override any similar source values
 
    TODO: is there is a faster/more performant way to do this?
  */

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -324,49 +324,6 @@ type styleProps = [
   | `Cursor(option(MouseCursors.t))
 ];
 
-let right = f => `Right(f);
-let bottom = f => `Bottom(f);
-let left = f => `Left(f);
-let top = f => `Top(f);
-
-let fontSize = f => `FontSize(f);
-let fontFamily = f => `FontFamily(f);
-
-let height = h => `Height(h);
-let width = w => `Width(w);
-
-let position = p => `Position(p);
-
-let margin = m => `Margin(m);
-let marginLeft = m => `MarginLeft(m);
-let marginRight = m => `MarginRight(m);
-let marginTop = m => `MarginTop(m);
-let marginBottom = m => `MarginBottom(m);
-
-let border = (b: Border.t) =>
-  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `Border(b));
-let borderLeft = (b: Border.t) =>
-  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderLeft(b));
-let borderRight = (b: Border.t) =>
-  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderRight(b));
-let borderTop = (b: Border.t) =>
-  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderTop(b));
-let borderBottom = (b: Border.t) =>
-  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderBottom(b));
-let borderHorizontal = (b: Border.t) =>
-  Border.make(~color=b.color, ~width=b.width, ())
-  |> (b => `BorderHorizontal(b));
-let borderVertical = (b: Border.t) =>
-  Border.make(~color=b.color, ~width=b.width, ())
-  |> (b => `BorderVertical(b));
-
-let opacity = o => `Opacity(o);
-let transform = t => `Transform(t);
-let boxShadow = b => `BoxShadow(b);
-let overflow = o => `Overflow(o);
-let color = o => `Color(o);
-let backgroundColor = o => `BackgroundColor(o);
-
 let flexDirection = d =>
   switch (d) {
   | `Column => LayoutTypes.Column
@@ -391,8 +348,65 @@ let justify = j =>
   | `FlexEnd => LayoutTypes.JustifyFlexEnd
   };
 
+let right = f => `Right(f);
+let bottom = f => `Bottom(f);
+let left = f => `Left(f);
+let top = f => `Top(f);
+
+let fontSize = f => `FontSize(f);
+let fontFamily = f => `FontFamily(f);
+
+let height = h => `Height(h);
+let width = w => `Width(w);
+
+let position = p => {
+  let value =
+    switch (p) {
+    | `Absolute => LayoutTypes.Absolute
+    | `Relative => LayoutTypes.Relative
+    };
+  `Position(value);
+};
+
+let margin = m => `Margin(m);
+let marginLeft = m => `MarginLeft(m);
+let marginRight = m => `MarginRight(m);
+let marginTop = m => `MarginTop(m);
+let marginBottom = m => `MarginBottom(m);
+
+let border = (b: Border.t) =>
+  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `Border(b));
+let borderLeft = (b: Border.t) =>
+  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderLeft(b));
+let borderRight = (b: Border.t) =>
+  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderRight(b));
+let borderTop = (b: Border.t) =>
+  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderTop(b));
+let borderBottom = (b: Border.t) =>
+  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderBottom(b));
+let borderHorizontal = (b: Border.t) =>
+  Border.make(~color=b.color, ~width=b.width, ())
+  |> (b => `BorderHorizontal(b));
+let borderVertical = (b: Border.t) =>
+  Border.make(~color=b.color, ~width=b.width, ())
+  |> (b => `BorderVertical(b));
+
+let alignItems = a => `AlignItems(alignment(a));
+let justifyContent = a => `JustifyContent(justify(a));
+
+let cursor = c => `Cursor(Some(c));
+
+let opacity = o => `Opacity(o);
+let transform = t => `Transform(t);
+let boxShadow = b => `BoxShadow(b);
+let overflow = o => `Overflow(o);
+let color = o => `Color(o);
+let backgroundColor = o => `BackgroundColor(o);
+
 let applyStyle = (style: t, styleRule: [> styleProps]) =>
   switch (styleRule) {
+  | `AlignItems(alignItems) => {...style, alignItems}
+  | `JustifyContent(justifyContent) => {...style, justifyContent}
   | `FlexDirection(flexDirection) => {...style, flexDirection}
   | `Position(position) => {...style, position}
   | `Margin(margin) => {...style, margin}
@@ -412,6 +426,7 @@ let applyStyle = (style: t, styleRule: [> styleProps]) =>
   | `BoxShadow(boxShadow) => {...style, boxShadow}
   | `Transform(transform) => {...style, transform}
   | `FontFamily(fontFamily) => {...style, fontFamily}
+  | `FontSize(fontSize) => {...style, fontSize}
   | `Cursor(cursor) => {...style, cursor}
   | `MarginVertical(marginVertical) => {...style, marginVertical}
   | `MarginHorizontal(marginHorizontal) => {...style, marginHorizontal}
@@ -426,6 +441,10 @@ let applyStyle = (style: t, styleRule: [> styleProps]) =>
   | _ => style
   };
 
-let create = (~userStyles=[], ~styles=make(), ()) =>
-  List.fold_left(applyStyle, styles, userStyles);
-/* -------------------------------------------------------------------------------*/
+let create = (~style=[], ~default=make(), ()) =>
+  List.fold_left(applyStyle, default, style);
+
+/* let merge = (~source, ~target) => {*/
+/*   List.map()*/
+/* }*/
+/* /* -------------------------------------------------------------------------------*/*/

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -287,15 +287,22 @@ type xy = {
   vertical: int,
 };
 
-type props = [
+type baseProps = [
+  | `FontSize(int)
+  | `FontFamily(fontFamily)
+  | `FlexGrow(int)
+  | `FlexDirection(LayoutTypes.flexDirection)
+  | `JustifyContent(LayoutTypes.justify)
+  | `AlignItems(LayoutTypes.align)
   | `Position(LayoutTypes.positionType)
   | `BackgroundColor(Color.t)
   | `Color(Color.t)
   | `Width(int)
   | `Height(int)
+  | `Top(int)
+  | `Right(int)
   | `Bottom(int)
   | `Left(int)
-  | `Right(int)
   | `MarginTop(int)
   | `MarginLeft(int)
   | `MarginRight(int)
@@ -315,13 +322,13 @@ type props = [
   | `BorderVertical(Border.t)
   | `Transform(list(Transform.t))
   | `Opacity(float)
-  | `Boxshadow(BoxShadow.properties)
+  | `BoxShadow(BoxShadow.properties)
   | `Cursor(option(MouseCursors.t))
 ];
 
 type fontProps = [ | `FontFamily(string) | `FontSize(int)];
-type textStyleProps = [ fontProps | props];
-type viewStyleProps = [ props];
+type textStyleProps = [ fontProps | baseProps];
+type viewStyleProps = [ baseProps];
 
 let flexDirection = d => {
   let dir =
@@ -410,7 +417,7 @@ let overflow = o => `Overflow(o);
 let color = o => `Color(o);
 let backgroundColor = o => `BackgroundColor(o);
 
-let applyStyle = (style: t, styleRule: [> props]) =>
+let applyStyle = (style, styleRule: baseProps) =>
   switch (styleRule) {
   | `AlignItems(alignItems) => {...style, alignItems}
   | `JustifyContent(justifyContent) => {...style, justifyContent}
@@ -458,10 +465,9 @@ let applyStyle = (style: t, styleRule: [> props]) =>
   | `Left(left) => {...style, left}
   | `Top(top) => {...style, top}
   | `Right(right) => {...style, right}
-  | _ => style
   };
 
-let create = (~style=[], ~default=make(), ()) =>
+let create = (~style, ~default=make(), ()) =>
   List.fold_left(applyStyle, default, style);
 
 /*
@@ -506,7 +512,7 @@ let merge = (~source, ~target) =>
               | (`BorderVertical(_), `BorderVertical(_)) => targetStyle
               | (`Transform(_), `Transform(_)) => targetStyle
               | (`Opacity(_), `Opacity(_)) => targetStyle
-              | (`Boxshadow(_), `Boxshadow(_)) => targetStyle
+              | (`BoxShadow(_), `BoxShadow(_)) => targetStyle
               | (newRule, _) => newRule
               }
             )

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -464,7 +464,60 @@ let applyStyle = (style: t, styleRule: [> props]) =>
 let create = (~style=[], ~default=make(), ()) =>
   List.fold_left(applyStyle, default, style);
 
-/* let merge = (~source, ~target) => {*/
-/*   List.map()*/
-/* }*/
-/* /* -------------------------------------------------------------------------------*/*/
+/*
+   This function merges two lists of type styleprops
+   the target values override any similar source, values
+
+   TODO: is there is a faster/more performant way to do this?
+ */
+let merge = (~source, ~target) =>
+  List.fold_left(
+    (merged, targetStyle) => {
+      let newStyles =
+        List.fold_left(
+          (accum, sourceStyle) =>
+            (
+              switch (targetStyle, sourceStyle) {
+              | (`Cursor(_), `Cursor(_)) => targetStyle
+              | (`Position(_), `Position(_)) => targetStyle
+              | (`BackgroundColor(_), `BackgroundColor(_)) => targetStyle
+              | (`Color(_), `Color(_)) => targetStyle
+              | (`Width(_), `Width(_)) => targetStyle
+              | (`Height(_), `Height(_)) => targetStyle
+              | (`Bottom(_), `Bottom(_)) => targetStyle
+              | (`Left(_), `Left(_)) => targetStyle
+              | (`Right(_), `Right(_)) => targetStyle
+              | (`MarginTop(_), `MarginTop(_)) => targetStyle
+              | (`MarginLeft(_), `MarginLeft(_)) => targetStyle
+              | (`MarginRight(_), `MarginRight(_)) => targetStyle
+              | (`MarginBottom(_), `MarginBottom(_)) => targetStyle
+              | (`Margin(_), `Margin(_)) => targetStyle
+              | (`MarginVertical(_), `MarginVertical(_)) => targetStyle
+              | (`MarginHorizontal(_), `MarginHorizontal(_)) => targetStyle
+              | (`Margin2(_), `Margin2(_)) => targetStyle
+              | (`Margin4(_), `Margin4(_)) => targetStyle
+              | (`Overflow(_), `Overflow(_)) => targetStyle
+              | (`BorderTop(_), `BorderTop(_)) => targetStyle
+              | (`BorderLeft(_), `BorderLeft(_)) => targetStyle
+              | (`BorderRight(_), `BorderRight(_)) => targetStyle
+              | (`BorderBottom(_), `BorderBottom(_)) => targetStyle
+              | (`Border(_), `Border(_)) => targetStyle
+              | (`BorderHorizontal(_), `BorderHorizontal(_)) => targetStyle
+              | (`BorderVertical(_), `BorderVertical(_)) => targetStyle
+              | (`Transform(_), `Transform(_)) => targetStyle
+              | (`Opacity(_), `Opacity(_)) => targetStyle
+              | (`Boxshadow(_), `Boxshadow(_)) => targetStyle
+              | (newRule, _) => newRule
+              }
+            )
+            |> (style => [style, ...accum]),
+          [],
+          source,
+        );
+      List.append(merged, newStyles);
+    },
+    source,
+    target,
+  );
+
+/* -------------------------------------------------------------------------------*/

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -324,22 +324,50 @@ type styleProps = [
   | `Cursor(option(MouseCursors.t))
 ];
 
+let right = f => `Right(f);
+let bottom = f => `Bottom(f);
+let left = f => `Left(f);
+let top = f => `Top(f);
+
+let fontSize = f => `FontSize(f);
 let fontFamily = f => `FontFamily(f);
+
 let height = h => `Height(h);
 let width = w => `Width(w);
+
 let position = p => `Position(p);
+
 let margin = m => `Margin(m);
 let marginLeft = m => `MarginLeft(m);
 let marginRight = m => `MarginRight(m);
 let marginTop = m => `MarginTop(m);
 let marginBottom = m => `MarginBottom(m);
-let border = b => `Border(b);
-let borderLeft = b => `BorderLeft(b);
-let borderRight = b => `BorderRight(b);
-let borderTop = b => `BorderTop(b);
-let borderBottom = b => `BorderBottom(b);
 
-let getflexDirection = d =>
+let border = (b: Border.t) =>
+  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `Border(b));
+let borderLeft = (b: Border.t) =>
+  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderLeft(b));
+let borderRight = (b: Border.t) =>
+  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderRight(b));
+let borderTop = (b: Border.t) =>
+  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderTop(b));
+let borderBottom = (b: Border.t) =>
+  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderBottom(b));
+let borderHorizontal = (b: Border.t) =>
+  Border.make(~color=b.color, ~width=b.width, ())
+  |> (b => `BorderHorizontal(b));
+let borderVertical = (b: Border.t) =>
+  Border.make(~color=b.color, ~width=b.width, ())
+  |> (b => `BorderVertical(b));
+
+let opacity = o => `Opacity(o);
+let transform = t => `Transform(t);
+let boxShadow = b => `BoxShadow(b);
+let overflow = o => `Overflow(o);
+let color = o => `Color(o);
+let backgroundColor = o => `BackgroundColor(o);
+
+let flexDirection = d =>
   switch (d) {
   | `Column => LayoutTypes.Column
   | `ColumnReverse => LayoutTypes.ColumnReverse
@@ -347,7 +375,7 @@ let getflexDirection = d =>
   | `Row => LayoutTypes.Row
   };
 
-let getAlignment = a =>
+let alignment = a =>
   switch (a) {
   | `Center => LayoutTypes.AlignCenter
   | `Stretch => LayoutTypes.AlignStretch
@@ -356,7 +384,7 @@ let getAlignment = a =>
   | `FlexEnd => LayoutTypes.AlignFlexEnd
   };
 
-let getJustification = j =>
+let justify = j =>
   switch (j) {
   | `FlexStart => LayoutTypes.JustifyFlexStart
   | `Center => LayoutTypes.JustifyCenter

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -288,11 +288,9 @@ let toLayoutNode = (s: t) => {
   ret;
 };
 
-/* -------------------------------------------------------------------------------*/
-/*
-   Styles: As a list of Polymorphic variants
- */
-/* -------------------------------------------------------------------------------*/
+/* -------------------------------------------------------------------------------
+        Styles: As a list of Polymorphic variants
+   -------------------------------------------------------------------------------*/
 
 type styleProps = [
   | `Position(LayoutTypes.positionType)
@@ -326,21 +324,20 @@ type styleProps = [
   | `Cursor(option(MouseCursors.t))
 ];
 
-module Height = {
-  let make = h => `Height(h);
-};
-
-module Width = {
-  let make = w => `Width(w);
-};
-
-module FontFamily = {
-  let make = ff => `FontFamily(ff);
-};
-
-let height = Height.make;
-let width = Width.make;
-let fontFamily = FontFamily.make;
+let fontFamily = f => `FontFamily(f);
+let height = h => `Height(h);
+let width = w => `Width(w);
+let position = p => `Position(p);
+let margin = m => `Margin(m);
+let marginLeft = m => `MarginLeft(m);
+let marginRight = m => `MarginRight(m);
+let marginTop = m => `MarginTop(m);
+let marginBottom = m => `MarginBottom(m);
+let border = b => `Border(b);
+let borderLeft = b => `BorderLeft(b);
+let borderRight = b => `BorderRight(b);
+let borderTop = b => `BorderTop(b);
+let borderBottom = b => `BorderBottom(b);
 
 let getflexDirection = d =>
   switch (d) {
@@ -370,11 +367,13 @@ let applyStyle = (style: t, styleRule: [> styleProps]) =>
   switch (styleRule) {
   | `FlexDirection(flexDirection) => {...style, flexDirection}
   | `Position(position) => {...style, position}
+  | `Margin(margin) => {...style, margin}
   | `MarginTop(marginTop) => {...style, marginTop}
   | `MarginBottom(marginBottom) => {...style, marginBottom}
   | `MarginRight(marginRight) => {...style, marginRight}
   | `MarginLeft(marginLeft) => {...style, marginLeft}
   | `Overflow(overflow) => {...style, overflow}
+  | `Border(border) => {...style, border}
   | `BorderBottom(borderBottom) => {...style, borderBottom}
   | `BorderTop(borderTop) => {...style, borderTop}
   | `BorderLeft(borderLeft) => {...style, borderLeft}

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -291,8 +291,20 @@ let toLayoutNode = (s: t) => {
 /* -------------------------------------------------------------------------------
         Styles: As a list of Polymorphic variants
    -------------------------------------------------------------------------------*/
+module Margin = {
+  type m2 = {
+    horizontal: int,
+    vertical: int,
+  };
+  type m4 = {
+    top: int,
+    right: int,
+    bottom: int,
+    left: int,
+  };
+};
 
-type styleProps = [
+type props = [
   | `Position(LayoutTypes.positionType)
   | `BackgroundColor(Color.t)
   | `Color(Color.t)
@@ -301,8 +313,6 @@ type styleProps = [
   | `Bottom(int)
   | `Left(int)
   | `Right(int)
-  | `FontFamily(string)
-  | `FontSize(int)
   | `MarginTop(int)
   | `MarginLeft(int)
   | `MarginRight(int)
@@ -310,6 +320,8 @@ type styleProps = [
   | `Margin(int)
   | `MarginVertical(int)
   | `MarginHorizontal(int)
+  | `Margin2(Margin.m2)
+  | `Margin4(Margin.m4)
   | `Overflow(LayoutTypes.overflow)
   | `BorderTop(Border.t)
   | `BorderLeft(Border.t)
@@ -323,6 +335,10 @@ type styleProps = [
   | `Boxshadow(BoxShadow.properties)
   | `Cursor(option(MouseCursors.t))
 ];
+
+type fontProps = [ | `FontFamily(string) | `FontSize(int)];
+type textStyleProps = [ fontProps | props];
+type viewStyleProps = [ props];
 
 let flexDirection = d => {
   let dir =
@@ -380,6 +396,10 @@ let marginTop = m => `MarginTop(m);
 let marginBottom = m => `MarginBottom(m);
 let marginVertical = m => `MarginVertical(m);
 let marginHorizontal = m => `MarginHorizontal(m);
+let margin2 = ({horizontal, vertical}: Margin.m2) =>
+  `Margin2((horizontal, vertical));
+let margin4 = ({top, right, bottom, left}: Margin.m4) =>
+  `Margin4((top, right, bottom, left));
 
 let border = (b: Border.t) =>
   Border.make(~color=b.color, ~width=b.width, ()) |> (b => `Border(b));
@@ -410,7 +430,7 @@ let overflow = o => `Overflow(o);
 let color = o => `Color(o);
 let backgroundColor = o => `BackgroundColor(o);
 
-let applyStyle = (style: t, styleRule: [> styleProps]) =>
+let applyStyle = (style: t, styleRule: [> props]) =>
   switch (styleRule) {
   | `AlignItems(alignItems) => {...style, alignItems}
   | `JustifyContent(justifyContent) => {...style, justifyContent}
@@ -422,6 +442,20 @@ let applyStyle = (style: t, styleRule: [> styleProps]) =>
   | `MarginBottom(marginBottom) => {...style, marginBottom}
   | `MarginRight(marginRight) => {...style, marginRight}
   | `MarginLeft(marginLeft) => {...style, marginLeft}
+  | `MarginVertical(marginVertical) => {...style, marginVertical}
+  | `MarginHorizontal(marginHorizontal) => {...style, marginHorizontal}
+  | `Margin2({horizontal, vertical}) => {
+      ...style,
+      marginHorizontal: horizontal,
+      marginVertical: vertical,
+    }
+  | `Margin4({top, right, bottom, left}) => {
+      ...style,
+      marginTop: top,
+      marginLeft: left,
+      marginRight: right,
+      marginBottom: bottom,
+    }
   | `Overflow(overflow) => {...style, overflow}
   | `Border(border) => {...style, border}
   | `BorderBottom(borderBottom) => {...style, borderBottom}
@@ -436,8 +470,6 @@ let applyStyle = (style: t, styleRule: [> styleProps]) =>
   | `FontFamily(fontFamily) => {...style, fontFamily}
   | `FontSize(fontSize) => {...style, fontSize}
   | `Cursor(cursor) => {...style, cursor}
-  | `MarginVertical(marginVertical) => {...style, marginVertical}
-  | `MarginHorizontal(marginHorizontal) => {...style, marginHorizontal}
   | `Color(color) => {...style, color}
   | `BackgroundColor(backgroundColor) => {...style, backgroundColor}
   | `Width(width) => {...style, width}

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -287,7 +287,7 @@ type xy = {
   vertical: int,
 };
 
-type baseProps = [
+type props = [
   | `FontSize(int)
   | `FontFamily(fontFamily)
   | `FlexGrow(int)
@@ -327,8 +327,8 @@ type baseProps = [
 ];
 
 type fontProps = [ | `FontFamily(string) | `FontSize(int)];
-type textStyleProps = [ fontProps | baseProps];
-type viewStyleProps = [ baseProps];
+type textStyleProps = [ fontProps | props];
+type viewStyleProps = [ props];
 
 let flexDirection = d => {
   let dir =
@@ -417,7 +417,7 @@ let overflow = o => `Overflow(o);
 let color = o => `Color(o);
 let backgroundColor = o => `BackgroundColor(o);
 
-let applyStyle = (style, styleRule: baseProps) =>
+let applyStyle = (style, styleRule: props) =>
   switch (styleRule) {
   | `AlignItems(alignItems) => {...style, alignItems}
   | `JustifyContent(justifyContent) => {...style, justifyContent}

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -291,17 +291,16 @@ let toLayoutNode = (s: t) => {
 /* -------------------------------------------------------------------------------
         Styles: As a list of Polymorphic variants
    -------------------------------------------------------------------------------*/
-module Margin = {
-  type m2 = {
-    horizontal: int,
-    vertical: int,
-  };
-  type m4 = {
-    top: int,
-    right: int,
-    bottom: int,
-    left: int,
-  };
+type coords = {
+  top: int,
+  right: int,
+  bottom: int,
+  left: int,
+};
+
+type xy = {
+  horizontal: int,
+  vertical: int,
 };
 
 type props = [
@@ -320,8 +319,8 @@ type props = [
   | `Margin(int)
   | `MarginVertical(int)
   | `MarginHorizontal(int)
-  | `Margin2(Margin.m2)
-  | `Margin4(Margin.m4)
+  | `Margin2(xy)
+  | `Margin4(coords)
   | `Overflow(LayoutTypes.overflow)
   | `BorderTop(Border.t)
   | `BorderLeft(Border.t)
@@ -396,10 +395,9 @@ let marginTop = m => `MarginTop(m);
 let marginBottom = m => `MarginBottom(m);
 let marginVertical = m => `MarginVertical(m);
 let marginHorizontal = m => `MarginHorizontal(m);
-let margin2 = ({horizontal, vertical}: Margin.m2) =>
-  `Margin2((horizontal, vertical));
-let margin4 = ({top, right, bottom, left}: Margin.m4) =>
-  `Margin4((top, right, bottom, left));
+let margin2 = ({horizontal, vertical}) => `Margin2({horizontal, vertical});
+let margin4 = ({top, right, bottom, left}) =>
+  `Margin4({top, right, bottom, left});
 
 let border = (b: Border.t) =>
   Border.make(~color=b.color, ~width=b.width, ()) |> (b => `Border(b));

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -288,8 +288,6 @@ type xy = {
 };
 
 type props = [
-  | `FontSize(int)
-  | `FontFamily(fontFamily)
   | `FlexGrow(int)
   | `FlexDirection(LayoutTypes.flexDirection)
   | `JustifyContent(LayoutTypes.justify)
@@ -327,8 +325,16 @@ type props = [
 ];
 
 type fontProps = [ | `FontFamily(string) | `FontSize(int)];
+/*
+   Text and View props take different style properties as such
+   these nodes are types to only allow styles to be specified
+   which are relevant to each
+ */
 type textStyleProps = [ fontProps | props];
 type viewStyleProps = [ props];
+
+let emptyTextStyle: list(textStyleProps) = [];
+let emptyViewStyle: list(viewStyleProps) = [];
 
 let flexDirection = d => {
   let dir =
@@ -417,7 +423,12 @@ let overflow = o => `Overflow(o);
 let color = o => `Color(o);
 let backgroundColor = o => `BackgroundColor(o);
 
-let applyStyle = (style, styleRule: props) =>
+/*
+   Apply style takes all style props and maps the correct style
+   and is used to build up the style record, which is eventually
+   used to apply styling to elements.
+ */
+let applyStyle = (style, styleRule: [< props | fontProps]) =>
   switch (styleRule) {
   | `AlignItems(alignItems) => {...style, alignItems}
   | `JustifyContent(justifyContent) => {...style, justifyContent}

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -24,21 +24,6 @@ module BoxShadow = {
     spreadRadius: float,
     color: Color.t,
   };
-  let make =
-      (
-        ~xOffset=0.0,
-        ~yOffset=0.0,
-        ~blurRadius=0.0,
-        ~spreadRadius=0.0,
-        ~color=Colors.black,
-        (),
-      ) => {
-    color,
-    xOffset,
-    yOffset,
-    blurRadius,
-    spreadRadius,
-  };
 };
 
 type t = {
@@ -198,14 +183,13 @@ let make =
       ~borderVertical=Border.make(),
       ~transform=[],
       ~opacity=1.0,
-      ~boxShadow=BoxShadow.make(
-                   ~xOffset=0.0,
-                   ~yOffset=0.0,
-                   ~blurRadius=0.0,
-                   ~spreadRadius=0.0,
-                   ~color=Colors.black,
-                   (),
-                 ),
+      ~boxShadow=BoxShadow.{
+                   xOffset: 0.0,
+                   yOffset: 0.0,
+                   blurRadius: 0.0,
+                   spreadRadius: 0.0,
+                   color: Colors.black,
+                 },
       ~cursor=?,
       _unit: unit,
     ) => {
@@ -399,22 +383,20 @@ let margin2 = ({horizontal, vertical}) => `Margin2({horizontal, vertical});
 let margin4 = ({top, right, bottom, left}) =>
   `Margin4({top, right, bottom, left});
 
-let border = (b: Border.t) =>
-  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `Border(b));
-let borderLeft = (b: Border.t) =>
-  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderLeft(b));
-let borderRight = (b: Border.t) =>
-  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderRight(b));
-let borderTop = (b: Border.t) =>
-  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderTop(b));
-let borderBottom = (b: Border.t) =>
-  Border.make(~color=b.color, ~width=b.width, ()) |> (b => `BorderBottom(b));
-let borderHorizontal = (b: Border.t) =>
-  Border.make(~color=b.color, ~width=b.width, ())
-  |> (b => `BorderHorizontal(b));
-let borderVertical = (b: Border.t) =>
-  Border.make(~color=b.color, ~width=b.width, ())
-  |> (b => `BorderVertical(b));
+let border = (~color, ~width) =>
+  Border.make(~color, ~width, ()) |> (b => `Border(b));
+let borderLeft = (~color, ~width) =>
+  Border.make(~color, ~width, ()) |> (b => `BorderLeft(b));
+let borderRight = (~color, ~width) =>
+  Border.make(~color, ~width, ()) |> (b => `BorderRight(b));
+let borderTop = (~color, ~width) =>
+  Border.make(~color, ~width, ()) |> (b => `BorderTop(b));
+let borderBottom = (~color, ~width) =>
+  Border.make(~color, ~width, ()) |> (b => `BorderBottom(b));
+let borderHorizontal = (~color, ~width) =>
+  Border.make(~color, ~width, ()) |> (b => `BorderHorizontal(b));
+let borderVertical = (~color, ~width) =>
+  Border.make(~color, ~width, ()) |> (b => `BorderVertical(b));
 
 let alignItems = a => `AlignItems(alignment(a));
 let justifyContent = a => `JustifyContent(justify(a));

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -324,13 +324,16 @@ type styleProps = [
   | `Cursor(option(MouseCursors.t))
 ];
 
-let flexDirection = d =>
-  switch (d) {
-  | `Column => LayoutTypes.Column
-  | `ColumnReverse => LayoutTypes.ColumnReverse
-  | `RowReverse => LayoutTypes.RowReverse
-  | `Row => LayoutTypes.Row
-  };
+let flexDirection = d => {
+  let dir =
+    switch (d) {
+    | `Column => LayoutTypes.Column
+    | `ColumnReverse => LayoutTypes.ColumnReverse
+    | `RowReverse => LayoutTypes.RowReverse
+    | `Row => LayoutTypes.Row
+    };
+  `FlexDirection(dir);
+};
 
 let alignment = a =>
   switch (a) {
@@ -347,6 +350,8 @@ let justify = j =>
   | `Center => LayoutTypes.JustifyCenter
   | `FlexEnd => LayoutTypes.JustifyFlexEnd
   };
+
+let flexGrow = g => `FlexGrow(g);
 
 let right = f => `Right(f);
 let bottom = f => `Bottom(f);
@@ -373,6 +378,8 @@ let marginLeft = m => `MarginLeft(m);
 let marginRight = m => `MarginRight(m);
 let marginTop = m => `MarginTop(m);
 let marginBottom = m => `MarginBottom(m);
+let marginVertical = m => `MarginVertical(m);
+let marginHorizontal = m => `MarginHorizontal(m);
 
 let border = (b: Border.t) =>
   Border.make(~color=b.color, ~width=b.width, ()) |> (b => `Border(b));
@@ -407,6 +414,7 @@ let applyStyle = (style: t, styleRule: [> styleProps]) =>
   switch (styleRule) {
   | `AlignItems(alignItems) => {...style, alignItems}
   | `JustifyContent(justifyContent) => {...style, justifyContent}
+  | `FlexGrow(flexGrow) => {...style, flexGrow}
   | `FlexDirection(flexDirection) => {...style, flexDirection}
   | `Position(position) => {...style, position}
   | `Margin(margin) => {...style, margin}

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -379,8 +379,8 @@ let marginTop = m => `MarginTop(m);
 let marginBottom = m => `MarginBottom(m);
 let marginVertical = m => `MarginVertical(m);
 let marginHorizontal = m => `MarginHorizontal(m);
-let margin2 = ({horizontal, vertical}) => `Margin2({horizontal, vertical});
-let margin4 = ({top, right, bottom, left}) =>
+let margin2 = (~horizontal, ~vertical) => `Margin2({horizontal, vertical});
+let margin4 = (~top, ~right, ~bottom, ~left) =>
   `Margin4({top, right, bottom, left});
 
 let border = (~color, ~width) =>

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -287,3 +287,118 @@ let toLayoutNode = (s: t) => {
   };
   ret;
 };
+
+/* -------------------------------------------------------------------------------*/
+/*
+   Styles: As a list of Polymorphic variants
+ */
+/* -------------------------------------------------------------------------------*/
+
+type styleProps = [
+  | `Position(LayoutTypes.positionType)
+  | `BackgroundColor(Color.t)
+  | `Color(Color.t)
+  | `Width(int)
+  | `Height(int)
+  | `Bottom(int)
+  | `Left(int)
+  | `Right(int)
+  | `FontFamily(string)
+  | `FontSize(int)
+  | `MarginTop(int)
+  | `MarginLeft(int)
+  | `MarginRight(int)
+  | `MarginBottom(int)
+  | `Margin(int)
+  | `MarginVertical(int)
+  | `MarginHorizontal(int)
+  | `Overflow(LayoutTypes.overflow)
+  | `BorderTop(Border.t)
+  | `BorderLeft(Border.t)
+  | `BorderRight(Border.t)
+  | `BorderBottom(Border.t)
+  | `Border(Border.t)
+  | `BorderHorizontal(Border.t)
+  | `BorderVertical(Border.t)
+  | `Transform(list(Transform.t))
+  | `Opacity(float)
+  | `Boxshadow(BoxShadow.properties)
+  | `Cursor(option(MouseCursors.t))
+];
+
+module Height = {
+  let make = h => `Height(h);
+};
+
+module Width = {
+  let make = w => `Width(w);
+};
+
+module FontFamily = {
+  let make = ff => `FontFamily(ff);
+};
+
+let height = Height.make;
+let width = Width.make;
+let fontFamily = FontFamily.make;
+
+let getflexDirection = d =>
+  switch (d) {
+  | `Column => LayoutTypes.Column
+  | `ColumnReverse => LayoutTypes.ColumnReverse
+  | `RowReverse => LayoutTypes.RowReverse
+  | `Row => LayoutTypes.Row
+  };
+
+let getAlignment = a =>
+  switch (a) {
+  | `Center => LayoutTypes.AlignCenter
+  | `Stretch => LayoutTypes.AlignStretch
+  | `Auto => LayoutTypes.AlignAuto
+  | `FlexStart => LayoutTypes.AlignFlexStart
+  | `FlexEnd => LayoutTypes.AlignFlexEnd
+  };
+
+let getJustification = j =>
+  switch (j) {
+  | `FlexStart => LayoutTypes.JustifyFlexStart
+  | `Center => LayoutTypes.JustifyCenter
+  | `FlexEnd => LayoutTypes.JustifyFlexEnd
+  };
+
+let applyStyle = (style: t, styleRule: [> styleProps]) =>
+  switch (styleRule) {
+  | `FlexDirection(flexDirection) => {...style, flexDirection}
+  | `Position(position) => {...style, position}
+  | `MarginTop(marginTop) => {...style, marginTop}
+  | `MarginBottom(marginBottom) => {...style, marginBottom}
+  | `MarginRight(marginRight) => {...style, marginRight}
+  | `MarginLeft(marginLeft) => {...style, marginLeft}
+  | `Overflow(overflow) => {...style, overflow}
+  | `BorderBottom(borderBottom) => {...style, borderBottom}
+  | `BorderTop(borderTop) => {...style, borderTop}
+  | `BorderLeft(borderLeft) => {...style, borderLeft}
+  | `BorderRight(borderRight) => {...style, borderRight}
+  | `BorderVertical(borderVertical) => {...style, borderVertical}
+  | `BorderHorizontal(borderHorizontal) => {...style, borderHorizontal}
+  | `Opacity(opacity) => {...style, opacity}
+  | `BoxShadow(boxShadow) => {...style, boxShadow}
+  | `Transform(transform) => {...style, transform}
+  | `FontFamily(fontFamily) => {...style, fontFamily}
+  | `Cursor(cursor) => {...style, cursor}
+  | `MarginVertical(marginVertical) => {...style, marginVertical}
+  | `MarginHorizontal(marginHorizontal) => {...style, marginHorizontal}
+  | `Color(color) => {...style, color}
+  | `BackgroundColor(backgroundColor) => {...style, backgroundColor}
+  | `Width(width) => {...style, width}
+  | `Height(height) => {...style, height}
+  | `Bottom(bottom) => {...style, bottom}
+  | `Left(left) => {...style, left}
+  | `Top(top) => {...style, top}
+  | `Right(right) => {...style, right}
+  | _ => style
+  };
+
+let create = (~userStyles=[], ~styles=make(), ()) =>
+  List.fold_left(applyStyle, styles, userStyles);
+/* -------------------------------------------------------------------------------*/

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -423,7 +423,7 @@ let cursor = c => `Cursor(Some(c));
 
 let opacity = o => `Opacity(o);
 let transform = t => `Transform(t);
-let boxShadow = b => `BoxShadow(b);
+let boxShadow = (b: BoxShadow.properties) => `BoxShadow(b);
 let overflow = o => `Overflow(o);
 let color = o => `Color(o);
 let backgroundColor = o => `BackgroundColor(o);

--- a/src/UI_Components/Button.re
+++ b/src/UI_Components/Button.re
@@ -29,7 +29,7 @@ let make =
           backgroundColor(disabled ? Colors.dimGrey : c),
           justifyContent(`Center),
           alignItems(`Center),
-          border({width: 1, color: Colors.white}),
+          border(~width=1, ~color=Colors.white),
           height(h),
           width(w),
         ]>

--- a/src/UI_Components/Button.re
+++ b/src/UI_Components/Button.re
@@ -3,43 +3,44 @@ open Revery_Core;
 
 let noop = () => ();
 
-let textStyle = (~fontSize, ~fontFamily) =>
-  Style.make(~fontSize, ~fontFamily, ~color=Colors.white, ());
-
-let containerStyle = (~width, ~height, ~disabled, ~color) =>
-  Style.make(
-    ~position=Relative,
-    ~backgroundColor=disabled ? Colors.dimGrey : color,
-    ~justifyContent=JustifyCenter,
-    ~alignItems=AlignCenter,
-    ~border=Style.Border.make(~width=1, ~color=Colors.white, ()),
-    ~height,
-    ~width,
-    (),
-  );
-
 let component = React.component("Button");
 
 let make =
     (
       ~title,
       ~onClick=noop,
-      ~color=Colors.dodgerBlue,
-      ~fontSize=40,
-      ~width=300,
-      ~height=100,
+      ~color as c=Colors.dodgerBlue,
+      ~fontSize as size=40,
+      ~width as w=300,
+      ~height as h=100,
       ~disabled=false,
       ~tabindex=?,
       ~onFocus=?,
       ~onBlur=?,
-      ~fontFamily="Roboto-Regular.ttf",
+      ~fontFamily as family="Roboto-Regular.ttf",
       (),
     ) =>
   /* children, */
   component((_slots: React.Hooks.empty) =>
     <Clickable onClick={disabled ? noop : onClick} ?onFocus ?onBlur ?tabindex>
-      <View style={containerStyle(~width, ~height, ~disabled, ~color)}>
-        <Text style={textStyle(~fontSize, ~fontFamily)} text=title />
+      <View
+        style=Style.[
+          position(`Relative),
+          backgroundColor(disabled ? Colors.dimGrey : c),
+          justifyContent(`Center),
+          alignItems(`Center),
+          border({width: 1, color: Colors.white}),
+          height(h),
+          width(w),
+        ]>
+        <Text
+          style=Style.[
+            fontSize(size),
+            fontFamily(family),
+            color(Colors.white),
+          ]
+          text=title
+        />
       </View>
     </Clickable>
   );

--- a/src/UI_Components/Clickable.re
+++ b/src/UI_Components/Clickable.re
@@ -18,7 +18,7 @@ let component = React.component("Clickable");
  */
 let make =
     (
-      ~style as _,
+      ~style,
       ~onClick: clickFunction=noop,
       ~onBlur=?,
       ~onFocus=?,
@@ -45,7 +45,11 @@ let make =
     /*   Style.extend(style, ~opacity=animatedOpacity, ~cursor=MouseCursors.pointer, ()); */
 
     <View
-      style=Style.[opacity(animatedOpacity), cursor(MouseCursors.pointer)]
+      style=Style.[
+        opacity(animatedOpacity),
+        cursor(MouseCursors.pointer),
+        ...style,
+      ]
       onMouseDown
       onMouseUp
       ?onBlur

--- a/src/UI_Components/Clickable.re
+++ b/src/UI_Components/Clickable.re
@@ -13,9 +13,12 @@ let noop = () => ();
 
 let component = React.component("Clickable");
 
+/*
+   FIXME: Merge the passed down styles with the default styles
+ */
 let make =
     (
-      ~style=Style.defaultStyle,
+      ~style as _,
       ~onClick: clickFunction=noop,
       ~onBlur=?,
       ~onFocus=?,
@@ -23,7 +26,7 @@ let make =
       children: React.syntheticElement,
     ) =>
   component(slots => {
-    let (opacity, setOpacity, _slots: React.Hooks.empty) =
+    let (animatedOpacity, setOpacity, _slots: React.Hooks.empty) =
       React.Hooks.state(0.8, slots);
 
     /* TODO:
@@ -38,17 +41,23 @@ let make =
       onClick();
     };
 
-    let style2 =
-      Style.extend(style, ~opacity, ~cursor=MouseCursors.pointer, ());
+    /* let style2 = */
+    /*   Style.extend(style, ~opacity=animatedOpacity, ~cursor=MouseCursors.pointer, ()); */
 
-    <View style=style2 onMouseDown onMouseUp ?onBlur ?onFocus tabindex>
+    <View
+      style=Style.[opacity(animatedOpacity), cursor(MouseCursors.pointer)]
+      onMouseDown
+      onMouseUp
+      ?onBlur
+      ?onFocus
+      tabindex>
       children
     </View>;
   });
 
 let createElement =
     (
-      ~style=Style.defaultStyle,
+      ~style=[],
       ~onClick: clickFunction=noop,
       ~onBlur=?,
       ~onFocus=?,

--- a/src/UI_Components/Clickable.re
+++ b/src/UI_Components/Clickable.re
@@ -13,9 +13,6 @@ let noop = () => ();
 
 let component = React.component("Clickable");
 
-/*
-   FIXME: Merge the passed down styles with the default styles
- */
 let make =
     (
       ~style,
@@ -41,20 +38,15 @@ let make =
       onClick();
     };
 
-    /* let style2 = */
-    /*   Style.extend(style, ~opacity=animatedOpacity, ~cursor=MouseCursors.pointer, ()); */
+    let mergedStyles =
+      Style.(
+        merge(
+          ~source=style,
+          ~target=[opacity(animatedOpacity), cursor(MouseCursors.pointer)],
+        )
+      );
 
-    <View
-      style=Style.[
-        opacity(animatedOpacity),
-        cursor(MouseCursors.pointer),
-        ...style,
-      ]
-      onMouseDown
-      onMouseUp
-      ?onBlur
-      ?onFocus
-      tabindex>
+    <View style=mergedStyles onMouseDown onMouseUp ?onBlur ?onFocus tabindex>
       children
     </View>;
   });

--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -2,38 +2,6 @@ open Revery_UI;
 open Revery_Core;
 open Revery_Core.Window;
 
-let cursorStyles =
-    (
-      ~fontSize,
-      ~cursorColor,
-      ~opacity as o,
-      ~containerHeight,
-      ~hasPlaceholder,
-    ) => {
-  /*
-     calculate the top padding needed to place the cursor centrally
-   */
-  let verticalAlignPos = (containerHeight - fontSize) / 2;
-  Style.[
-    marginLeft(2),
-    height(fontSize),
-    width(2),
-    opacity(o),
-    backgroundColor(cursorColor),
-  ]
-  |> (
-    initial =>
-      hasPlaceholder ?
-        Style.[
-          position(`Absolute),
-          top(verticalAlignPos),
-          left(5),
-          ...initial,
-        ] :
-        initial
-  );
-};
-
 type state = {
   value: string,
   placeholder: string,
@@ -81,7 +49,6 @@ let noop = (~value as _value) => ();
 
 let defaultStyles =
   Style.[
-    fontSize(18),
     color(Colors.black),
     width(200),
     height(50),
@@ -150,7 +117,7 @@ let make =
         slots,
       );
 
-    let (opacity, _slots: React.Hooks.empty) =
+    let (animatedOpacity, _slots: React.Hooks.empty) =
       Hooks.animation(
         Animated.floatValue(0.),
         {
@@ -188,7 +155,7 @@ let make =
     /*
        TODO: convert this to a getter utility function
      */
-    let height =
+    let inputHeight =
       List.fold_left(
         (default, s) =>
           switch (s) {
@@ -220,13 +187,28 @@ let make =
         marginLeft(6),
       ];
 
+    /*
+       calculate the top padding needed to place the cursor centrally
+     */
+    let verticalAlignPos = (inputHeight - 20) / 2;
     let inputCursorStyles =
-      cursorStyles(
-        ~opacity=state.isFocused ? opacity : 0.0,
-        ~fontSize=20,
-        ~cursorColor,
-        ~containerHeight=height,
-        ~hasPlaceholder,
+      Style.[
+        marginLeft(2),
+        height(20),
+        width(2),
+        opacity(state.isFocused ? animatedOpacity : 0.0),
+        backgroundColor(cursorColor),
+      ]
+      |> (
+        initial =>
+          hasPlaceholder ?
+            Style.[
+              position(`Absolute),
+              top(verticalAlignPos),
+              left(5),
+              ...initial,
+            ] :
+            initial
       );
 
     /*
@@ -246,23 +228,9 @@ let createElement =
     (
       ~window,
       ~children as _,
-      ~margin=defaultStyles.margin,
-      ~marginLeft=defaultStyles.marginLeft,
-      ~marginRight=defaultStyles.marginRight,
-      ~marginBottom=defaultStyles.marginBottom,
-      ~marginTop=defaultStyles.marginTop,
-      ~boxShadow=defaultStyles.boxShadow,
-      ~height=defaultStyles.height,
-      ~width=defaultStyles.width,
-      ~top=defaultStyles.top,
-      ~bottom=defaultStyles.bottom,
-      ~right=defaultStyles.right,
-      ~left=defaultStyles.left,
-      ~color=defaultStyles.color,
-      ~backgroundColor=defaultStyles.backgroundColor,
+      ~style=defaultStyles,
       ~placeholderColor=Colors.grey,
-      ~fontSize=defaultStyles.fontSize,
-      ~border=defaultStyles.border,
+      ~cursorColor=Colors.white,
       ~value="",
       ~placeholder="",
       ~onChange=noop,
@@ -271,24 +239,10 @@ let createElement =
   React.element(
     make(
       ~window,
-      ~margin,
-      ~marginLeft,
-      ~marginRight,
-      ~marginBottom,
-      ~marginTop,
-      ~boxShadow,
-      ~height,
-      ~width,
-      ~top,
-      ~bottom,
-      ~right,
-      ~left,
-      ~color,
-      ~backgroundColor,
-      ~fontSize,
-      ~border,
       ~value,
+      ~style,
       ~placeholder,
+      ~cursorColor,
       ~placeholderColor,
       ~onChange,
       (),

--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -2,85 +2,35 @@ open Revery_UI;
 open Revery_Core;
 open Revery_Core.Window;
 
-let containerStyles =
-    (
-      ~margin,
-      ~marginLeft,
-      ~marginRight,
-      ~marginBottom,
-      ~marginTop,
-      ~top,
-      ~right,
-      ~left,
-      ~bottom,
-      ~height,
-      ~width,
-      ~border,
-      ~color,
-      ~backgroundColor,
-      ~boxShadow,
-      (),
-    ) =>
-  Style.make(
-    ~margin,
-    ~marginLeft,
-    ~marginRight,
-    ~marginBottom,
-    ~marginTop,
-    ~backgroundColor,
-    ~width,
-    ~top,
-    ~right,
-    ~left,
-    ~bottom,
-    ~color,
-    ~height,
-    ~flexDirection=LayoutTypes.Row,
-    ~alignItems=LayoutTypes.AlignCenter,
-    ~justifyContent=LayoutTypes.JustifyFlexStart,
-    ~overflow=LayoutTypes.Hidden,
-    ~border,
-    ~boxShadow,
-    ~cursor=MouseCursors.text,
-    (),
-  );
-
-let textStyles = (~color, ~fontSize, ~hasPlaceholder, ~placeholderColor) =>
-  Style.make(
-    ~color=hasPlaceholder ? placeholderColor : color,
-    ~fontFamily="Roboto-Regular.ttf",
-    ~fontSize,
-    ~alignItems=LayoutTypes.AlignCenter,
-    ~justifyContent=LayoutTypes.JustifyFlexStart,
-    ~marginLeft=6,
-    (),
-  );
-
 let cursorStyles =
-    (~fontSize, ~cursorColor, ~opacity, ~containerHeight, ~hasPlaceholder) => {
+    (
+      ~fontSize,
+      ~cursorColor,
+      ~opacity as o,
+      ~containerHeight,
+      ~hasPlaceholder,
+    ) => {
   /*
      calculate the top padding needed to place the cursor centrally
    */
   let verticalAlignPos = (containerHeight - fontSize) / 2;
-  Style.make(
-    ~marginLeft=2,
-    ~height=fontSize,
-    ~width=2,
-    ~opacity,
-    ~backgroundColor=cursorColor,
-    (),
-  )
+  Style.[
+    marginLeft(2),
+    height(fontSize),
+    width(2),
+    opacity(o),
+    backgroundColor(cursorColor),
+  ]
   |> (
     initial =>
-      hasPlaceholder
-        ? Style.extend(
-            initial,
-            ~position=LayoutTypes.Absolute,
-            ~top=verticalAlignPos,
-            ~left=5,
-            (),
-          )
-        : initial
+      hasPlaceholder ?
+        Style.[
+          position(`Absolute),
+          top(verticalAlignPos),
+          left(5),
+          ...initial,
+        ] :
+        initial
   );
 };
 
@@ -112,12 +62,12 @@ let reducer = (action, state) =>
   | UpdateText(t) =>
     state.isFocused ? {...state, value: addCharacter(state.value, t)} : state
   | Backspace =>
-    state.isFocused
-      ? {
+    state.isFocused ?
+      {
         let length = String.length(state.value);
         length > 0 ? {...state, value: removeCharacter(state.value)} : state;
-      }
-      : state
+      } :
+      state
   | ClearWord => {...state, value: ""}
   };
 
@@ -129,49 +79,30 @@ let handleKeyDown = (~dispatch, event: Events.keyEvent) =>
 
 let noop = (~value as _value) => ();
 
-let defaultBorder = height =>
-  Style.Border.make(
-    /*
-       The default border width should be 5% of the full input height
-     */
-    ~width=float_of_int(height) *. 0.05 |> int_of_float,
-    ~color=Colors.black,
-    (),
-  );
-
 let defaultStyles =
-  Style.make(
-    ~fontSize=18,
-    ~color=Colors.black,
-    ~width=200,
-    ~height=50,
-    ~border=defaultBorder(50),
-    ~backgroundColor=Colors.transparentWhite,
-    (),
-  );
+  Style.[
+    fontSize(18),
+    color(Colors.black),
+    width(200),
+    height(50),
+    border(
+      /*
+         The default border width should be 5% of the full input height
+       */
+      ~width=float_of_int(50) *. 0.05 |> int_of_float,
+      ~color=Colors.black,
+    ),
+    backgroundColor(Colors.transparentWhite),
+  ];
 
 let component = React.component("Input");
 let make =
     (
       ~window,
-      ~margin,
-      ~marginLeft,
-      ~marginRight,
-      ~marginBottom,
-      ~marginTop,
-      ~boxShadow,
-      ~height,
-      ~width,
-      ~top,
-      ~bottom,
-      ~right,
-      ~left,
-      ~color,
-      ~backgroundColor,
-      ~fontSize,
-      ~border,
+      ~style,
       ~value,
       ~placeholder,
+      ~cursorColor,
       ~placeholderColor,
       ~onChange,
       (),
@@ -239,34 +170,61 @@ let make =
     /*
        computed styles
      */
+
     let viewStyles =
-      containerStyles(
-        ~margin,
-        ~marginLeft,
-        ~marginRight,
-        ~marginBottom,
-        ~marginTop,
-        ~height,
-        ~width,
-        ~color,
-        ~backgroundColor,
-        ~boxShadow,
-        ~border,
-        ~left,
-        ~right,
-        ~top,
-        ~bottom,
-        (),
+      Style.(
+        merge(
+          ~source=[
+            flexDirection(`Row),
+            alignItems(`Center),
+            justifyContent(`FlexStart),
+            overflow(LayoutTypes.Hidden),
+            cursor(MouseCursors.text),
+          ],
+          ~target=style,
+        )
+      );
+
+    /*
+       TODO: convert this to a getter utility function
+     */
+    let height =
+      List.fold_left(
+        (default, s) =>
+          switch (s) {
+          | `Height(h) => h
+          | _ => default
+          },
+        18,
+        style,
+      );
+
+    let inputColor =
+      List.fold_left(
+        (default, s) =>
+          switch (s) {
+          | `Color(c) => c
+          | _ => default
+          },
+        Colors.black,
+        style,
       );
 
     let innerTextStyles =
-      textStyles(~color, ~fontSize, ~hasPlaceholder, ~placeholderColor);
+      Style.[
+        color(hasPlaceholder ? placeholderColor : inputColor),
+        fontFamily("Roboto-Regular.ttf"),
+        fontSize(20),
+        alignItems(`Center),
+        justifyContent(`FlexStart),
+        marginLeft(6),
+      ];
 
     let inputCursorStyles =
       cursorStyles(
         ~opacity=state.isFocused ? opacity : 0.0,
-        ~fontSize,
-        ~cursorColor=color,
+        ~fontSize=20,
+        ~cursorColor,
         ~containerHeight=height,
         ~hasPlaceholder,
       );

--- a/src/UI_Components/Slider.re
+++ b/src/UI_Components/Slider.re
@@ -34,40 +34,36 @@ let make =
     let (thumbPosition, setThumbPosition, _slots: React.Hooks.empty) =
       React.Hooks.state(0, slots);
 
-    let setSlideRef = r => {
-      _setSlideRef(Some(r));
-    };
+    let setSlideRef = r => _setSlideRef(Some(r));
 
-    let setThumbRef = r => {
-      _setThumbRef(Some(r));
-    };
+    let setThumbRef = r => _setThumbRef(Some(r));
 
-    let onMouseDown = (evt: NodeEvents.mouseButtonEventParams) => {
+    let onMouseDown = (evt: NodeEvents.mouseButtonEventParams) =>
       switch (slideRef, thumbRef) {
       | (Some(slider), Some(thumb)) =>
         let sliderDimensions: BoundingBox2d.t = slider#getBoundingBox();
         let thumbDimensions: BoundingBox2d.t = thumb#getBoundingBox();
 
         let sliderWidth =
-          vertical
-            ? Vec2.get_y(sliderDimensions.max)
-              -. Vec2.get_y(sliderDimensions.min)
-            : Vec2.get_x(sliderDimensions.max)
-              -. Vec2.get_x(sliderDimensions.min);
+          vertical ?
+            Vec2.get_y(sliderDimensions.max)
+            -. Vec2.get_y(sliderDimensions.min) :
+            Vec2.get_x(sliderDimensions.max)
+            -. Vec2.get_x(sliderDimensions.min);
 
         let thumbWidth =
-          vertical
-            ? Vec2.get_y(thumbDimensions.max)
-              -. Vec2.get_y(thumbDimensions.min)
-            : Vec2.get_x(thumbDimensions.max)
-              -. Vec2.get_x(thumbDimensions.min);
+          vertical ?
+            Vec2.get_y(thumbDimensions.max)
+            -. Vec2.get_y(thumbDimensions.min) :
+            Vec2.get_x(thumbDimensions.max)
+            -. Vec2.get_x(thumbDimensions.min);
 
         let availableWidth = sliderWidth -. thumbWidth;
 
         let startPosition =
-          vertical
-            ? Vec2.get_y(sliderDimensions.min)
-            : Vec2.get_x(sliderDimensions.min);
+          vertical ?
+            Vec2.get_y(sliderDimensions.min) :
+            Vec2.get_x(sliderDimensions.min);
         let endPosition = startPosition +. availableWidth;
 
         let getValue = x =>
@@ -106,12 +102,11 @@ let make =
         );
       | _ => ()
       };
-    };
 
-    let backgroundColor = Colors.darkGray;
+    let sliderBackgroundColor = Colors.darkGray;
     let thumbColor = Colors.gray;
 
-    let opacity = isActive ? 1.0 : 0.8;
+    let sliderOpacity = isActive ? 1.0 : 0.8;
 
     let sliderHeight = 25;
     let trackHeight = 5;
@@ -119,53 +114,38 @@ let make =
     let trackMargins = (sliderHeight - trackHeight) / 2;
 
     let style =
-      Style.make(
-        ~opacity,
-        ~width={
-          vertical ? sliderHeight : sliderLength;
-        },
-        ~height={
-          vertical ? sliderLength : sliderHeight;
-        },
-        ~cursor=MouseCursors.pointer,
-        (),
-      );
+      Style.[
+        opacity(sliderOpacity),
+        width(vertical ? sliderHeight : sliderLength),
+        height(vertical ? sliderLength : sliderHeight),
+        cursor(MouseCursors.pointer),
+      ];
 
     let thumbWidth = thumbLength;
 
     let trackStyle =
-      Style.make(
-        ~opacity,
-        ~top={
-          vertical ? 0 : trackMargins;
-        },
-        ~bottom={
-          vertical ? 0 : trackMargins;
-        },
-        ~left={
-          vertical ? trackMargins : 0;
-        },
-        ~right={
-          vertical ? trackMargins : 0;
-        },
-        ~position=LayoutTypes.Absolute,
-        ~backgroundColor,
-        (),
-      );
+      Style.[
+        opacity(sliderOpacity),
+        top(vertical ? 0 : trackMargins),
+        bottom(vertical ? 0 : trackMargins),
+        left(vertical ? trackMargins : 0),
+        right(vertical ? trackMargins : 0),
+        position(`Absolute),
+        backgroundColor(sliderBackgroundColor),
+      ];
 
     <View onMouseDown style ref={r => setSlideRef(r)}>
       <View style=trackStyle />
       <View
         ref={r => setThumbRef(r)}
-        style={Style.make(
-          ~position=LayoutTypes.Absolute,
-          ~height={vertical ? thumbWidth : thumbHeight},
-          ~width={vertical ? thumbHeight : thumbWidth},
-          ~left={vertical ? 0 : thumbPosition},
-          ~top={vertical ? thumbPosition : 0},
-          ~backgroundColor=thumbColor,
-          (),
-        )}
+        style=Style.[
+          position(`Absolute),
+          height(vertical ? thumbWidth : thumbHeight),
+          width(vertical ? thumbHeight : thumbWidth),
+          left(vertical ? 0 : thumbPosition),
+          top(vertical ? thumbPosition : 0),
+          backgroundColor(thumbColor),
+        ]
       />
     </View>;
   });

--- a/test/UI/StyleTest.re
+++ b/test/UI/StyleTest.re
@@ -6,14 +6,14 @@ open Style;
 test("Style API tests", () => {
   test("that a style record is created correctly", () => {
     let styles =
-      create(~userStyles=[height(1), width(2), fontFamily("Roboto")], ());
+      create(~style=[height(1), width(2), fontFamily("Roboto")], ());
     expect(styles.height).toEqual(1);
     expect(styles.width).toEqual(2);
     expect(styles.fontFamily).toEqual("Roboto");
   });
 
   test("defaults should be correctly set", () => {
-    let styles = create(~userStyles=[height(1), width(2)], ());
+    let styles = create(~style=[height(1), width(2)], ());
     expect(styles.position).toEqual(LayoutTypes.Relative);
     expect(styles.border).toEqual(Border.make());
   });
@@ -21,7 +21,7 @@ test("Style API tests", () => {
   test("it correctly sets a margin", () => {
     let styles =
       create(
-        ~userStyles=[
+        ~style=[
           margin(1),
           marginLeft(7),
           marginTop(4),
@@ -40,7 +40,7 @@ test("Style API tests", () => {
   test("it correctly sets a border", () => {
     let styles =
       create(
-        ~userStyles=[
+        ~style=[
           border({color: black, width: 2}),
           borderLeft({color: rebeccaPurple, width: 2}),
           borderTop({color: red, width: 2}),
@@ -61,5 +61,11 @@ test("Style API tests", () => {
       width: 12,
     });
     expect(styles.borderVertical).toEqual({color: paleTurquoise, width: 18});
+  });
+
+  test("It correctly sets a margin", () => {
+    let styles = create(~style=[margin2({vertical: 2, horizontal: 4})], ());
+    expect(styles.marginVertical).toEqual(2);
+    expect(styles.marginHorizontal).toEqual(4);
   });
 });

--- a/test/UI/StyleTest.re
+++ b/test/UI/StyleTest.re
@@ -1,16 +1,64 @@
 open Rejest;
 open Revery_UI;
+open Revery_Core.Colors;
 open Style;
 
 test("Style API tests", () => {
   test("that a style record is created correctly", () => {
-    let styles = create(~userStyles=[height(1), width(2)], ());
+    let styles =
+      create(~userStyles=[height(1), width(2), fontFamily("Roboto")], ());
     expect(styles.height).toEqual(1);
     expect(styles.width).toEqual(2);
+    expect(styles.fontFamily).toEqual("Roboto");
   });
+
   test("defaults should be correctly set", () => {
     let styles = create(~userStyles=[height(1), width(2)], ());
     expect(styles.position).toEqual(LayoutTypes.Relative);
     expect(styles.border).toEqual(Border.make());
+  });
+
+  test("it correctly sets a margin", () => {
+    let styles =
+      create(
+        ~userStyles=[
+          margin(1),
+          marginLeft(7),
+          marginTop(4),
+          marginRight(8),
+          marginBottom(9),
+        ],
+        (),
+      );
+    expect(styles.margin).toEqual(1);
+    expect(styles.marginBottom).toEqual(9);
+    expect(styles.marginTop).toEqual(4);
+    expect(styles.marginRight).toEqual(8);
+    expect(styles.marginBottom).toEqual(9);
+  });
+
+  test("it correctly sets a border", () => {
+    let borderStyle = Border.make(~color=black, ~width=2, ());
+    let borderLeftStyle = Border.make(~color=rebeccaPurple, ~width=2, ());
+    let borderTopStyle = Border.make(~color=red, ~width=2, ());
+    let borderRightStyle = Border.make(~color=blue, ~width=2, ());
+    let borderBottomStyle = Border.make(~color=orange, ~width=2, ());
+
+    let styles =
+      create(
+        ~userStyles=[
+          border(borderStyle),
+          borderLeft(borderLeftStyle),
+          borderTop(borderTopStyle),
+          borderRight(borderRightStyle),
+          borderBottom(borderBottomStyle),
+        ],
+        (),
+      );
+    expect(styles.border).toEqual({color: black, width: 2});
+    expect(styles.borderBottom).toEqual({color: orange, width: 2});
+    expect(styles.borderTop).toEqual({color: red, width: 2});
+    expect(styles.borderRight).toEqual({color: blue, width: 2});
+    expect(styles.borderLeft).toEqual({color: rebeccaPurple, width: 2});
   });
 });

--- a/test/UI/StyleTest.re
+++ b/test/UI/StyleTest.re
@@ -38,20 +38,16 @@ test("Style API tests", () => {
   });
 
   test("it correctly sets a border", () => {
-    let borderStyle = Border.make(~color=black, ~width=2, ());
-    let borderLeftStyle = Border.make(~color=rebeccaPurple, ~width=2, ());
-    let borderTopStyle = Border.make(~color=red, ~width=2, ());
-    let borderRightStyle = Border.make(~color=blue, ~width=2, ());
-    let borderBottomStyle = Border.make(~color=orange, ~width=2, ());
-
     let styles =
       create(
         ~userStyles=[
-          border(borderStyle),
-          borderLeft(borderLeftStyle),
-          borderTop(borderTopStyle),
-          borderRight(borderRightStyle),
-          borderBottom(borderBottomStyle),
+          border({color: black, width: 2}),
+          borderLeft({color: rebeccaPurple, width: 2}),
+          borderTop({color: red, width: 2}),
+          borderRight({color: blue, width: 2}),
+          borderBottom({color: orange, width: 2}),
+          borderHorizontal({color: paleVioletRed, width: 12}),
+          borderVertical({color: paleTurquoise, width: 18}),
         ],
         (),
       );
@@ -60,5 +56,10 @@ test("Style API tests", () => {
     expect(styles.borderTop).toEqual({color: red, width: 2});
     expect(styles.borderRight).toEqual({color: blue, width: 2});
     expect(styles.borderLeft).toEqual({color: rebeccaPurple, width: 2});
+    expect(styles.borderHorizontal).toEqual({
+      color: paleVioletRed,
+      width: 12,
+    });
+    expect(styles.borderVertical).toEqual({color: paleTurquoise, width: 18});
   });
 });

--- a/test/UI/StyleTest.re
+++ b/test/UI/StyleTest.re
@@ -1,0 +1,16 @@
+open Rejest;
+open Revery_UI;
+open Style;
+
+test("Style API tests", () => {
+  test("that a style record is created correctly", () => {
+    let styles = create(~userStyles=[height(1), width(2)], ());
+    expect(styles.height).toEqual(1);
+    expect(styles.width).toEqual(2);
+  });
+  test("defaults should be correctly set", () => {
+    let styles = create(~userStyles=[height(1), width(2)], ());
+    expect(styles.position).toEqual(LayoutTypes.Relative);
+    expect(styles.border).toEqual(Border.make());
+  });
+});

--- a/test/UI/StyleTest.re
+++ b/test/UI/StyleTest.re
@@ -80,6 +80,17 @@ test("Style API tests", () => {
     let found = List.find(style => style == `Margin(4), result);
     expect(found).toEqual(`Margin(4));
     expect(styles.color).toEqual(blue);
+  });
+
+  test(
+    "Should keep old styles when merging if they do not conflict with new ones",
+    () => {
+    let result =
+      merge(
+        ~source=[margin(10), color(red), backgroundColor(paleTurquoise)],
+        ~target=[margin(4), color(blue)],
+      );
+
     let found =
       List.find(style => style == `BackgroundColor(paleTurquoise), result);
     expect(found).toEqual(`BackgroundColor(paleTurquoise));

--- a/test/UI/StyleTest.re
+++ b/test/UI/StyleTest.re
@@ -37,29 +37,32 @@ test("Style API tests", () => {
     expect(styles.marginBottom).toEqual(9);
   });
 
+  test("It correctly sets a margin in the x an y axis", () => {
+    let styles = create(~style=[margin2({vertical: 2, horizontal: 4})], ());
+    expect(styles.marginVertical).toEqual(2);
+    expect(styles.marginHorizontal).toEqual(4);
+  });
+
   test("it correctly sets a border", () => {
     let styles =
       create(
         ~style=[
-          border({color: black, width: 2}),
-          borderLeft({color: rebeccaPurple, width: 2}),
-          borderTop({color: red, width: 2}),
-          borderRight({color: blue, width: 2}),
-          borderBottom({color: orange, width: 2}),
-          borderHorizontal({color: paleVioletRed, width: 12}),
-          borderVertical({color: paleTurquoise, width: 18}),
+          border(~color=black, ~width=2),
+          borderLeft(~color=rebeccaPurple, ~width=2),
+          borderTop(~color=red, ~width=2),
+          borderRight(~color=blue, ~width=2),
+          borderBottom(~color=orange, ~width=2),
+          borderHorizontal(~color=paleVioletRed, ~width=12),
+          borderVertical(~color=paleTurquoise, ~width=18),
         ],
         (),
       );
-    expect(styles.border).toEqual({color: black, width: 2});
-    expect(styles.borderBottom).toEqual({color: orange, width: 2});
-    expect(styles.borderTop).toEqual({color: red, width: 2});
-    expect(styles.borderRight).toEqual({color: blue, width: 2});
-    expect(styles.borderLeft).toEqual({color: rebeccaPurple, width: 2});
-    expect(styles.borderHorizontal).toEqual({
-      color: paleVioletRed,
-      width: 12,
-    });
+    expect(styles.border).toEqual(~color=black, ~width=2);
+    expect(styles.borderBottom).toEqual(~color=orange, ~width=2);
+    expect(styles.borderTop).toEqual(~color=red, ~width=2);
+    expect(styles.borderRight).toEqual(~color=blue, ~width=2);
+    expect(styles.borderLeft).toEqual(~color=rebeccaPurple, ~width=2);
+    expect(styles.borderHorizontal).toEqual(~color=paleVioletRed, ~width=12);
     expect(styles.borderVertical).toEqual({color: paleTurquoise, width: 18});
   });
 

--- a/test/UI/StyleTest.re
+++ b/test/UI/StyleTest.re
@@ -38,7 +38,7 @@ test("Style API tests", () => {
   });
 
   test("It correctly sets a margin in the x an y axis", () => {
-    let styles = create(~style=[margin2({vertical: 2, horizontal: 4})], ());
+    let styles = create(~style=[margin2(~vertical=2, ~horizontal=4)], ());
     expect(styles.marginVertical).toEqual(2);
     expect(styles.marginHorizontal).toEqual(4);
   });
@@ -57,18 +57,31 @@ test("Style API tests", () => {
         ],
         (),
       );
-    expect(styles.border).toEqual(~color=black, ~width=2);
-    expect(styles.borderBottom).toEqual(~color=orange, ~width=2);
-    expect(styles.borderTop).toEqual(~color=red, ~width=2);
-    expect(styles.borderRight).toEqual(~color=blue, ~width=2);
-    expect(styles.borderLeft).toEqual(~color=rebeccaPurple, ~width=2);
-    expect(styles.borderHorizontal).toEqual(~color=paleVioletRed, ~width=12);
+    expect(styles.border).toEqual({color: black, width: 2});
+    expect(styles.borderBottom).toEqual({color: orange, width: 2});
+    expect(styles.borderTop).toEqual({color: red, width: 2});
+    expect(styles.borderRight).toEqual({color: blue, width: 2});
+    expect(styles.borderLeft).toEqual({color: rebeccaPurple, width: 2});
+    expect(styles.borderHorizontal).toEqual({
+      color: paleVioletRed,
+      width: 12,
+    });
     expect(styles.borderVertical).toEqual({color: paleTurquoise, width: 18});
   });
 
-  test("It correctly sets a margin", () => {
-    let styles = create(~style=[margin2({vertical: 2, horizontal: 4})], ());
-    expect(styles.marginVertical).toEqual(2);
-    expect(styles.marginHorizontal).toEqual(4);
+  test("Should correctly overwrite the source style if the target exists", () => {
+    let result =
+      merge(
+        ~source=[margin(10), color(red), backgroundColor(paleTurquoise)],
+        ~target=[margin(4), color(blue)],
+      );
+    let styles = create(~style=result, ());
+    expect(styles.margin).toEqual(4);
+    let found = List.find(style => style == `Margin(4), result);
+    expect(found).toEqual(`Margin(4));
+    expect(styles.color).toEqual(blue);
+    let found =
+      List.find(style => style == `BackgroundColor(paleTurquoise), result);
+    expect(found).toEqual(`BackgroundColor(paleTurquoise));
   });
 });


### PR DESCRIPTION
I was inspired by @wokalski suggestion in #205 idea of a change to the style api that would change it from
```reason
<Text
  style=Style.make(
     ~color=Colors.red
     ~backgroundColor=Colors.blue
    /* a bunch of stuff */
    (),
    )
  />
```

to 
```reason
 <Text
  style=[
   fontSize(1)
   fontFamily(green)
   flexDirection(row)
   width(percent(90)) /* future plan that can come based on this */
  ]/>
```
Other examples of similar patterns are `brisk`, `bs-nice` and `bs-css`.
Current implementation so far is heavily inspired by `brisk` :laughing: 

### Advantages
The advantages of this would be a simpler, less error prone to newbie syntax (like forgetting to pass `unit` at the end of the make function) less exposure of the internal api of things like `BoxShadow` so this way it can be re-implemented and a user wouldn't have to refactor their usage of `BoxShadow.make(~specificLabels)`
Also merging styles would be easier as a list can be easily iterated and modified vs a record type