### PR TITLE
Performance Fixes - Part 2: GC tuning + profiling

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -89,13 +89,17 @@ let startWithState: startFunc('s, 'a) =
         /* We're taking path 2 of the garbage collector route to nirvana:
          * https://blogs.msdn.microsoft.com/shawnhar/2007/07/02/twin-paths-to-garbage-collector-nirvana/
          */
-        GarbageCollector.minor();
+        Performance.bench("gc: minor", () => {
+          GarbageCollector.minor();
+        });
       } else {
         /* If the app is idle, this is the perfect time to make sure
          * we're in a clear memory state, so we're ready to go on the next
          * tick
          */
-        GarbageCollector.full();
+        Performance.bench("gc: full", () => {
+          GarbageCollector.full();
+        });
       };
 
       if (Environment.isNative) {

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -70,6 +70,8 @@ let startWithState: startFunc('s, 'a) =
       needsRender: true,
     };
 
+    GarbageCollector.tune();
+
     let _ = Glfw.glfwInit();
     let _ = initFunc(appInstance);
 
@@ -84,9 +86,18 @@ let startWithState: startFunc('s, 'a) =
           List.iter(w => Window.render(w), getWindows(appInstance));
           appInstance.needsRender = false;
         });
+        /* We're taking path 2 of the garbage collector route to nirvana:
+         * https://blogs.msdn.microsoft.com/shawnhar/2007/07/02/twin-paths-to-garbage-collector-nirvana/
+         */
+         GarbageCollector.minor();
       } else {
-        Environment.sleep(Milliseconds(1.));
+        /* If the app is idle, this is the perfect time to make sure
+         * we're in a clear memory state, so we're ready to go on the next
+         * tick
+         */
+        GarbageCollector.full();
       };
+
       List.length(getWindows(appInstance)) == 0;
     };
 

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -98,6 +98,9 @@ let startWithState: startFunc('s, 'a) =
         GarbageCollector.full();
       };
 
+      if (Environment.isNative) {
+          Thread.yield();
+      }
       List.length(getWindows(appInstance)) == 0;
     };
 

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -89,7 +89,7 @@ let startWithState: startFunc('s, 'a) =
         /* We're taking path 2 of the garbage collector route to nirvana:
          * https://blogs.msdn.microsoft.com/shawnhar/2007/07/02/twin-paths-to-garbage-collector-nirvana/
          */
