### PR TITLE
Scroll for smaller amounts

### DIFF
--- a/src/UI_Components/ScrollView.re
+++ b/src/UI_Components/ScrollView.re
@@ -101,7 +101,7 @@ let make =
 
         let scroll = (wheelEvent: NodeEvents.mouseWheelEventParams) => {
           let newScrollTop =
-            actualScrollTop - int_of_float(wheelEvent.deltaY) * 25;
+            actualScrollTop - int_of_float(wheelEvent.deltaY *. 25.);
 
           let clampedScrollTop =
             if (newScrollTop < 0) {

--- a/src/UI_Components/ScrollView.re
+++ b/src/UI_Components/ScrollView.re
@@ -165,8 +165,7 @@ let make =
     </View>;
   });
 
-let createElement = (~children, ~style, ~scrollLeft=0, ~scrollTop=0, ()) => {
+let createElement = (~children, ~style, ~scrollLeft=0, ~scrollTop=0, ()) =>
   React.element(
     make(~style, ~scrollLeft, ~scrollTop, React.listToElement(children)),
   );
-};


### PR DESCRIPTION
No companion issue. Found while investigating #288.

When the wheel event would return `0.x` we wouldn't move the scroll position. This PR changes the calculation order so that we multiple first by 25 and then round, so every event causes some effect, even if small.