### PR TITLE
Bugfix: Clickable now tracking its bounds and mouse events appropriately

### DIFF
--- a/src/UI_Components/Clickable.re
+++ b/src/UI_Components/Clickable.re
@@ -12,8 +12,8 @@ open Revery_Math;
 type clickFunction = unit => unit;
 let noop = () => ();
 
-let isMouseInsideRef = (_ref: node, mouseX: float, mouseY: float) => {
-  let clickableDimensions: BoundingBox2d.t = _ref#getBoundingBox();
+let isMouseInsideRef = (ref: node, mouseX: float, mouseY: float) => {
+  let clickableDimensions: BoundingBox2d.t = ref#getBoundingBox();
   let pointVec = Vec2.create(mouseX, mouseY);
   BoundingBox2d.isPointInside(clickableDimensions, pointVec);
 }
@@ -30,8 +30,8 @@ let make =
       children: React.syntheticElement,
     ) =>
   component(slots => {
-    let (clickableRef, _setClickableRef, slots) = React.Hooks.state(None, slots);
-    let setClickableRef = r => _setClickableRef(Some(r));
+    let (clickableRef, setClickableRefOption, slots) = React.Hooks.state(None, slots);
+    let setClickableRef = r => setClickableRefOption(Some(r));
 
     let (animatedOpacity, setOpacity, _slots: React.Hooks.empty) =
       React.Hooks.state(0.8, slots);

--- a/src/UI_Components/Clickable.re
+++ b/src/UI_Components/Clickable.re
@@ -7,9 +7,16 @@
 
 open Revery_UI;
 open Revery_Core;
+open Revery_Math;
 
 type clickFunction = unit => unit;
 let noop = () => ();
+
+let isMouseInsideRef = (_ref: node, mouseX: float, mouseY: float) => {
+  let clickableDimensions: BoundingBox2d.t = _ref#getBoundingBox();
+  let pointVec = Vec2.create(mouseX, mouseY);
+  BoundingBox2d.isPointInside(clickableDimensions, pointVec);
+}
 
 let component = React.component("Clickable");
 
@@ -23,19 +30,47 @@ let make =
       children: React.syntheticElement,
     ) =>
   component(slots => {
+    let (clickableRef, _setClickableRef, slots) = React.Hooks.state(None, slots);
+    let setClickableRef = r => _setClickableRef(Some(r));
+
     let (animatedOpacity, setOpacity, _slots: React.Hooks.empty) =
       React.Hooks.state(0.8, slots);
 
-    /* TODO:
-     *
-     * This logic isn't really correct,
-     * for the case where you hold down the mouse,
-     * move around (leave the item), and come back.
-     */
-    let onMouseDown = _ => setOpacity(1.0);
-    let onMouseUp = _ => {
+    let onMouseMove = (mouseX: float, mouseY: float) => {
+      switch (clickableRef) {
+        | Some(clickable) => {
+          /* Is it ok to run it on every event? Do we need to throttle mouse move or it's already throttled? */
+          if (isMouseInsideRef(clickable, mouseX, mouseY)) {
+            setOpacity(1.0)
+          } else {
+            setOpacity(0.8)
+          }
+        }
+        | None => ()
+      }
+    };
+
+    let onMouseUp = (mouseX: float, mouseY: float) => {
+      switch (clickableRef) {
+        | Some(clickable) => {
+          if (isMouseInsideRef(clickable, mouseX, mouseY)) {
+            onClick();
+          }
+        }
+        | None => ()
+      }
+      
       setOpacity(0.8);
-      onClick();
+      Mouse.releaseCapture();
+    }
+
+    let onMouseDown = _ => {
+      Mouse.setCapture(
+        ~onMouseMove=evt => onMouseMove(evt.mouseX, evt.mouseY),
+        ~onMouseUp=evt => onMouseUp(evt.mouseX, evt.mouseY),
+        ());
+        
+      setOpacity(1.0)
     };
 
     let mergedStyles =
@@ -46,7 +81,7 @@ let make =
         )
       );
 
-    <View style=mergedStyles onMouseDown onMouseUp ?onBlur ?onFocus tabindex>
+    <View style=mergedStyles onMouseDown ?onBlur ?onFocus tabindex ref={r => setClickableRef(r)}>
       children
     </View>;
   });

