### PR TITLE
[TEST] Prebuilt binaries

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "aba4730dc9b90430568071e04356fe8c",
+  "checksum": "a01e2bffd408d27e6d1a597e0c8372c8",
   "root": "revery@link:./package.json",
   "node": {
     "revery@link:./package.json": {
@@ -11,7 +11,7 @@
       "dependencies": [
         "reason-glfw@github:bryphe/reason-glfw#4be18fb@d41d8cd9",
         "reason-gl-matrix@0.9.9302@d41d8cd9",
-        "reason-fontkit@github:bryphe/reason-fontkit#147368b@d41d8cd9",
+        "reason-fontkit@github:bryphe/reason-fontkit#b92e839@d41d8cd9",
         "ocaml@4.7.1003@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@opam/lwt_ppx@opam:1.2.1@db1172a7", "@opam/lwt@opam:4.1.0@111fc2bf",
         "@opam/js_of_ocaml-lwt@opam:3.3.0@ff746e31",
@@ -105,13 +105,13 @@
       ],
       "devDependencies": []
     },
-    "reason-fontkit@github:bryphe/reason-fontkit#147368b@d41d8cd9": {
-      "id": "reason-fontkit@github:bryphe/reason-fontkit#147368b@d41d8cd9",
+    "reason-fontkit@github:bryphe/reason-fontkit#b92e839@d41d8cd9": {
+      "id": "reason-fontkit@github:bryphe/reason-fontkit#b92e839@d41d8cd9",
       "name": "reason-fontkit",
-      "version": "github:bryphe/reason-fontkit#147368b",
+      "version": "github:bryphe/reason-fontkit#b92e839",
       "source": {
         "type": "install",
-        "source": [ "github:bryphe/reason-fontkit#147368b" ]
+        "source": [ "github:bryphe/reason-fontkit#b92e839" ]
       },
       "overrides": [],
       "dependencies": [
@@ -120,8 +120,7 @@
         "reason-gl-matrix@0.9.9302@d41d8cd9",
         "esy-harfbuzz-prebuilt@1.9.1003@d41d8cd9",
         "esy-freetype2-prebuilt@2.9.1005@d41d8cd9",
-        "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.6.3@a7d7baed",
-        "@esy-ocaml/reason@3.4.0@d41d8cd9"
+        "@opam/dune@opam:1.6.3@a7d7baed", "@esy-ocaml/reason@3.4.0@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -192,20 +191,6 @@
         "type": "install",
         "source": [
           "archive:https://registry.npmjs.org/esy-freetype2-prebuilt/-/esy-freetype2-prebuilt-2.9.1005.tgz#sha1:d2a41195257499617b4a0907fcdc5e5b36dfe6ae"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [],
-      "devDependencies": []
-    },
-    "esy-cmake@0.3.5@d41d8cd9": {
-      "id": "esy-cmake@0.3.5@d41d8cd9",
-      "name": "esy-cmake",
-      "version": "0.3.5",
-      "source": {
-        "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/esy-cmake/-/esy-cmake-0.3.5.tgz#sha1:2df0bdfe9317fbcded5f463fca1f346464494c7a"
         ]
       },
       "overrides": [],

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
     "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934",
     "reason-glfw": "github:bryphe/reason-glfw#4be18fb",
-    "reason-fontkit": "github:bryphe/reason-fontkit#147368b"
+    "reason-fontkit": "github:bryphe/reason-fontkit#b92e839"
   },
   "peerDependencies": {
     "ocaml": "^4.7.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "@opam/cmdliner": "1.0.2",
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
-    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934"
+    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#7901934",
+    "reason-glfw": "github:bryphe/reason-glfw#4be18fb",
+    "reason-fontkit": "github:bryphe/reason-fontkit#147368b"
   },
   "peerDependencies": {
     "ocaml": "^4.7.0"


### PR DESCRIPTION
This brings in a couple of resolutions to test using prebuilt binaries:

- `reason-glfw`
  - `esy-glfw-prebuilt`
- `reason-fontkit`
  - `esy-freetype2-prebuilt`
  - `esy-harfbuzz-prebuilt`

CI will help highlight the failures we hit

First failure - linux fails with:
```
2019-01-30T01:32:56.0950039Z     (cd _build/default && /home/vsts/.esy/3_____________________________________________________________________/i/ocaml-4.7.1003-1f1a5110/bin/ocamlopt.opt -w @a-4-29-40-41-42-44-45-48-58-59-60-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -shared -linkall -I src -o src/fontkit.cmxs src/fontkit.cmxa)
2019-01-30T01:32:56.0950835Z     /usr/bin/ld: /home/vsts/.esy/3_____________________________________________________________________/i/esy_harfbuzz_prebuilt-1.9.1003-5c8aa558/lib/libharfbuzz.a(libharfbuzz_la-hb-blob.o): relocation R_X86_64_32 against `_hb_Null_hb_blob_t' can not be used when making a shared object; recompile with -fPIC
2019-01-30T01:32:56.0951546Z     /home/vsts/.esy/3_____________________________________________________________________/i/esy_harfbuzz_prebuilt-1.9.1003-5c8aa558/lib/libharfbuzz.a: error adding symbols: Bad value
2019-01-30T01:32:56.0951834Z     collect2: error: ld returned 1 exit status
```

The PR for `reason-glfw` here: https://github.com/bryphe/reason-glfw/pull/90 also fails on Travis CI, with:
```
    ocamlopt test/test.exe (exit 2)
(cd _build/default && /home/travis/.esy/3___________________________________________________________________/i/ocaml-4.7.1003-1f1a5110/bin/ocamlopt.opt -w @a-4-29-40-41-42-44-45-48-58-59-60-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -o test/test.exe -I /home/travis/.esy/3___________________________________________________________________/i/opam__s__lwt-opam__c__4.1.0-5a700701/lib/lwt -I /home/travis/.esy/3___________________________________________________________________/i/opam__s__ocamlfind-opam__c__1.8.0-07921252/lib/bytes -I /home/travis/.esy/3___________________________________________________________________/i/opam__s__result-opam__c__1.3-bd29344e/lib/result -I /home/travis/.esy/3___________________________________________________________________/i/reason_gl_matrix-0.9.9302-a74b8681/lib/reglm -I src /home/travis/.esy/3___________________________________________________________________/i/opam__s__result-opam__c__1.3-bd29344e/lib/result/result.cmxa /home/travis/.esy/3___________________________________________________________________/i/opam__s__lwt-opam__c__4.1.0-5a700701/lib/lwt/lwt.cmxa /home/travis/.esy/3___________________________________________________________________/i/reason_gl_matrix-0.9.9302-a74b8681/lib/reglm/reglm.cmxa src/reglfw.cmxa test/.test.eobjs/test.cmx)
/usr/bin/ld: /home/travis/.esy/3___________________________________________________________________/i/esy_glfw_prebuilt-3.2.1008-c20361c9/lib/libglfw3.a(context.c.o): unrecognized relocation (0x2a) in section `.text'
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
File "caml_startup", line 1:
Error: Error during linking
```

