### PR TITLE
Example App: Animations keep running even after switching example

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -118,8 +118,9 @@ let init = app => {
         isActive
         name={x.name}
         onClick={(_) => {
-            /* TEMPORARY HACK: The animations don't always get stopped when switching examples,
-             * due to briskml/brisk-reconciler#8. We can remove this once it's fixed!
+            /*
+             * TEMPORARY WORKAROUND: The animations don't always get stopped when switching examples,
+             * tracked by briskml/brisk-reconciler#8. We can remove this once it's fixed!
              */
              Animated.cancelAll();
 

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -117,7 +117,14 @@ let init = app => {
       <ExampleButton
         isActive
         name={x.name}
-        onClick={_ => App.dispatch(app, SelectExample(x.name))}
+        onClick={(_) => {
+            /* TEMPORARY HACK: The animations don't always get stopped when switching examples,
+             * due to briskml/brisk-reconciler#8. We can remove this once it's fixed!
+             */
+             Animated.cancelAll();
+
+            App.dispatch(app, SelectExample(x.name));
+        }}
       />;
     };
 

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -117,14 +117,14 @@ let init = app => {
       <ExampleButton
         isActive
         name={x.name}
-        onClick={(_) => {
-            /*
-             * TEMPORARY WORKAROUND: The animations don't always get stopped when switching examples,
-             * tracked by briskml/brisk-reconciler#8. We can remove this once it's fixed!
-             */
-             Animated.cancelAll();
+        onClick={_ => {
+          /*
+           * TEMPORARY WORKAROUND: The animations don't always get stopped when switching examples,
+           * tracked by briskml/brisk-reconciler#8. We can remove this once it's fixed!
+           */
+          Animated.cancelAll();
 
-            App.dispatch(app, SelectExample(x.name));
+          App.dispatch(app, SelectExample(x.name));
         }}
       />;
     };

--- a/src/UI/Animation.re
+++ b/src/UI/Animation.re
@@ -121,6 +121,9 @@ module Make = (AnimationTickerImpl: AnimationTicker) => {
   let cancel = (anim: animation) =>
     activeAnimations := List.filter(a => a.id !== anim.id, activeAnimations^);
 
+  let cancelAll = () =>
+    activeAnimations := [];
+
   let tick = (t: float) => {
     List.iter(tickAnimation(t), activeAnimations^);
 


### PR DESCRIPTION
There's a bug with `OnMount` effects at the moment, tracked by https://github.com/briskml/brisk-reconciler/pull/8 . This causes some of our `OnMount` dispose handlers to not get called - and those are responsible for stopping the animations. Without that, the app will continue 'animating' even if it should stay idle.

This implements a temporary hack - when we switch examples, just stop all the animations. This won't be needed once that `OnMount` effect behavior is fixed, but for now this will workaround it.