--- a/src/UI_Components/Clickable.re
+++ b/src/UI_Components/Clickable.re
@@ -16,7 +16,7 @@ let isMouseInsideRef = (ref: node, mouseX: float, mouseY: float) => {
   let clickableDimensions: BoundingBox2d.t = ref#getBoundingBox();
   let pointVec = Vec2.create(mouseX, mouseY);
   BoundingBox2d.isPointInside(clickableDimensions, pointVec);
-}
+};
 
 let component = React.component("Clickable");
 
@@ -30,7 +30,8 @@ let make =
       children: React.syntheticElement,
     ) =>
   component(slots => {
-    let (clickableRef, setClickableRefOption, slots) = React.Hooks.state(None, slots);
+    let (clickableRef, setClickableRefOption, slots) =
+      React.Hooks.state(None, slots);
     let setClickableRef = r => setClickableRefOption(Some(r));
 
     let (animatedOpacity, setOpacity, _slots: React.Hooks.empty) =
@@ -38,38 +39,37 @@ let make =
 
     let onMouseMove = (mouseX: float, mouseY: float) => {
       switch (clickableRef) {
-        | Some(clickable) => {
-          if (isMouseInsideRef(clickable, mouseX, mouseY)) {
-            setOpacity(1.0)
-          } else {
-            setOpacity(0.8)
-          }
+      | Some(clickable) =>
+        if (isMouseInsideRef(clickable, mouseX, mouseY)) {
+          setOpacity(1.0);
+        } else {
+          setOpacity(0.8);
         }
-        | None => ()
-      }
+      | None => ()
+      };
     };
 
     let onMouseUp = (mouseX: float, mouseY: float) => {
       switch (clickableRef) {
-        | Some(clickable) => {
-          if (isMouseInsideRef(clickable, mouseX, mouseY)) {
-            onClick();
-          }
+      | Some(clickable) =>
+        if (isMouseInsideRef(clickable, mouseX, mouseY)) {
+          onClick();
         }
-        | None => ()
-      }
-      
+      | None => ()
+      };
+
       setOpacity(0.8);
       Mouse.releaseCapture();
-    }
+    };
 
     let onMouseDown = _ => {
       Mouse.setCapture(
         ~onMouseMove=evt => onMouseMove(evt.mouseX, evt.mouseY),
         ~onMouseUp=evt => onMouseUp(evt.mouseX, evt.mouseY),
-        ());
-        
-      setOpacity(1.0)
+        (),
+      );
+
+      setOpacity(1.0);
     };
 
     let mergedStyles =
@@ -80,7 +80,13 @@ let make =
         )
       );
 
-    <View style=mergedStyles onMouseDown ?onBlur ?onFocus tabindex ref={r => setClickableRef(r)}>
+    <View
+      style=mergedStyles
+      onMouseDown
+      ?onBlur
+      ?onFocus
+      tabindex
+      ref={r => setClickableRef(r)}>
       children
     </View>;
   });

--- a/src/UI_Components/Clickable.re
+++ b/src/UI_Components/Clickable.re
@@ -39,7 +39,6 @@ let make =
     let onMouseMove = (mouseX: float, mouseY: float) => {
       switch (clickableRef) {
         | Some(clickable) => {
-          /* Is it ok to run it on every event? Do we need to throttle mouse move or it's already throttled? */
           if (isMouseInsideRef(clickable, mouseX, mouseY)) {
             setOpacity(1.0)
           } else {


### PR DESCRIPTION
Fixes: #227

@bryphe I have a concern about constantly calling `setOpacity` on `mouseMove` (cause it may happen a lot)
https://github.com/revery-ui/revery/pull/296/files#diff-b70d90548201b5505a0a67ee349e4a53R42

Do we need to throttle it maybe, or it's somehow throttled for us?