### PR TITLE
Performance: Improve CPU usage when idle

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -3,15 +3,15 @@ open Reglfw;
 type reducer('s, 'a) = ('s, 'a) => 's;
 
 type idleState =
-| Running
-| Idle;
+  | Running
+  | Idle;
 
 type t('s, 'a) = {
   reducer: reducer('s, 'a),
   mutable state: 's,
   mutable windows: list(Window.t),
   mutable needsRender: bool,
-  mutable idleState: idleState,
+  mutable idleState,
 };
 
 /* If no state is specified, just use unit! */
@@ -97,20 +97,16 @@ let startWithState: startFunc('s, 'a) =
          */
         appInstance.idleState = Running;
         Performance.bench("gc: minor", () => GarbageCollector.minor());
+      } else if (appInstance.idleState == Running) {
+        /* If the we're transitioning from Running to Idle, this is the
+         * perfect time to do a full memory collection, so that
+         * we're in a clear memory state, so we're ready to go on the next
+         * tick
+         */
+        Performance.bench("gc: full", () => GarbageCollector.full());
+        appInstance.idleState = Idle;
       } else {
-        if (appInstance.idleState == Running) {
-            /* If the we're transitioning from Running to Idle, this is the
-             * perfect time to do a full memory collection, so that
-             * we're in a clear memory state, so we're ready to go on the next
-             * tick
-             */
-            Performance.bench("gc: full", () =>
-              GarbageCollector.full()
-            );
-            appInstance.idleState = Idle;
-        } else {
-            Environment.sleep(Milliseconds(1.));
-        }
+        Environment.sleep(Milliseconds(1.));
       };
 
       if (Environment.isNative) {


### PR DESCRIPTION
__Issue:__ When idle, the application was still taking up appreciable CPU.

__Defect:__ This was a regression from #217 - we removed a 'sleep' that is used when the application is idle, to limit CPU impact.

__Fix:__ Bring back the removed sleep, and implement a state machine:
- App is running 'real-time' - do a minor collection
- App is transition from 'running' to 'idle' - do a full collection
- App is 'idle' - sleep for 1ms