### PR TITLE
Enable optimized build output for JS target

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b5f20023f6e2705838cd616e85d8d0e0",
+  "checksum": "eb6ca7567a413bda44466421f9331d4b",
   "root": "revery@link:./package.json",
   "node": {
     "revery@link:./package.json": {
@@ -19,7 +19,7 @@
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce@d41d8cd9",
         "@opam/color@opam:0.2.0@8ef09171",
         "@esy-ocaml/reason@3.4.0@d41d8cd9",
-        "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#f545ba0@d41d8cd9"
+        "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#7901934@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1003@d41d8cd9", "@opam/odoc@opam:1.3.0@a3e1a29d",
@@ -1565,14 +1565,14 @@
       ],
       "devDependencies": []
     },
-    "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#f545ba0@d41d8cd9": {
+    "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#7901934@d41d8cd9": {
       "id":
-        "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#f545ba0@d41d8cd9",
+        "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#7901934@d41d8cd9",
       "name": "@brisk/brisk-reconciler",
-      "version": "github:briskml/brisk-reconciler#f545ba0",
+      "version": "github:briskml/brisk-reconciler#7901934",
       "source": {
         "type": "install",
-        "source": [ "github:briskml/brisk-reconciler#f545ba0" ]
+        "source": [ "github:briskml/brisk-reconciler#7901934" ]
       },
       "overrides": [],
       "dependencies": [

--- a/examples/index.html
+++ b/examples/index.html
@@ -6,6 +6,7 @@
         html, body {
             margin: 0px;
             padding: 0px;
+            background-color: #212733;
         }
         </style>
     </head>

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,6 +11,11 @@
     </head>
     <body>
         <script src="gl-matrix-min.js"></script>
+        <script>
+            // Compiled Examples.bc.js does a check for require,
+            // but it's not needed during runtime.
+            window.require = false;
+        </script>
         <script src="Examples.bc.js"></script>
     </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "@opam/cmdliner": "1.0.2",
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
-    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934",
-    "reason-fontkit": "link:../reason-fontkit"
+    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934"
   },
   "peerDependencies": {
     "ocaml": "^4.7.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@opam/cmdliner": "1.0.2",
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
-    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#f545ba0"
+    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934"
   },
   "peerDependencies": {
     "ocaml": "^4.7.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "bugs": { "url": "https://github.com/bryphe/revery/issues" },
   "scripts": {
     "build": "esy b",
-    "build:js": "esy b dune build examples/Bin.bc.js",
+    "build:release": "esy b dune build --profile=release --root . -j4",
+    "build:js": "esy b dune build examples/Examples.bc.js",
+    "build:js:release": "esy b dune build examples/Examples.bc.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "format": "esy b .ci/format.sh",
     "doc": "refmterr esy dune build @doc --root ."
@@ -41,7 +43,8 @@
     "@opam/cmdliner": "1.0.2",
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
-    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934"
+    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934",
+    "reason-fontkit": "link:../reason-fontkit"
   },
   "peerDependencies": {
     "ocaml": "^4.7.0"


### PR DESCRIPTION
__Issue:__ The 'debug' build of our 'Examples.bc.js' (the JavaScript build of our example app) is ~10MB. That would be a quite a lot to expect someone to download!

This adds an `esy build:release` command that uses Dune's release profile to emit a smaller output. After the change, its around ~750KB.

However, there were a few small blockers fixed in this PR and https://github.com/revery-ui/reason-fontkit/pull/17 to enable this.

Have a placeholder site up with an inline demo of our JS+WebGL build (still VERY WIP) - https://5c4a7c5587220f76e47df405--compassionate-aryabhata-b8425c.netlify.com/revery/

