### PR TITLE
Fix #180 - Crash when shrinking window

### DIFF
--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -46,7 +46,7 @@ class node ('a) (()) = {
       style.overflow,
       dimensions,
       parentContext.screenHeight,
-      float_of_int(parentContext.pixelRatio),
+      parentContext.pixelRatio,
       () => {
         let localContext =
           NodeDrawContext.createFromParent(parentContext, style.opacity);

--- a/src/UI/NodeDrawContext.re
+++ b/src/UI/NodeDrawContext.re
@@ -10,7 +10,8 @@ type t = {
   screenHeight: int,
 };
 
-let create = (pixelRatio: float, zIndex: int, opacity: float, screenHeight: int) => {
+let create =
+    (pixelRatio: float, zIndex: int, opacity: float, screenHeight: int) => {
   let ret: t = {zIndex, opacity, pixelRatio, screenHeight};
   ret;
 };

--- a/src/UI/NodeDrawContext.re
+++ b/src/UI/NodeDrawContext.re
@@ -6,11 +6,11 @@
 type t = {
   zIndex: int,
   opacity: float,
-  pixelRatio: int,
+  pixelRatio: float,
   screenHeight: int,
 };
 
-let create = (pixelRatio: int, zIndex: int, opacity: float, screenHeight: int) => {
+let create = (pixelRatio: float, zIndex: int, opacity: float, screenHeight: int) => {
   let ret: t = {zIndex, opacity, pixelRatio, screenHeight};
   ret;
 };

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -36,7 +36,9 @@ class textNode (text: string) = {
       let font =
         FontCache.load(
           style.fontFamily,
-          int_of_float(float_of_int(style.fontSize) *. parentContext.pixelRatio +. 0.5),
+          int_of_float(
+            float_of_int(style.fontSize) *. parentContext.pixelRatio +. 0.5,
+          ),
         );
       let dimensions = _super#measurements();
       let color = Color.multiplyAlpha(opacity, style.color);
@@ -81,10 +83,7 @@ class textNode (text: string) = {
         );
 
         let scaleTransform = Mat4.create();
-        Mat4.fromScaling(
-          scaleTransform,
-          Vec3.create(width, height, 1.0),
-        );
+        Mat4.fromScaling(scaleTransform, Vec3.create(width, height, 1.0));
 
         let local = Mat4.create();
         Mat4.multiply(local, glyphTransform, scaleTransform);

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -36,7 +36,7 @@ class textNode (text: string) = {
       let font =
         FontCache.load(
           style.fontFamily,
-          style.fontSize * parentContext.pixelRatio,
+          int_of_float(float_of_int(style.fontSize) *. parentContext.pixelRatio +. 0.5),
         );
       let dimensions = _super#measurements();
       let color = Color.multiplyAlpha(opacity, style.color);
@@ -57,11 +57,11 @@ class textNode (text: string) = {
 
         let {width, height, bearingX, bearingY, advance, _} = glyph;
 
-        let width = width / parentContext.pixelRatio;
-        let height = height / parentContext.pixelRatio;
-        let bearingX = bearingX / parentContext.pixelRatio;
-        let bearingY = bearingY / parentContext.pixelRatio;
-        let advance = advance / parentContext.pixelRatio;
+        let width = float_of_int(width) /. parentContext.pixelRatio;
+        let height = float_of_int(height) /. parentContext.pixelRatio;
+        let bearingX = float_of_int(bearingX) /. parentContext.pixelRatio;
+        let bearingY = float_of_int(bearingY) /. parentContext.pixelRatio;
+        let advance = float_of_int(advance) /. parentContext.pixelRatio;
 
         Glfw.glPixelStorei(GL_PACK_ALIGNMENT, 1);
         Glfw.glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
@@ -74,8 +74,8 @@ class textNode (text: string) = {
         Mat4.fromTranslation(
           glyphTransform,
           Vec3.create(
-            x +. float_of_int(bearingX) +. float_of_int(width) /. 2.,
-            float_of_int(height) *. 0.5 -. float_of_int(bearingY),
+            x +. bearingX +. width /. 2.,
+            height *. 0.5 -. bearingY,
             0.0,
           ),
         );
@@ -83,7 +83,7 @@ class textNode (text: string) = {
         let scaleTransform = Mat4.create();
         Mat4.fromScaling(
           scaleTransform,
-          Vec3.create(float_of_int(width), float_of_int(height), 1.0),
+          Vec3.create(width, height, 1.0),
         );
 
         let local = Mat4.create();
@@ -101,7 +101,7 @@ class textNode (text: string) = {
 
         Geometry.draw(quad, textureShader);
 
-        x +. float_of_int(advance) /. 64.0;
+        x +. advance /. 64.0;
       };
 
       let shapedText = FontRenderer.shape(font, text);

--- a/src/UI/UiRender.re
+++ b/src/UI/UiRender.re
@@ -72,7 +72,7 @@ let render = (container: UiContainer.t, component: UiReact.syntheticElement) => 
     );
 
     let drawContext =
-      NodeDrawContext.create(int_of_float(pixelRatio), 0, 1.0, size.height);
+      NodeDrawContext.create(pixelRatio, 0, 1.0, size.height);
 
     let solidPass = SolidPass(_projection);
     rootNode#draw(solidPass, drawContext);

--- a/src/UI/UiRender.re
+++ b/src/UI/UiRender.re
@@ -71,8 +71,7 @@ let render = (container: UiContainer.t, component: UiReact.syntheticElement) => 
       -1000.0,
     );
 
-    let drawContext =
-      NodeDrawContext.create(pixelRatio, 0, 1.0, size.height);
+    let drawContext = NodeDrawContext.create(pixelRatio, 0, 1.0, size.height);
 
     let solidPass = SolidPass(_projection);
     rootNode#draw(solidPass, drawContext);


### PR DESCRIPTION
__Issue:__ When shrinking the window (either by dragging to make the window smaller, or pressing the 'restore' button after maximizing), the app would crash with a division-by-zero error.

__Defect:__ During resize, there are some transient states with the resize where we calculate the pixel ratio as `0.99` - the `float_to_int` is a `floor` operation, so when we run `float_to_int(0.99)`, it gets converted to an integer of 0, and then the division operations down the road fail.

__Fix:__ Leave the floating point value and defer conversion until the endpoints. For usages in finding the font size, we need to convert to an integer at that point. For text, though, we can just use the floating point value as-is.