-         GarbageCollector.minor();
+        GarbageCollector.minor();
       } else {
         /* If the app is idle, this is the perfect time to make sure
          * we're in a clear memory state, so we're ready to go on the next

--- a/src/Core/GarbageCollector.re
+++ b/src/Core/GarbageCollector.re
@@ -1,0 +1,42 @@
+/*
+ * GarbageCollector.re
+ *
+ * Thin wrapper over the 'Gc' module to support some
+ * basic primitives for tuning performance in the
+ * Revery app model.
+ */
+
+let tune = () => {
+    /* Gc tuning is only applicable in the native space */
+    if (Environment.isNative) {
+        let settings = Gc.get();        
+
+        /* Increase minor heap size: 256kb -> 8MB */
+        /* 
+         * Some more info on why this is helpful: 
+         * https://md.ekstrandom.net/blog/2010/06/ocaml-memory-tuning
+         */
+        let minorHeapSize = 8 * 1024 * 1024;
+        Gc.set({...settings, minor_heap_size: minorHeapSize});
+    };
+};
+
+let minor = () => {
+    if (Environment.isNative) {
+        Gc.minor();
+    };
+};
+
+let full = () => {
+    if (Environment.isNative) {
+        Gc.full_major();
+    };
+};
+
+let counters = () => {
+    if (Environment.isNative) {
+        Gc.counters();
+    } else {
+        (0., 0., 0.);
+    }
+};

--- a/src/Core/GarbageCollector.re
+++ b/src/Core/GarbageCollector.re
@@ -6,37 +6,33 @@
  * Revery app model.
  */
 
-let tune = () => {
-    /* Gc tuning is only applicable in the native space */
-    if (Environment.isNative) {
-        let settings = Gc.get();        
+let tune = () =>
+  /* Gc tuning is only applicable in the native space */
+  if (Environment.isNative) {
+    let settings = Gc.get();
 
-        /* Increase minor heap size: 256kb -> 8MB */
-        /* 
-         * Some more info on why this is helpful: 
-         * https://md.ekstrandom.net/blog/2010/06/ocaml-memory-tuning
-         */
-        let minorHeapSize = 8 * 1024 * 1024;
-        Gc.set({...settings, minor_heap_size: minorHeapSize});
-    };
-};
+    /* Increase minor heap size: 256kb -> 8MB */
+    /*
+     * Some more info on why this is helpful:
+     * https://md.ekstrandom.net/blog/2010/06/ocaml-memory-tuning
+     */
+    let minorHeapSize = 8 * 1024 * 1024;
+    Gc.set({...settings, minor_heap_size: minorHeapSize});
+  };
 
-let minor = () => {
-    if (Environment.isNative) {
-        Gc.minor();
-    };
-};
+let minor = () =>
+  if (Environment.isNative) {
+    Gc.minor();
+  };
 
-let full = () => {
-    if (Environment.isNative) {
-        Gc.full_major();
-    };
-};
+let full = () =>
+  if (Environment.isNative) {
+    Gc.full_major();
+  };
 
-let counters = () => {
-    if (Environment.isNative) {
-        Gc.counters();
-    } else {
-        (0., 0., 0.);
-    }
-};
+let counters = () =>
+  if (Environment.isNative) {
+    Gc.counters();
+  } else {
+    (0., 0., 0.);
+  };

--- a/src/Core/Performance.re
+++ b/src/Core/Performance.re
@@ -4,6 +4,30 @@ type performanceFunction = unit => unit;
 
 let nestingLevel = ref(0);
 
+module MemoryAllocations {
+    type t = {
+        minorWords: int,
+        promotedWords: int,
+        majorWords: int,
+    };
+
+    
+    let show = ({minorWords, promotedWords, majorWords}: t) => {
+        "| minor: " ++ string_of_int(minorWords) ++ " | major: " ++ string_of_int(majorWords) ++ " | promoted: " ++ string_of_int(promotedWords) ++ " |"
+    };
+}
+let getMemoryAllocations =  (startCounters, endCounters) => {
+    let (startMinor, startPromoted, startMajor) = startCounters;   
+    let (endMinor, endPromoted, endMajor) = endCounters;
+
+    let ret: MemoryAllocations.t = {
+        minorWords: int_of_float(endMinor -. startMinor),
+        promotedWords: int_of_float(endPromoted -. startPromoted),
+        majorWords: int_of_float(endMajor -. startMajor),
+    };
+    ret;
+};
+
 let bench =
   switch (Sys.getenv_opt("REVERY_DEBUG")) {
   | None => ((_name, f) => f())
@@ -11,16 +35,22 @@ let bench =
       (name, f) => {
         nestingLevel := nestingLevel^ + 1;
         let startTime = glfwGetTime();
+        let startCounters = GarbageCollector.counters();
         f();
         let endTime = glfwGetTime();
+        let endCounters = GarbageCollector.counters();
+        let allocations = getMemoryAllocations(startCounters, endCounters);
         print_endline(
           String.make(nestingLevel^, '-')
           ++ "[PERF: "
           ++ name
-          ++ "]: "
+          ++ "] Time: "
           ++ string_of_float((endTime -. startTime) *. 1000.)
-          ++ "ms",
+          ++ "ms"
+          ++ " Memory: "
+          ++ MemoryAllocations.show(allocations)
         );
+
         nestingLevel := nestingLevel^ - 1;
       }
     )

--- a/src/Core/Performance.re
+++ b/src/Core/Performance.re
@@ -4,28 +4,33 @@ type performanceFunction = unit => unit;
 
 let nestingLevel = ref(0);
 
-module MemoryAllocations {
-    type t = {
-        minorWords: int,
-        promotedWords: int,
-        majorWords: int,
-    };
+module MemoryAllocations = {
+  type t = {
+    minorWords: int,
+    promotedWords: int,
+    majorWords: int,
+  };
 
-    
-    let show = ({minorWords, promotedWords, majorWords}: t) => {
-        "| minor: " ++ string_of_int(minorWords) ++ " | major: " ++ string_of_int(majorWords) ++ " | promoted: " ++ string_of_int(promotedWords) ++ " |"
-    };
-}
-let getMemoryAllocations =  (startCounters, endCounters) => {
-    let (startMinor, startPromoted, startMajor) = startCounters;   
-    let (endMinor, endPromoted, endMajor) = endCounters;
+  let show = ({minorWords, promotedWords, majorWords}: t) => {
+    "| minor: "
+    ++ string_of_int(minorWords)
+    ++ " | major: "
+    ++ string_of_int(majorWords)
+    ++ " | promoted: "
+    ++ string_of_int(promotedWords)
+    ++ " |";
+  };
+};
+let getMemoryAllocations = (startCounters, endCounters) => {
+  let (startMinor, startPromoted, startMajor) = startCounters;
+  let (endMinor, endPromoted, endMajor) = endCounters;
 
-    let ret: MemoryAllocations.t = {
-        minorWords: int_of_float(endMinor -. startMinor),
-        promotedWords: int_of_float(endPromoted -. startPromoted),
-        majorWords: int_of_float(endMajor -. startMajor),
-    };
-    ret;
+  let ret: MemoryAllocations.t = {
+    minorWords: int_of_float(endMinor -. startMinor),
+    promotedWords: int_of_float(endPromoted -. startPromoted),
+    majorWords: int_of_float(endMajor -. startMajor),
+  };
+  ret;
 };
 
 let bench =
@@ -48,7 +53,7 @@ let bench =
           ++ string_of_float((endTime -. startTime) *. 1000.)
           ++ "ms"
           ++ " Memory: "
-          ++ MemoryAllocations.show(allocations)
+          ++ MemoryAllocations.show(allocations),
         );
 
         nestingLevel := nestingLevel^ - 1;


### PR DESCRIPTION
__Issue:__ The current strategy we use for the GC isn't really amenable for real-time, animated apps like we want to build with Revery. For real-time apps, we don't want to get surprise allocations that could kill our render deadline and result in a skipped frame.

We see a lot of GC activity in examples that render a _lot_ of elements (ie, #212)

There's two real options for this:
- __Option 1:__ Never allocate during the course of the app. Pre-allocate ahead of time. Then, GC is never triggered, and you don't have to worry. This option is feasible in some languages like C# or Java by 'pre-allocating' and using 'Recycle Pools', but it's not really feasible in a functional world.
- __Option 2:__ Allocate frequently, but clean up the GC frequently such as to minimize promotions to the major heap. This is the option we need to take for `revery` to support a functional programming model.

A good article on this called [Twin Paths to Garbage Collector Nirvana](https://blogs.msdn.microsoft.com/shawnhar/2007/07/02/twin-paths-to-garbage-collector-nirvana/) - geared towards games built on the .NET CLR, but similiar concepts apply.

In addition, there is an OCaml specific article on tuning the GC here: [Tuning the OCaml Garbage collector for lage data processing jobs](https://md.ekstrandom.net/blog/2010/06/ocaml-memory-tuning) that gives some specific tips.

This change bumps up the size of our 'minor' (cheap) heap, and we do a minor collection every frame. We also take the opportunity if the app is idle to do a full collection.

This isn't the end of the story - this just sets us up for success in reasonable cases. We also need __to be able to detect functions that allocate lots of memory__ and __optimize those code paths__. For that - I've extended our `Performance` API to be aware of allocations, and print that out - we can then zero-in on where we need to focus on memory tuning to minimize collections. Those changes aren't part of this, but will come later as we profile.
