### PR TITLE
Bugfix: Exception on start

### DIFF
--- a/src/UI/Mouse.re
+++ b/src/UI/Mouse.re
@@ -109,36 +109,34 @@ let isMouseDownEv =
 
 let dispatch =
     (cursor: Cursor.t, evt: Events.internalMouseEvents, node: Node.node('a)) => {
-
-  switch (node#hasRendered()) {
-  | true => {
+  node#hasRendered()
+    ? {
       let pos = getPositionFromMouseEvent(cursor, evt);
 
-  let eventToSend = internalToExternalEvent(cursor, evt);
+      let eventToSend = internalToExternalEvent(cursor, evt);
 
-  let mouseDown = isMouseDownEv(eventToSend);
-  if (mouseDown) {
-    switch (getFirstFocusable(node, pos)) {
-    | Some(node) => Focus.dispatch(node)
-    | None => Focus.loseFocus()
-    };
-  } else {
-    ();
-  };
+      let mouseDown = isMouseDownEv(eventToSend);
+      if (mouseDown) {
+        switch (getFirstFocusable(node, pos)) {
+        | Some(node) => Focus.dispatch(node)
+        | None => Focus.loseFocus()
+        };
+      } else {
+        ();
+      };
 
-  if (!handleCapture(eventToSend)) {
-    let deepestNode = getDeepestNode(node, pos);
-    switch (deepestNode^) {
-    | None => ()
-    | Some(node) =>
-      bubble(node, eventToSend);
-      let cursor = node#getCursorStyle();
-      Event.dispatch(onCursorChanged, cursor);
-    };
-  };
+      if (!handleCapture(eventToSend)) {
+        let deepestNode = getDeepestNode(node, pos);
+        switch (deepestNode^) {
+        | None => ()
+        | Some(node) =>
+          bubble(node, eventToSend);
+          let cursor = node#getCursorStyle();
+          Event.dispatch(onCursorChanged, cursor);
+        };
+      };
 
-  Cursor.set(cursor, pos);
-  }
-  | false => ();
-  };
+      Cursor.set(cursor, pos);
+    }
+    : ();
 };

--- a/src/UI/Mouse.re
+++ b/src/UI/Mouse.re
@@ -109,7 +109,10 @@ let isMouseDownEv =
 
 let dispatch =
     (cursor: Cursor.t, evt: Events.internalMouseEvents, node: Node.node('a)) => {
-  let pos = getPositionFromMouseEvent(cursor, evt);
+
+  switch (node#hasRendered()) {
+  | true => {
+      let pos = getPositionFromMouseEvent(cursor, evt);
 
   let eventToSend = internalToExternalEvent(cursor, evt);
 
@@ -135,4 +138,7 @@ let dispatch =
   };
 
   Cursor.set(cursor, pos);
+  }
+  | false => ();
+  };
 };

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -143,6 +143,12 @@ class node ('a) (()) = {
     | (Some(cursorStyle), _) => cursorStyle
     };
   };
+  pub hasRendered = () => {
+      switch(_cachedNodeState^) {
+      | Some(_) => true
+      | None => false
+      } 
+  };
   pub hitTest = (p: Vec2.t) => {
     let bbox = _this#getBoundingBox();
     BoundingBox2d.isPointInside(bbox, p);

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -144,10 +144,10 @@ class node ('a) (()) = {
     };
   };
   pub hasRendered = () => {
-      switch(_cachedNodeState^) {
-      | Some(_) => true
-      | None => false
-      } 
+    switch (_cachedNodeState^) {
+    | Some(_) => true
+    | None => false
+    };
   };
   pub hitTest = (p: Vec2.t) => {
     let bbox = _this#getBoundingBox();


### PR DESCRIPTION
__Issue:__ Intermittently when starting the example app, get an error like:
```
Fatal error: exception Revery_UI__Node.NoDataException("getBoundingBox")
```

__Defect:__ This is a regression from #216 . We calculate certain properties (`transform`, `worldTransform`, `bbox`, etc) during rendering. Prior to the first render - these properties are not available. However, if there is mouse movement, the mouse event can potentially get dispatched prior to the render. The mouse dispatching uses the calculated bbox to figure out if it needs to dispatch an event. In this case - there is a crash occurring because the bounding box hasn't been calculated yet.

__Fix:__ Don't dispatch events until these calculated properties are available.