### PR TITLE
Bugfix: Failure to build GLFW when MingW cross-compiler toolchain is present

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "67ccffbb675f5d75ae4de61c20c4494c",
+  "checksum": "1d81663c61856d7ddee79cf574285e40",
   "root": "revery@link:./package.json",
   "node": {
     "revery@link:./package.json": {
@@ -79,8 +79,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.1.10@d41d8cd9", "reason-gl-matrix@0.9.9302@d41d8cd9",
-        "ocaml@4.7.1003@d41d8cd9",
-        "esy-glfw@github:esy-packages/esy-glfw#f54c461@d41d8cd9",
+        "ocaml@4.7.1003@d41d8cd9", "esy-glfw@3.2.1009@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/lwt_ppx@opam:1.2.1@db1172a7",
         "@opam/lwt@opam:4.1.0@111fc2bf",
         "@opam/js_of_ocaml-lwt@opam:3.3.0@ff746e31",
@@ -174,13 +173,15 @@
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
       "devDependencies": []
     },
-    "esy-glfw@github:esy-packages/esy-glfw#f54c461@d41d8cd9": {
-      "id": "esy-glfw@github:esy-packages/esy-glfw#f54c461@d41d8cd9",
+    "esy-glfw@3.2.1009@d41d8cd9": {
+      "id": "esy-glfw@3.2.1009@d41d8cd9",
       "name": "esy-glfw",
-      "version": "github:esy-packages/esy-glfw#f54c461",
+      "version": "3.2.1009",
       "source": {
         "type": "install",
-        "source": [ "github:esy-packages/esy-glfw#f54c461" ]
+        "source": [
+          "archive:https://registry.npmjs.org/esy-glfw/-/esy-glfw-3.2.1009.tgz#sha1:48bbd3cb0b8f63f6f8bbfa5fd77284605f26c80b"
+        ]
       },
       "overrides": [],
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "c661b78bcd7c5cad47e0df079e25f169",
+  "checksum": "67ccffbb675f5d75ae4de61c20c4494c",
   "root": "revery@link:./package.json",
   "node": {
     "revery@link:./package.json": {
@@ -80,7 +80,7 @@
       "dependencies": [
         "refmterr@3.1.10@d41d8cd9", "reason-gl-matrix@0.9.9302@d41d8cd9",
         "ocaml@4.7.1003@d41d8cd9",
-        "esy-glfw@github:esy-packages/esy-glfw#638b5d3@d41d8cd9",
+        "esy-glfw@github:esy-packages/esy-glfw#f54c461@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/lwt_ppx@opam:1.2.1@db1172a7",
         "@opam/lwt@opam:4.1.0@111fc2bf",
         "@opam/js_of_ocaml-lwt@opam:3.3.0@ff746e31",
@@ -174,13 +174,13 @@
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
       "devDependencies": []
     },
-    "esy-glfw@github:esy-packages/esy-glfw#638b5d3@d41d8cd9": {
-      "id": "esy-glfw@github:esy-packages/esy-glfw#638b5d3@d41d8cd9",
+    "esy-glfw@github:esy-packages/esy-glfw#f54c461@d41d8cd9": {
+      "id": "esy-glfw@github:esy-packages/esy-glfw#f54c461@d41d8cd9",
       "name": "esy-glfw",
-      "version": "github:esy-packages/esy-glfw#638b5d3",
+      "version": "github:esy-packages/esy-glfw#f54c461",
       "source": {
         "type": "install",
-        "source": [ "github:esy-packages/esy-glfw#638b5d3" ]
+        "source": [ "github:esy-packages/esy-glfw#f54c461" ]
       },
       "overrides": [],
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "1d81663c61856d7ddee79cf574285e40",
+  "checksum": "c661b78bcd7c5cad47e0df079e25f169",
   "root": "revery@link:./package.json",
   "node": {
     "revery@link:./package.json": {
@@ -79,7 +79,8 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.1.10@d41d8cd9", "reason-gl-matrix@0.9.9302@d41d8cd9",
-        "ocaml@4.7.1003@d41d8cd9", "esy-glfw@3.2.1008@d41d8cd9",
+        "ocaml@4.7.1003@d41d8cd9",
+        "esy-glfw@github:esy-packages/esy-glfw#638b5d3@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/lwt_ppx@opam:1.2.1@db1172a7",
         "@opam/lwt@opam:4.1.0@111fc2bf",
         "@opam/js_of_ocaml-lwt@opam:3.3.0@ff746e31",
@@ -173,15 +174,13 @@
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
       "devDependencies": []
     },
-    "esy-glfw@3.2.1008@d41d8cd9": {
-      "id": "esy-glfw@3.2.1008@d41d8cd9",
+    "esy-glfw@github:esy-packages/esy-glfw#638b5d3@d41d8cd9": {
+      "id": "esy-glfw@github:esy-packages/esy-glfw#638b5d3@d41d8cd9",
       "name": "esy-glfw",
-      "version": "3.2.1008",
+      "version": "github:esy-packages/esy-glfw#638b5d3",
       "source": {
         "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/esy-glfw/-/esy-glfw-3.2.1008.tgz#sha1:0f161ccdc9fc9d1c66679739b710ca217708f4b4"
-        ]
+        "source": [ "github:esy-packages/esy-glfw#638b5d3" ]
       },
       "overrides": [],
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "@opam/cmdliner": "1.0.2",
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
-    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934"
+    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934",
+    "esy-glfw": "github:esy-packages/esy-glfw#638b5d3"
   },
   "peerDependencies": {
     "ocaml": "^4.7.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
     "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934",
-    "esy-glfw": "github:esy-packages/esy-glfw#638b5d3"
+    "esy-glfw": "github:esy-packages/esy-glfw#f54c461"
   },
   "peerDependencies": {
     "ocaml": "^4.7.0"

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "@opam/cmdliner": "1.0.2",
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
-    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934",
-    "esy-glfw": "github:esy-packages/esy-glfw#f54c461"
+    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934"
   },
   "peerDependencies": {
     "ocaml": "^4.7.0"


### PR DESCRIPTION
Similiar issue as #266 , but impacting `esy-glfw`. This brings in the fix for esy-glfw in esy-packages/esy-glfw#1 

This should address the next issue in #209 