### PR TITLE
UI - Slider: Separate styling for 'before' and 'after' track

### DIFF
--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -30,12 +30,12 @@ let reducer = (action, state) =>
   | UpdateText(t) =>
     state.isFocused ? {...state, value: addCharacter(state.value, t)} : state
   | Backspace =>
-    state.isFocused ?
-      {
+    state.isFocused
+      ? {
         let length = String.length(state.value);
         length > 0 ? {...state, value: removeCharacter(state.value)} : state;
-      } :
-      state
+      }
+      : state
   | ClearWord => {...state, value: ""}
   };
 
@@ -201,14 +201,14 @@ let make =
       ]
       |> (
         initial =>
-          hasPlaceholder ?
-            Style.[
-              position(`Absolute),
-              top(verticalAlignPos),
-              left(5),
-              ...initial,
-            ] :
-            initial
+          hasPlaceholder
+            ? Style.[
+                position(`Absolute),
+                top(verticalAlignPos),
+                left(5),
+                ...initial,
+              ]
+            : initial
       );
 
     /*

--- a/src/UI_Components/Slider.re
+++ b/src/UI_Components/Slider.re
@@ -142,7 +142,7 @@ let make =
         left(vertical ? trackMargins : thumbPosition + thumbWidth),
         right(vertical ? trackMargins : 0),
         position(`Absolute),
-        backgroundColor(backgroundColor),
+        backgroundColor(sliderBackgroundColor),
       ];
 
     <View onMouseDown style ref={r => setSlideRef(r)}>

--- a/src/UI_Components/Slider.re
+++ b/src/UI_Components/Slider.re
@@ -45,25 +45,25 @@ let make =
         let thumbDimensions: BoundingBox2d.t = thumb#getBoundingBox();
 
         let sliderWidth =
-          vertical ?
-            Vec2.get_y(sliderDimensions.max)
-            -. Vec2.get_y(sliderDimensions.min) :
-            Vec2.get_x(sliderDimensions.max)
-            -. Vec2.get_x(sliderDimensions.min);
+          vertical
+            ? Vec2.get_y(sliderDimensions.max)
+              -. Vec2.get_y(sliderDimensions.min)
+            : Vec2.get_x(sliderDimensions.max)
+              -. Vec2.get_x(sliderDimensions.min);
 
         let thumbWidth =
-          vertical ?
-            Vec2.get_y(thumbDimensions.max)
-            -. Vec2.get_y(thumbDimensions.min) :
-            Vec2.get_x(thumbDimensions.max)
-            -. Vec2.get_x(thumbDimensions.min);
+          vertical
+            ? Vec2.get_y(thumbDimensions.max)
+              -. Vec2.get_y(thumbDimensions.min)
+            : Vec2.get_x(thumbDimensions.max)
+              -. Vec2.get_x(thumbDimensions.min);
 
         let availableWidth = sliderWidth -. thumbWidth;
 
         let startPosition =
-          vertical ?
-            Vec2.get_y(sliderDimensions.min) :
-            Vec2.get_x(sliderDimensions.min);
+          vertical
+            ? Vec2.get_y(sliderDimensions.min)
+            : Vec2.get_x(sliderDimensions.min);
         let endPosition = startPosition +. availableWidth;
 
         let getValue = x =>

--- a/src/UI_Components/Slider.re
+++ b/src/UI_Components/Slider.re
@@ -133,17 +133,37 @@ let make =
 
     let thumbWidth = thumbLength;
 
-    let trackStyle =
+    let beforeTrackStyle =
       Style.make(
         ~opacity,
         ~top={
           vertical ? 0 : trackMargins;
         },
         ~bottom={
-          vertical ? 0 : trackMargins;
+          vertical ? sliderLength - thumbPosition : trackMargins;
         },
         ~left={
           vertical ? trackMargins : 0;
+        },
+        ~right={
+          vertical ? trackMargins : sliderLength - thumbPosition;
+        },
+        ~position=LayoutTypes.Absolute,
+        ~backgroundColor=Color.hex("#90f7ff"),
+        (),
+      );
+
+    let afterTrackStyle =
+      Style.make(
+        ~opacity,
+        ~top={
+          vertical ? thumbPosition + thumbWidth : trackMargins;
+        },
+        ~bottom={
+          vertical ? 0 : trackMargins;
+        },
+        ~left={
+          vertical ? trackMargins : thumbPosition + thumbWidth;
         },
         ~right={
           vertical ? trackMargins : 0;
@@ -154,7 +174,7 @@ let make =
       );
 
     <View onMouseDown style ref={r => setSlideRef(r)}>
-      <View style=trackStyle />
+      <View style=beforeTrackStyle />
       <View
         ref={r => setThumbRef(r)}
         style={Style.make(
@@ -167,6 +187,7 @@ let make =
           (),
         )}
       />
+      <View style=afterTrackStyle />
     </View>;
   });
 


### PR DESCRIPTION
This adds subtly different styling for the slider 'before' portion of the track and 'after' portion:

![slider-track-styling](https://user-images.githubusercontent.com/13532591/51509716-12004280-1daf-11e9-99f3-7e727996f6f0.gif)
