### PR TITLE
Add missing revery_native.install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.5.1",
   "description": "App toolkit built with Reason",
   "license": "MIT",
-  "bugs": { "url": "https://github.com/bryphe/revery/issues" },
+  "bugs": {
+    "url": "https://github.com/bryphe/revery/issues"
+  },
   "scripts": {
     "build": "esy b",
     "build:release": "esy b dune build --profile=release --root . -j4",
@@ -24,7 +26,8 @@
       "esy-installer Revery_Native.install",
       "esy-installer Revery_Shaders.install",
       "esy-installer Revery_UI.install",
-      "esy-installer Revery_UI_Components.install"
+      "esy-installer Revery_UI_Components.install",
+      "esy-installer Revery_Native.install"
     ]
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "0.5.1",
   "description": "App toolkit built with Reason",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/bryphe/revery/issues"
-  },
+  "bugs": { "url": "https://github.com/bryphe/revery/issues" },
   "scripts": {
     "build": "esy b",
     "build:release": "esy b dune build --profile=release --root . -j4",


### PR DESCRIPTION
@bryphe After pulling the latest master branch, I wasn't able to run the examples. I think it's because of the new package you've added, so I've added it to the install list under esy in the package.json.