### PR TITLE
Native Integration: Platform alert dialog

### DIFF
--- a/Revery_Native.opam
+++ b/Revery_Native.opam
@@ -1,0 +1,7 @@
+opam-version: "1.2"
+version: "dev"
+maintainer: "bryphe@outlook.com"
+author: ["Bryan Phelps"]
+build: [
+
+]

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "2f7d5682e52b8533cfa0cd393ad506b0",
+  "checksum": "172de2e0481d422d5d08539ac434ba67",
   "root": "revery@link:./package.json",
   "node": {
     "revery@link:./package.json": {
@@ -9,7 +9,7 @@
       "source": { "type": "link", "path": ".", "manifest": "package.json" },
       "overrides": [],
       "dependencies": [
-        "reason-glfw@github:bryphe/reason-glfw#d6c5f44@d41d8cd9",
+        "reason-glfw@3.2.1013@d41d8cd9",
         "reason-gl-matrix@0.9.9302@d41d8cd9",
         "reason-fontkit@2.0.6@d41d8cd9", "ocaml@4.7.1003@d41d8cd9",
         "flex@1.2.2@d41d8cd9", "@opam/lwt_ppx@opam:1.2.1@db1172a7",
@@ -66,13 +66,15 @@
       ],
       "devDependencies": []
     },
-    "reason-glfw@github:bryphe/reason-glfw#d6c5f44@d41d8cd9": {
-      "id": "reason-glfw@github:bryphe/reason-glfw#d6c5f44@d41d8cd9",
+    "reason-glfw@3.2.1013@d41d8cd9": {
+      "id": "reason-glfw@3.2.1013@d41d8cd9",
       "name": "reason-glfw",
-      "version": "github:bryphe/reason-glfw#d6c5f44",
+      "version": "3.2.1013",
       "source": {
         "type": "install",
-        "source": [ "github:bryphe/reason-glfw#d6c5f44" ]
+        "source": [
+          "archive:https://registry.npmjs.org/reason-glfw/-/reason-glfw-3.2.1013.tgz#sha1:042b0bdcde972a558c28bcfcefad0a2b1facd062"
+        ]
       },
       "overrides": [],
       "dependencies": [
@@ -118,8 +120,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.1.10@d41d8cd9",
-        "reason-glfw@github:bryphe/reason-glfw#d6c5f44@d41d8cd9",
+        "refmterr@3.1.10@d41d8cd9", "reason-glfw@3.2.1013@d41d8cd9",
         "reason-gl-matrix@0.9.9302@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.6.3@a7d7baed",

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -35,6 +35,7 @@ let state: state = {
     {name: "Box Shadow", render: _ => Boxshadow.render()},
     {name: "Focus", render: _ => Focus.render()},
     {name: "Stopwatch", render: _ => Stopwatch.render()},
+    {name: "Native", render: w => Native.render(w)},
     {name: "Input", render: w => InputExample.render(w)},
     {name: "Radio Button", render: _ => RadioButtonExample.render()},
     {name: "Game Of Life", render: _ => GameOfLife.render()},

--- a/examples/Native.re
+++ b/examples/Native.re
@@ -11,15 +11,16 @@ module NativeExamples = {
         Dialog.alert(window, "Hello, world");
       };
 
-      let containerStyle = Style.[
-      position(`Absolute),
-      justifyContent(`Center),
-      alignItems(`Center),
-      bottom(0),
-      top(0),
-      left(0),
-      right(0),
-    ];
+      let containerStyle =
+        Style.[
+          position(`Absolute),
+          justifyContent(`Center),
+          alignItems(`Center),
+          bottom(0),
+          top(0),
+          left(0),
+          right(0),
+        ];
 
       <View style=containerStyle>
         <Button title="Alert" onClick=increment />

--- a/examples/Native.re
+++ b/examples/Native.re
@@ -11,15 +11,23 @@ module NativeExamples = {
         Dialog.alert(window, "Hello, world");
       };
 
-      let containerStyle =
-        Style.[justifyContent(`Center), alignItems(`Center)];
+      let containerStyle = Style.[
+      position(`Absolute),
+      justifyContent(`Center),
+      alignItems(`Center),
+      bottom(0),
+      top(0),
+      left(0),
+      right(0),
+    ];
 
       <View style=containerStyle>
         <Button title="Alert" onClick=increment />
       </View>;
     });
 
-  let createElement = (~children as _, ~window, ()) => React.element(make(~window, ()));
+  let createElement = (~children as _, ~window, ()) =>
+    React.element(make(~window, ()));
 };
 
-let render = (window) => <View> <NativeExamples window /> </View>;
+let render = window => <NativeExamples window />;

--- a/examples/Native.re
+++ b/examples/Native.re
@@ -1,0 +1,25 @@
+open Revery.UI;
+open Revery.UI.Components;
+open Revery.Platform;
+
+module NativeExamples = {
+  let component = React.component("DefaultButtonWithCounter");
+
+  let make = (~window, ()) =>
+    component((_slots: React.Hooks.empty) => {
+      let increment = () => {
+        Dialog.alert(window, "Hello, world");
+      };
+
+      let containerStyle =
+        Style.[justifyContent(`Center), alignItems(`Center)];
+
+      <View style=containerStyle>
+        <Button title="Alert" onClick=increment />
+      </View>;
+    });
+
+  let createElement = (~children as _, ~window, ()) => React.element(make(~window, ()));
+};
+
+let render = (window) => <View> <NativeExamples window /> </View>;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@esy-ocaml/reason": "3.4.0",
-    "reason-glfw": "^3.2.1010",
+    "reason-glfw": "^3.2.1013",
     "reason-fontkit": "^2.0.6",
     "reason-gl-matrix": "^0.9.9302",
     "@opam/color": "^0.2.0",
@@ -45,8 +45,7 @@
     "@opam/cmdliner": "1.0.2",
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
-    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934",
-    "reason-glfw": "github:bryphe/reason-glfw#d6c5f44"
+    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934"
   },
   "peerDependencies": {
     "ocaml": "^4.7.0"

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
   "esy": {
     "build": [ "dune build --root . -j4" ],
     "install": [
-      "esy-installer Revery.install", "esy-installer Revery_Core.install",
+      "esy-installer Revery.install",
+      "esy-installer Revery_Core.install",
       "esy-installer Revery_Geometry.install",
       "esy-installer Revery_Math.install",
+      "esy-installer Revery_Native.install",
       "esy-installer Revery_Shaders.install",
       "esy-installer Revery_UI.install",
       "esy-installer Revery_UI_Components.install"
@@ -43,7 +45,8 @@
     "@opam/cmdliner": "1.0.2",
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
-    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934"
+    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934",
+    "reason-glfw": "github:bryphe/reason-glfw#d6c5f44"
   },
   "peerDependencies": {
     "ocaml": "^4.7.0"

--- a/src/Native/Dialog.re
+++ b/src/Native/Dialog.re
@@ -1,3 +1,5 @@
 open Reglfw.Glfw;
 
-external showAlert: (NativeWindow.t, string) => unit = "revery_showAlert";
+[@noalloc] external alertSupported: unit => bool = "revery_alertSupported";
+
+[@noalloc] external alert: (NativeWindow.t, string) => unit = "revery_showAlert";

--- a/src/Native/Dialog.re
+++ b/src/Native/Dialog.re
@@ -1,5 +1,3 @@
-open Reglfw;
+open Reglfw.Glfw;
 
-external supportsMessageBox: unit => bool = "revery_supportsMessageBox";
-
-external showMessageBox: (NativeWindow.t, string, string) => "revery_showMessageBox";
+external showAlert: (NativeWindow.t, string) => unit = "revery_showAlert";

--- a/src/Native/Dialog.re
+++ b/src/Native/Dialog.re
@@ -1,0 +1,5 @@
+open Reglfw;
+
+external supportsMessageBox: unit => bool = "revery_supportsMessageBox";
+
+external showMessageBox: (NativeWindow.t, string, string) => "revery_showMessageBox";

--- a/src/Native/Dialog.re
+++ b/src/Native/Dialog.re
@@ -2,4 +2,4 @@ open Reglfw.Glfw;
 
 [@noalloc] external alertSupported: unit => bool = "revery_alertSupported";
 
-[@noalloc] external alert: (NativeWindow.t, string) => unit = "revery_showAlert";
+[@noalloc] external alert: (NativeWindow.t, string) => unit = "revery_alert";

--- a/src/Native/ReveryCocoa.h
+++ b/src/Native/ReveryCocoa.h
@@ -1,0 +1,3 @@
+extern "C" {	
+   void revery_alert_cocoa(void* pWin, const char* szMessage);
+}

--- a/src/Native/ReveryWin32.h
+++ b/src/Native/ReveryWin32.h
@@ -1,0 +1,3 @@
+extern "C" {	
+   void revery_alert_win32(void *pWin, const char* szMessage);
+}

--- a/src/Native/Revery_Native.re
+++ b/src/Native/Revery_Native.re
@@ -1,0 +1,1 @@
+module Dialog = Dialog;

--- a/src/Native/config/discover.ml
+++ b/src/Native/config/discover.ml
@@ -17,7 +17,11 @@ let get_os =
                         | "Darwin" -> Mac
                                 | "Linux" -> Linux
                                         | _ -> Unknown
-let c_flags = ["-I"; "."; "-x"; "objective-c"]
+let c_flags = match get_os with
+    | Mac -> ["-I"; "."; "-x"; "objective-c"]
+    | _ -> []
+;;
+
 let flags = []
 ;;
 Configurator.V1.Flags.write_sexp "c_flags.sexp" c_flags;

--- a/src/Native/config/discover.ml
+++ b/src/Native/config/discover.ml
@@ -1,28 +1,21 @@
 type os =
-    | Windows
-            | Mac
-                | Linux
-                    | Unknown
-
+  | Windows 
+  | Mac 
+  | Linux 
+  | Unknown 
 let uname () =
-    let ic = Unix.open_process_in "uname" in
-    let uname = input_line ic in
-    let () = close_in ic in
-    uname;;
-
-let get_os = 
-    match Sys.os_type with
-    | "Win32" -> Windows
-                | _ -> match uname () with
-                        | "Darwin" -> Mac
-                                | "Linux" -> Linux
-                                        | _ -> Unknown
-let c_flags = match get_os with
-    | Mac -> ["-I"; "."; "-x"; "objective-c"]
-    | _ -> []
-;;
-
+  let ic = Unix.open_process_in "uname" in
+  let uname = input_line ic in let () = close_in ic in uname
+let get_os =
+  match Sys.os_type with
+  | "Win32" -> Windows
+  | _ ->
+      (match uname () with
+       | "Darwin" -> Mac
+       | "Linux" -> Linux
+       | _ -> Unknown)
+let c_flags =
+  match get_os with | Mac -> ["-I"; "."; "-x"; "objective-c"] | _ -> []
 let flags = []
-;;
-Configurator.V1.Flags.write_sexp "c_flags.sexp" c_flags;
-Configurator.V1.Flags.write_sexp "flags.sexp" flags;
+;;Configurator.V1.Flags.write_sexp "c_flags.sexp" c_flags;
+  Configurator.V1.Flags.write_sexp "flags.sexp" flags

--- a/src/Native/config/discover.ml
+++ b/src/Native/config/discover.ml
@@ -12,17 +12,13 @@ let uname () =
 
 let get_os = 
     match Sys.os_type with
-            | "Win32" -> Windows
+    | "Win32" -> Windows
                 | _ -> match uname () with
                         | "Darwin" -> Mac
                                 | "Linux" -> Linux
                                         | _ -> Unknown
-
-
-let c_names = [];
-let c_flags = [];
-let flags = [];
-
-Configurator.V1.Flags.write_sexp "c_names.sexp" c_names;
+let c_flags = []
+let flags = []
+;;
 Configurator.V1.Flags.write_sexp "c_flags.sexp" c_flags;
 Configurator.V1.Flags.write_sexp "flags.sexp" flags;

--- a/src/Native/config/discover.ml
+++ b/src/Native/config/discover.ml
@@ -1,0 +1,28 @@
+type os =
+    | Windows
+            | Mac
+                | Linux
+                    | Unknown
+
+let uname () =
+    let ic = Unix.open_process_in "uname" in
+    let uname = input_line ic in
+    let () = close_in ic in
+    uname;;
+
+let get_os = 
+    match Sys.os_type with
+            | "Win32" -> Windows
+                | _ -> match uname () with
+                        | "Darwin" -> Mac
+                                | "Linux" -> Linux
+                                        | _ -> Unknown
+
+
+let c_names = [];
+let c_flags = [];
+let flags = [];
+
+Configurator.V1.Flags.write_sexp "c_names.sexp" c_names;
+Configurator.V1.Flags.write_sexp "c_flags.sexp" c_flags;
+Configurator.V1.Flags.write_sexp "flags.sexp" flags;

--- a/src/Native/config/discover.ml
+++ b/src/Native/config/discover.ml
@@ -17,7 +17,7 @@ let get_os =
                         | "Darwin" -> Mac
                                 | "Linux" -> Linux
                                         | _ -> Unknown
-let c_flags = []
+let c_flags = ["-I"; "."; "-x"; "objective-c"]
 let flags = []
 ;;
 Configurator.V1.Flags.write_sexp "c_flags.sexp" c_flags;

--- a/src/Native/config/dune
+++ b/src/Native/config/dune
@@ -1,0 +1,3 @@
+(executable
+    (name discover)
+    (libraries dune.configurator))

--- a/src/Native/dialog.c
+++ b/src/Native/dialog.c
@@ -1,1 +1,0 @@
-#include "dialog_win32.c"

--- a/src/Native/dialog.c
+++ b/src/Native/dialog.c
@@ -1,10 +1,1 @@
-#include <stdio.h>
-
-#include <caml/mlvalues.h>
-#include <caml/memory.h>
-#include <caml/alloc.h>
-#include <caml/callback.h>
-
-void alert() {
-    printf("MESSAGE: %s\n", message);
-}
+#include "dialog_win32.c"

--- a/src/Native/dialog.c
+++ b/src/Native/dialog.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/callback.h>
+
+void alert() {
+    printf("MESSAGE: %s\n", message);
+}

--- a/src/Native/dialog.cpp
+++ b/src/Native/dialog.cpp
@@ -30,10 +30,11 @@ revery_alert(value vWindow, value vMessage) {
     void* pWin = (void *)vWindow;
 
 #ifdef WIN32
-    revery_alert_win32(pWin, szMessage); 
+    revery_alert_win32(pWin, szMessage);
 #elif __APPLE__
     revery_alert_cocoa(pWin, szMessage);
 #else
+    printf("WARNING - Not implemented: alert");
 #endif
     return Val_unit;
 }

--- a/src/Native/dialog.cpp
+++ b/src/Native/dialog.cpp
@@ -12,30 +12,30 @@
 #endif
 
 extern "C" {
-CAMLprim value
-revery_alertSupported() {
-#ifdef WIN32
-    return Val_true;
-#elif __APPLE__
-    return Val_true;
-#else
-    return Val_false;
-#endif
-}
+  CAMLprim value
+  revery_alertSupported() {
+  #ifdef WIN32
+      return Val_true;
+  #elif __APPLE__
+      return Val_true;
+  #else
+      return Val_false;
+  #endif
+  }
 
-CAMLprim value
-revery_alert(value vWindow, value vMessage) {
-    CAMLparam2(vWindow, vMessage);
-    const char *szMessage = String_val(vMessage);
-    void* pWin = (void *)vWindow;
+  CAMLprim value
+  revery_alert(value vWindow, value vMessage) {
+      CAMLparam2(vWindow, vMessage);
+      const char *szMessage = String_val(vMessage);
+      void* pWin = (void *)vWindow;
 
-#ifdef WIN32
-    revery_alert_win32(pWin, szMessage);
-#elif __APPLE__
-    revery_alert_cocoa(pWin, szMessage);
-#else
-    printf("WARNING - Not implemented: alert");
-#endif
-    return Val_unit;
-}
+  #ifdef WIN32
+      revery_alert_win32(pWin, szMessage);
+  #elif __APPLE__
+      revery_alert_cocoa(pWin, szMessage);
+  #else
+      printf("WARNING - Not implemented: alert");
+  #endif
+      return Val_unit;
+  }
 }

--- a/src/Native/dialog.cpp
+++ b/src/Native/dialog.cpp
@@ -1,0 +1,40 @@
+#include <stdio.h>
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/callback.h>
+
+#ifdef WIN32
+  #include "ReveryWin32.h"
+#elif __APPLE__
+  #include "ReveryCocoa.h"
+#endif
+
+extern "C" {
+CAMLprim value
+revery_alertSupported() {
+#ifdef WIN32
+    return Val_true;
+#elif __APPLE__
+    return Val_true;
+#else
+    return Val_false;
+#endif
+}
+
+CAMLprim value
+revery_alert(value vWindow, value vMessage) {
+    CAMLparam2(vWindow, vMessage);
+    const char *szMessage = String_val(vMessage);
+    void* pWin = (void *)vWindow;
+
+#ifdef WIN32
+    revery_alert_win32(pWin, szMessage); 
+#elif __APPLE__
+    revery_alert_cocoa(pWin, szMessage);
+#else
+#endif
+    return Val_unit;
+}
+}

--- a/src/Native/dialog.js
+++ b/src/Native/dialog.js
@@ -1,4 +1,9 @@
+// Provides: revery_alertSupported
+function revery_alertSupported() {
+    return true;
+}
+
 // Provides: revery_alert
 function revery_alert(win, msg) {
-    alert(msg);
+    joo_global_object.alert(msg);
 }

--- a/src/Native/dialog.js
+++ b/src/Native/dialog.js
@@ -1,0 +1,4 @@
+// Provides: revery_alert
+function revery_alert(win, msg) {
+    alert(msg);
+}

--- a/src/Native/dialog_cocoa.c
+++ b/src/Native/dialog_cocoa.c
@@ -7,9 +7,10 @@ void revery_alert_cocoa(void *pWin, const char *szMessage) {
 
     NSView *view = [[NSView alloc] init];
     NSAlert *alert = [[NSAlert alloc] init];
+    NSString *message = [NSString stringWithUTF8String:szMessage];
     [alert addButtonWithTitle:@"Ok"];
     [alert setMessageText:@"Alert"];
-    [alert setInformativeText:@"Info"];
+    [alert setInformativeText:message];
     [alert runModal];
 
 

--- a/src/Native/dialog_cocoa.c
+++ b/src/Native/dialog_cocoa.c
@@ -1,3 +1,4 @@
+#ifdef __APPLE__
 #include <stdio.h>
 
 #import <Cocoa/Cocoa.h>
@@ -12,7 +13,5 @@ void revery_alert_cocoa(void *pWin, const char *szMessage) {
     [alert setMessageText:@"Alert"];
     [alert setInformativeText:message];
     [alert runModal];
-
-
-    printf("ALERT: %s - hwnd: %p\n", szMessage, pCocoaWin);
 }
+#endif

--- a/src/Native/dialog_cocoa.c
+++ b/src/Native/dialog_cocoa.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+#import <Cocoa/Cocoa.h>
+
+void revery_alert_cocoa(void *pWin, const char *szMessage) {
+    NSWindow* pCocoaWin  = (NSWindow *)pWin;
+
+    NSView *view = [[NSView alloc] init];
+    NSAlert *alert = [[NSAlert alloc] init];
+    [alert addButtonWithTitle:@"Ok"];
+    [alert setMessageText:@"Alert"];
+    [alert setInformativeText:@"Info"];
+    [alert runModal];
+
+
+    printf("ALERT: %s - hwnd: %p\n", szMessage, pCocoaWin);
+}

--- a/src/Native/dialog_win32.c
+++ b/src/Native/dialog_win32.c
@@ -1,3 +1,5 @@
+#ifdef WIN32
+
 #include <stdio.h>
 
 #include <Windows.h>
@@ -13,6 +15,5 @@ revery_alert_win32(void *pWin, const char *szMessage) {
             "Alert",
             MB_ICONWARNING | MB_OK
             );
-
-    printf("ALERT: %s - hwnd: %p\n", szMessage, hwnd);
 }
+#endif

--- a/src/Native/dialog_win32.c
+++ b/src/Native/dialog_win32.c
@@ -1,24 +1,11 @@
 #include <stdio.h>
 
-#include <caml/mlvalues.h>
-#include <caml/memory.h>
-#include <caml/alloc.h>
-#include <caml/callback.h>
-
 #include <Windows.h>
 #include <winuser.h>
 
-CAMLprim value
-revery_alertSupported() {
-    return Val_true;
-}
-
-CAMLprim value
-revery_alert(value vWindow, value vMessage) {
-    CAMLparam2(vWindow, vMessage);
-
-    const char *szMessage = String_val(vMessage);
-    HWND hwnd = (HWND)vWindow;
+void
+revery_alert_win32(void *pWin, const char *szMessage) {
+    HWND hwnd = (HWND)pWin;
 
     int msgboxId = MessageBox(
             hwnd,
@@ -28,5 +15,4 @@ revery_alert(value vWindow, value vMessage) {
             );
 
     printf("ALERT: %s - hwnd: %p\n", szMessage, hwnd);
-    return Val_unit;
 }

--- a/src/Native/dialog_win32.c
+++ b/src/Native/dialog_win32.c
@@ -1,0 +1,32 @@
+#include <stdio.h>
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/callback.h>
+
+#include <Windows.h>
+#include <winuser.h>
+
+CAMLprim value
+revery_alertSupported() {
+    return Val_true;
+}
+
+CAMLprim value
+revery_alert(value vWindow, value vMessage) {
+    CAMLparam2(vWindow, vMessage);
+
+    const char *szMessage = String_val(vMessage);
+    HWND hwnd = (HWND)vWindow;
+
+    int msgboxId = MessageBox(
+            hwnd,
+            szMessage,
+            "Alert",
+            MB_ICONWARNING | MB_OK
+            );
+
+    printf("ALERT: %s - hwnd: %p\n", szMessage, hwnd);
+    return Val_unit;
+}

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -3,7 +3,7 @@
     (public_name Revery_Native)
     (preprocess (pps lwt_ppx))
     (library_flags (:include flags.sexp))
-    (c_names dialog_win32)
+    (c_names dialog)
     (c_flags (:include c_flags.sexp))
     (libraries reglfw))
 

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -1,5 +1,5 @@
 (library
-    (name Revery_Dune)
-    (public_name Revery_Dune)
+    (name Revery_Native)
+    (public_name Revery_Native)
     (preprocess (pps lwt_ppx))
     (libraries reglfw))

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -3,7 +3,7 @@
     (public_name Revery_Native)
     (preprocess (pps lwt_ppx))
     (library_flags (:include flags.sexp))
-    (c_names dialog_cocoa)
+    (c_names dialog_cocoa dialog_win32)
     (cxx_names dialog)
     (c_flags (:include c_flags.sexp))
     (libraries reglfw))

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -3,7 +3,8 @@
     (public_name Revery_Native)
     (preprocess (pps lwt_ppx))
     (library_flags (:include flags.sexp))
-    (c_names dialog)
+    (c_names dialog_cocoa)
+    (cxx_names dialog)
     (c_flags (:include c_flags.sexp))
     (libraries reglfw))
 

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -3,6 +3,7 @@
     (public_name Revery_Native)
     (preprocess (pps lwt_ppx))
     (library_flags (:include flags.sexp))
+    (js_of_ocaml (javascript_files dialog.js))
     (c_names dialog_cocoa dialog_win32)
     (cxx_names dialog)
     (c_flags (:include c_flags.sexp))

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -2,4 +2,12 @@
     (name Revery_Native)
     (public_name Revery_Native)
     (preprocess (pps lwt_ppx))
+    (library_flags (:include flags.sexp))
+    (c_names dialog_win32)
+    (c_flags (:include c_flags.sexp))
     (libraries reglfw))
+
+(rule
+(targets c_flags.sexp flags.sexp)
+(deps (:discover config/discover.exe))
+(action (run %{discover})))

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -1,0 +1,5 @@
+(library
+    (name Revery_Dune)
+    (public_name Revery_Dune)
+    (preprocess (pps lwt_ppx))
+    (libraries reglfw))

--- a/src/Platform.re
+++ b/src/Platform.re
@@ -1,0 +1,29 @@
+/**
+ * Platform.re
+ *
+ * Thin convenience wrapper over the Revery_Native module.
+ *
+ * Why a wrapper? A couple reasons:
+ * 1) Coerce the `Window.t` type to `NativeWindow.t` transparently, so it doesn't have to be handled in user-space
+ *  2) More importantly, some Platform primitives may need to be 'emulated'. For example, for X11, I'm not sure how to implement dialogs.
+ */
+
+open Reglfw;
+
+module Window = Revery_Core.Window;
+module Native = Revery_Native;
+
+module Dialog {
+    let alert = (window: Window.t, message: string) => {
+        if (Native.Dialog.alertSupported()) {
+            let nativeWindow = window
+                |> w => w.glfwWindow
+                |> Glfw.glfwGetNativeWindow;
+            Native.Dialog.alert(nativeWindow, message);
+        } else {
+            /* TODO */
+            /* Fallback when not supported on a platform */
+            prerr_endline ("WARNING: alert not supported on this platform");
+        }
+    };
+}

--- a/src/Platform.re
+++ b/src/Platform.re
@@ -7,23 +7,22 @@
  * 1) Coerce the `Window.t` type to `NativeWindow.t` transparently, so it doesn't have to be handled in user-space
  *  2) More importantly, some Platform primitives may need to be 'emulated'. For example, for X11, I'm not sure how to implement dialogs.
  */
-
 open Reglfw;
 
 module Window = Revery_Core.Window;
 module Native = Revery_Native;
 
-module Dialog {
-    let alert = (window: Window.t, message: string) => {
-        if (Native.Dialog.alertSupported()) {
-            let nativeWindow = window
-                |> w => w.glfwWindow
-                |> Glfw.glfwGetNativeWindow;
-            Native.Dialog.alert(nativeWindow, message);
-        } else {
-            /* TODO */
-            /* Fallback when not supported on a platform */
-            prerr_endline ("WARNING: alert not supported on this platform");
-        }
+module Dialog = {
+  let alert = (window: Window.t, message: string) =>
+    if (Native.Dialog.alertSupported()) {
+      let nativeWindow =
+        window |> (w => w.glfwWindow |> Glfw.glfwGetNativeWindow);
+      Native.Dialog.alert(nativeWindow, message);
+    } else {
+      /* TODO */
+      /* Fallback when not supported on a platform */
+      prerr_endline(
+        "WARNING: alert not supported on this platform",
+      );
     };
-}
+};

--- a/src/Revery.re
+++ b/src/Revery.re
@@ -16,5 +16,5 @@ module Window = Core.Window;
 module Time = Core.Time;
 
 module Platform = {
-    include Platform;
-}
+  include Platform;
+};

--- a/src/Revery.re
+++ b/src/Revery.re
@@ -16,5 +16,5 @@ module Window = Core.Window;
 module Time = Core.Time;
 
 module Platform = {
-    include Revery_Native;
+    include Platform;
 }

--- a/src/Revery.re
+++ b/src/Revery.re
@@ -14,3 +14,7 @@ module UI = {
 module App = Core.App;
 module Window = Core.Window;
 module Time = Core.Time;
+
+module Platform = {
+    include Revery_Native;
+}

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
     (name Revery)
     (public_name Revery)
-    (libraries lwt lwt.unix reglfw Revery_Core Revery_Math Revery_Shaders Revery_Geometry Revery_UI Revery_UI_Components))
+    (libraries lwt lwt.unix reglfw Revery_Core Revery_Math Revery_Shaders Revery_Geometry Revery_UI Revery_UI_Components Revery_Native))


### PR DESCRIPTION
This is a proposal for how we could (potentially) implement a native layer for Revery, re #250 #249 

This adds a `Revery_Native` module (which actually talks to the native Win32/Cocoa APIs). An open question is how we'll implement support on Linux platforms - what's the best way to handle this in X11? I see some apps "roll their own" platform dialogs, which seems pretty intense. I'm leaving this stubbed out for now, but perhaps someone more knowledgeable than me in X11 can help out.

This is what the 'native' example looks like on Windows:
![native alert](https://user-images.githubusercontent.com/13532591/51879563-d6262980-2328-11e9-817f-6f3cfda6fbfc.gif)

Also works on OSX (Cocoa) and JS with these changes. The Linux/X11 strategy is just a stub right now.

This depends on the work done in bryphe/reason-glfw#89 to expose a `glfwGetNativeWindow` API, which gives us access to the platform-specific window.

There is also a wrapper on top - these are accessible via the `Revery.Platform` API. The reason for the indirection is that, if we need to implement these primitives on the Revery side, we could check if the functionality is available (ie, via `Revery_Native.Dialog.alertSupported()`), and then, if it isn't, create a Revery-based fallback.

There's also some messiness in terms of how we cast from the `value` -> `void *` -> whatever platform-specific pointer is being used (`HWND`, `NSWindow *`, `unsigned long int`, etc..).

I was hoping I could conditionally include `c_names` based on the platform - but it turns out this is not possible. My current approach uses a lot of `#ifdef` platform detection, which isn't really ideal. This is what it looks like now: 
```
  CAMLprim value
  revery_alert(value vWindow, value vMessage) {
      CAMLparam2(vWindow, vMessage);
      const char *szMessage = String_val(vMessage);
      void* pWin = (void *)vWindow;

  #ifdef WIN32
      revery_alert_win32(pWin, szMessage);
  #elif __APPLE__
      revery_alert_cocoa(pWin, szMessage);
  #else
      printf("WARNING - Not implemented: alert");
  #endif
      return Val_unit;
  }
```
But I'm sure there's better ways to do this...  Some ideas were:

- Implementing the platform APIs as sub-packages
- Virtual modules to implement the back-ends

I like both of these ideas, but not sure how to implement them.

Once we've iterated on this API surface a bit, we could look at moving it out to a shared library like `revery-native` that `brisk` could use (if the APIs are helpful / reusable at all) cc @wokalski @rauanmayemir 
