### PR TITLE
Performance Fixes Part 1: Reduce unnecessary matrix multiplications

### DIFF
--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -11,17 +11,19 @@ module UniqueId =
 type callback = unit => unit;
 
 type cachedNodeState = {
-    transform: Mat4.t,
-    worldTransform: Mat4.t,   
-    bbox: BoundingBox2d.t,
-    depth: int,
+  transform: Mat4.t,
+  worldTransform: Mat4.t,
+  bbox: BoundingBox2d.t,
+  depth: int,
 };
 
 exception NoDataException(string);
-let getOrThrow: (string, option('a)) => 'a = (msg, opt) => switch(opt) {
-| Some(p) => p
-| None => raise(NoDataException(msg))
-};
+let getOrThrow: (string, option('a)) => 'a =
+  (msg, opt) =>
+    switch (opt) {
+    | Some(p) => p
+    | None => raise(NoDataException(msg))
+    };
 
 class node ('a) (()) = {
   as _this;
@@ -52,7 +54,6 @@ class node ('a) (()) = {
       },
     );
   };
-
   pub getInternalId = () => _internalId;
   pub measurements = () => _layoutNode^.layout;
   pub getTabIndex = () => _tabIndex^;
@@ -62,20 +63,20 @@ class node ('a) (()) = {
   pub setEvents = events => _events := events;
   pub getEvents = () => _events^;
   pub getWorldTransform = () => {
-      let state = _cachedNodeState^ |> getOrThrow("getWorldTransform");
-      state.worldTransform;
+    let state = _cachedNodeState^ |> getOrThrow("getWorldTransform");
+    state.worldTransform;
   };
   pub getTransform = () => {
-      let state = _cachedNodeState^ |> getOrThrow("getTransform");
-      state.transform;
+    let state = _cachedNodeState^ |> getOrThrow("getTransform");
+    state.transform;
   };
   pub getBoundingBox = () => {
-      let state = _cachedNodeState^ |> getOrThrow("getBoundingBox"); 
-      state.bbox;
+    let state = _cachedNodeState^ |> getOrThrow("getBoundingBox");
+    state.bbox;
   };
   pub getDepth = () => {
-      let state = _cachedNodeState^ |> getOrThrow("getDepth");
-      state.depth;
+    let state = _cachedNodeState^ |> getOrThrow("getDepth");
+    state.depth;
   };
   pri _recalculateTransform = () => {
     let dimensions = _layoutNode^.layout;
@@ -97,7 +98,7 @@ class node ('a) (()) = {
     Mat4.multiply(matrix, matrix, animationTransform);
     matrix;
   };
-  pri _recalculateWorldTransform = (localTransform) => {
+  pri _recalculateWorldTransform = localTransform => {
     let xform = localTransform;
     let world =
       switch (_parent^) {
@@ -108,7 +109,7 @@ class node ('a) (()) = {
     Mat4.multiply(matrix, world, xform);
     matrix;
   };
-  pri _recalculateBoundingBox = (worldTransform) => {
+  pri _recalculateBoundingBox = worldTransform => {
     let dimensions = _layoutNode^.layout;
     let min = Vec2.create(0., 0.);
     let max =
@@ -120,22 +121,18 @@ class node ('a) (()) = {
     let bbox = BoundingBox2d.transform(b, worldTransform);
     bbox;
   };
-  pri _recalculateDepth = () => switch(_parent^) {
-  | None => 0
-  | Some(p) => p#getDepth() + 1;
-  };
+  pri _recalculateDepth = () =>
+    switch (_parent^) {
+    | None => 0
+    | Some(p) => p#getDepth() + 1
+    };
   pub recalculate = () => {
-    let transform = _this#_recalculateTransform(); 
+    let transform = _this#_recalculateTransform();
     let worldTransform = _this#_recalculateWorldTransform(transform);
     let bbox = _this#_recalculateBoundingBox(worldTransform);
     let depth = _this#_recalculateDepth();
 
-    _cachedNodeState := Some({
-        transform,
-        worldTransform,
-        bbox,
-        depth,
-    });
+    _cachedNodeState := Some({transform, worldTransform, bbox, depth});
 
     List.iter(c => c#recalculate(), _children^);
   };

--- a/src/UI/UiRender.re
+++ b/src/UI/UiRender.re
@@ -63,6 +63,10 @@ let render = (container: UiContainer.t, component: UiReact.syntheticElement) => 
     -1000.0,
   );
 
+  Performance.bench("recalculate", () => {
+    rootNode#recalculate(); 
+  });
+
   Performance.bench("draw", () => {
     /* Do a first pass for all 'opaque' geometry */
     /* This helps reduce the overhead for the more expensive alpha pass, next */

--- a/src/UI/UiRender.re
+++ b/src/UI/UiRender.re
@@ -53,23 +53,21 @@ let render = (container: UiContainer.t, component: UiReact.syntheticElement) => 
   };
 
   /* Render */
-  Performance.bench("recalculate", () => {
-    rootNode#recalculate(); 
-  });
+  Performance.bench("recalculate", () => rootNode#recalculate());
 
   Performance.bench("draw", () => {
     /* Do a first pass for all 'opaque' geometry */
     /* This helps reduce the overhead for the more expensive alpha pass, next */
 
-     Mat4.ortho(
-       _projection,
-       0.0,
-       float_of_int(size.width),
-       float_of_int(size.height),
-       0.0,
-       1000.0,
-       -1000.0,
-     );
+    Mat4.ortho(
+      _projection,
+      0.0,
+      float_of_int(size.width),
+      float_of_int(size.height),
+      0.0,
+      1000.0,
+      -1000.0,
+    );
 
     let drawContext =
       NodeDrawContext.create(int_of_float(pixelRatio), 0, 1.0, size.height);

--- a/src/UI/UiRender.re
+++ b/src/UI/UiRender.re
@@ -53,16 +53,6 @@ let render = (container: UiContainer.t, component: UiReact.syntheticElement) => 
   };
 
   /* Render */
-  Mat4.ortho(
-    _projection,
-    0.0,
-    float_of_int(size.width),
-    float_of_int(size.height),
-    0.0,
-    1000.0,
-    -1000.0,
-  );
-
   Performance.bench("recalculate", () => {
     rootNode#recalculate(); 
   });
@@ -70,6 +60,16 @@ let render = (container: UiContainer.t, component: UiReact.syntheticElement) => 
   Performance.bench("draw", () => {
     /* Do a first pass for all 'opaque' geometry */
     /* This helps reduce the overhead for the more expensive alpha pass, next */
+
+     Mat4.ortho(
+       _projection,
+       0.0,
+       float_of_int(size.width),
+       float_of_int(size.height),
+       0.0,
+       1000.0,
+       -1000.0,
+     );
 
     let drawContext =
       NodeDrawContext.create(int_of_float(pixelRatio), 0, 1.0, size.height);

--- a/test/UI/MouseTest.re
+++ b/test/UI/MouseTest.re
@@ -7,6 +7,7 @@ let createNodeWithStyle = style => {
   let node = (new node)();
   node#setStyle(style);
   Layout.layout(node, 1.0);
+  node#recalculate();
   node;
 };
 

--- a/test/UI/NodeTests.re
+++ b/test/UI/NodeTests.re
@@ -31,8 +31,8 @@ test("NodeTests", () => {
     test("simple hitTest returns true case", () => {
       let node = (new node)();
       node#setStyle(Style.make(~width=400, ~height=500, ()));
-
       Layout.layout(node, 1.0);
+      node#recalculate();
 
       expect(node#hitTest(Vec2.create(200., 250.))).toBe(true);
     });
@@ -42,6 +42,7 @@ test("NodeTests", () => {
       node#setStyle(Style.make(~width=400, ~height=500, ()));
 
       Layout.layout(node, 1.0);
+      node#recalculate();
 
       expect(node#hitTest(Vec2.create(401., 250.))).toBe(false);
     });
@@ -49,8 +50,9 @@ test("NodeTests", () => {
     test("left / top are taken into account", () => {
       let node = (new node)();
       node#setStyle(Style.make(~top=5, ~left=5, ~height=2, ~width=2, ()));
-
       Layout.layout(node, 1.0);
+      node#recalculate();
+
       expect(node#hitTest(Vec2.create(1., 1.))).toBe(false);
       expect(node#hitTest(Vec2.create(6., 6.))).toBe(true);
     });
@@ -66,6 +68,8 @@ test("NodeTests", () => {
       parentNode#addChild(childNode);
 
       Layout.layout(parentNode, 1.0);
+      parentNode#recalculate();
+
       expect(childNode#hitTest(Vec2.create(0., 0.))).toBe(false);
       expect(childNode#hitTest(Vec2.create(60., 60.))).toBe(true);
     });


### PR DESCRIPTION
__Issue:__ One of the first performance bottlenecks with #212 is excessive amounts of garbage + matrix multiplication. Our matrix multiplication pipeline (getting the `worldTransform` and `transform`) is wholly unoptimized and _always_ recalculates on every request, and the `worldTransform` needs to be calculated based on the entire chain - so this can blow up to be a pretty huge number of matrix multiplications! 

In addition, generating the `worldTransform` is a function of `localTransform` * `parent.worldTransform`, and the local transform _itself_ takes multiple matrix multiplications.

This calculation happens for rendering, as well as for hit testing (getting the bounding box).

This change implements a `recalculate` step where we do all those calculations at once and cache the results, so we don't have to keep re-calculating the same values.

This implements a first-level optimization to only calculate the transforms _once_ per render frame.

With this change, the `caml_mat4_multiply` no longer shows up as a hot path in the profiler.