### PR TITLE
[WIP] Dependency: brisk-reconciler->1b8f321

### DIFF
--- a/examples/AnalogClock.re
+++ b/examples/AnalogClock.re
@@ -43,7 +43,7 @@ module AnalogClock = {
 
   let component = React.component("AnalogClock");
 
-  let make = () => {
+  let createElement = (~children as _, ()) => 
     component(slots => {
       let (state, dispatch, slots) =
         React.Hooks.reducer(
@@ -55,7 +55,7 @@ module AnalogClock = {
       let {hourDegrees, minuteDegrees, secondDegrees}: DegreeUtils.t =
         state.currentTime |> DegreeUtils.getDegreesFromTime;
 
-      let _slots: React.Hooks.empty =
+      let slots =
         React.Hooks.effect(
           OnMount,
           () => {
@@ -139,17 +139,14 @@ module AnalogClock = {
           )
         );
 
-      <View style=containerStyle>
+      (slots, <View style=containerStyle>
         <View style=clockContainer>
           <View style=secondsStyle />
           <View style=minutesStyle />
           <View style=hourStyle />
         </View>
-      </View>;
+      </View>);
     });
-  };
-
-  let createElement = (~children as _, ()) => React.element(make());
 };
 
 let render = () => <AnalogClock />;

--- a/examples/Calculator.re
+++ b/examples/Calculator.re
@@ -8,8 +8,8 @@ open Revery.UI.Components;
 module Row = {
   let component = React.component("Row");
 
-  let make = children =>
-    component((_slots: React.Hooks.empty) => {
+  let createElement = (~children, ()) => 
+    component((slots) => {
       let style =
         Style.[
           flexDirection(`Row),
@@ -17,17 +17,16 @@ module Row = {
           justifyContent(`Center),
           flexGrow(1),
         ];
-      <View style> ...children </View>;
+      (slots, <View style> ...children </View>);
     });
 
-  let createElement = (~children, ()) => React.element(make(children));
 };
 
 module Column = {
   let component = React.component("Column");
 
-  let make = children =>
-    component((_slots: React.Hooks.empty) => {
+  let createElement = (~children, ()) => 
+    component((slots) => {
       let style =
         Style.[
           flexDirection(`Column),
@@ -36,23 +35,23 @@ module Column = {
           backgroundColor(Colors.darkGrey),
           flexGrow(1),
         ];
-      <View style> ...children </View>;
+      (slots, <View style> ...children </View>);
     });
 
-  let createElement = (~children, ()) => React.element(make(children));
 };
 
 module Button = {
   let component = React.component("Button");
 
-  let make =
+  let createElement =
       (
-        ~fontFamily as family="Roboto-Regular.ttf",
-        ~contents: string,
+        ~fontFamily as family ="Roboto-Regular.ttf",
+        ~contents,
         ~onClick,
+        ~children as _,
         (),
       ) =>
-    component((_slots: React.Hooks.empty) => {
+    component((slots) => {
       let clickableStyle =
         Style.[
           position(`Relative),
@@ -73,26 +72,16 @@ module Button = {
       let textStyle =
         Style.[color(Colors.black), fontFamily(family), fontSize(32)];
 
-      <Clickable style=clickableStyle onClick>
+      (slots, <Clickable style=clickableStyle onClick>
         <View style=viewStyle> <Text style=textStyle text=contents /> </View>
-      </Clickable>;
+      </Clickable>);
     });
-
-  let createElement =
-      (
-        ~fontFamily="Roboto-Regular.ttf",
-        ~contents,
-        ~onClick,
-        ~children as _,
-        (),
-      ) =>
-    React.element(make(~fontFamily, ~contents, ~onClick, ()));
 };
 module Display = {
   let component = React.component("Display");
 
-  let make = (~display: string, ~curNum: string, ()) =>
-    component((_slots: React.Hooks.empty) => {
+  let createElement = (~display: string, ~curNum: string, ~children as _, ()) =>
+    component((slots) => {
       let viewStyle =
         Style.[
           backgroundColor(Colors.white),
@@ -117,14 +106,11 @@ module Display = {
           margin(15),
         ];
 
-      <View style=viewStyle>
+      (slots, <View style=viewStyle>
         <Text style=displayStyle text=display />
         <Text style=numStyle text=curNum />
-      </View>;
+      </View>);
     });
-
-  let createElement = (~display: string, ~curNum: string, ~children as _, ()) =>
-    React.element(make(~display, ~curNum, ()));
 };
 
 type operator = [ | `Nop | `Add | `Sub | `Mul | `Div];
@@ -236,7 +222,7 @@ let reducer = (action, state) =>
 module Calculator = {
   let component = React.component("Calculator");
 
-  let make = window =>
+  let createElement = (~window, ~children as _, ()) =>
     component(slots => {
       let ({display, number, _}, dispatch, slots) =
         React.Hooks.reducer(
@@ -279,7 +265,7 @@ module Calculator = {
       /* TODO: Pretty sure this isn't supposed to go in the render() function.
          Seems to cause lag the more times we re-render, so I guess this is
          subscribing a ton of times and never unsubscribing. */
-      let _slots: React.Hooks.empty =
+      let slots =
         React.Hooks.effect(
           OnMount,
           () => {
@@ -290,7 +276,7 @@ module Calculator = {
           slots,
         );
 
-      <Column>
+      (slots, <Column>
         <Display display curNum=number />
         <Row>
           <Button
@@ -378,11 +364,9 @@ module Calculator = {
             onClick={_ => dispatch(OperationKeyPressed(`Add))}
           />
         </Row>
-      </Column>;
+      </Column>);
     });
 
-  let createElement = (~window, ~children as _, ()) =>
-    React.element(make(window));
 };
 
 let render = window => <Calculator window />;

--- a/examples/CheckboxExample.re
+++ b/examples/CheckboxExample.re
@@ -4,11 +4,11 @@ open Revery.UI.Components;
 
 module Check = {
   let component = React.component("Check");
-  let make = () => {
+  let createElement = (~children as _, ()) => 
     component(slots => {
-      let (text, setText, _slots: React.Hooks.empty) =
+      let (text, setText, slots) =
         React.Hooks.state("Not Checked!", slots);
-      <View
+      (slots, <View
         style=Style.[
           width(500),
           height(500),
@@ -43,11 +43,8 @@ module Check = {
             fontSize(20),
           ]
         />
-      </View>;
+      </View>);
     });
-  };
-
-  let createElement = (~children as _, ()) => React.element(make());
 };
 
 let render = () => {

--- a/examples/DefaultButton.re
+++ b/examples/DefaultButton.re
@@ -5,9 +5,9 @@ open Revery.Core;
 module DefaultButtonWithCounter = {
   let component = React.component("DefaultButtonWithCounter");
 
-  let make = () =>
+  let createElement = (~children as _, ()) => 
     component(slots => {
-      let (count, setCount, _slots: React.Hooks.empty) =
+      let (count, setCount, slots) =
         React.Hooks.state(0, slots);
       let increment = () => setCount(count + 1);
 
@@ -31,16 +31,15 @@ module DefaultButtonWithCounter = {
         ];
 
       let countStr = string_of_int(count);
-      <View style=containerStyle>
+      (slots, <View style=containerStyle>
         <View style=countContainer>
           <Text style=countStyle text=countStr />
         </View>
         <Button title="click me!" onClick=increment />
         <Button disabled=true title="(disabled)" onClick=increment />
-      </View>;
+      </View>);
     });
 
-  let createElement = (~children as _, ()) => React.element(make());
 };
 
 let render = () => <View> <DefaultButtonWithCounter /> </View>;

--- a/examples/DropdownExample.re
+++ b/examples/DropdownExample.re
@@ -26,18 +26,17 @@ module DropdownExample = {
     {value: "5", label: "A really, really, really long option"},
   ];
 
-  let make = () =>
+  let createElement = (~children as _, ()) => 
     component(slots => {
-      let (selectedItem, setSelectedItem, _slots: React.Hooks.empty) =
+      let (selectedItem, setSelectedItem, slots) =
         React.Hooks.state(List.nth(items, 0), slots);
 
-      <View style=containerStyle>
+      (slots, <View style=containerStyle>
         <Text style=textStyle text={"Selected Item: " ++ selectedItem.label} />
         <Dropdown items onItemSelected={item => setSelectedItem(item)} />
-      </View>;
+      </View>);
     });
 
-  let createElement = (~children as _, ()) => React.element(make());
 };
 
 let render = () => <DropdownExample />;

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -127,8 +127,8 @@ let getRenderFunctionSelector: (state, Window.t) => React.syntheticElement =
 module ExampleButton = {
   let component = React.component("ExampleButton");
 
-  let make = (~isActive: bool, ~name, ~onClick, ()) =>
-    component((_slots: React.Hooks.empty) => {
+  let createElement = (~children as _, ~isActive, ~name, ~onClick, ()) =>
+    component((slots) => {
       let highlightColor =
         isActive ? selectionHighlight : Colors.transparentWhite;
 
@@ -151,15 +151,12 @@ module ExampleButton = {
           margin(16),
         ];
 
-      <View style=[Style.opacity(buttonOpacity)]>
+      (slots, <View style=[Style.opacity(buttonOpacity)]>
         <Clickable style=wrapperStyle onClick>
           <Text style=textHeaderStyle text=name />
         </Clickable>
-      </View>;
+      </View>);
     });
-
-  let createElement = (~children as _, ~isActive, ~name, ~onClick, ()) =>
-    React.element(make(~isActive, ~name, ~onClick, ()));
 };
 
 type action =

--- a/examples/Focus.re
+++ b/examples/Focus.re
@@ -8,14 +8,14 @@ module SimpleButton = {
   let make = () =>
     component(slots => {
       let (count, setCount, slots) = React.Hooks.state(0, slots);
-      let (focused, setFocus, _slots: React.Hooks.empty) =
+      let (focused, setFocus, slots) =
         React.Hooks.state(false, slots);
 
       let increment = () => setCount(count + 1);
 
       let txt = focused ? "Focused" : "Unfocused";
       let textContent = txt ++ " me: " ++ string_of_int(count);
-      <Clickable
+      (slots, <Clickable
         onClick=increment
         tabindex=0
         onFocus={() => setFocus(true)}
@@ -36,10 +36,10 @@ module SimpleButton = {
             text=textContent
           />
         </View>
-      </Clickable>;
+      </Clickable>);
     });
 
-  let createElement = (~children as _, ()) => React.element(make());
+  let createElement = (~children as _, ()) => make();
 };
 
 let render = () =>

--- a/examples/GameOfLife.re
+++ b/examples/GameOfLife.re
@@ -273,11 +273,11 @@ module Row = {
     ];
 
   let make = children =>
-    component((_slots: React.Hooks.empty) =>
-      <View style> ...children </View>
+    component((slots) =>
+      (slots, <View style> ...children </View>)
     );
 
-  let createElement = (~children, ()) => React.element(make(children));
+  let createElement = (~children, ()) => make(children);
 };
 
 module Column = {
@@ -292,10 +292,10 @@ module Column = {
     ];
 
   let make = children =>
-    component((_slots: React.Hooks.empty) =>
-      <View style> ...children </View>
+    component((slots) =>
+      (slots, <View style> ...children </View>)
     );
-  let createElement = (~children, ()) => React.element(make(children));
+  let createElement = (~children, ()) => make(children);
 };
 
 module Cell = {
@@ -325,16 +325,16 @@ module Cell = {
     );
 
   let make = (~cell, ~onClick, ()) =>
-    component((_slots: React.Hooks.empty) => {
+    component((slots) => {
       let style =
         switch (cell) {
         | Alive => <View style=aliveStyle />
         | Dead => <View style=deadStyle />
         };
-      <Clickable style=clickableStyle onClick> style </Clickable>;
+      (slots, <Clickable style=clickableStyle onClick> style </Clickable>);
     });
   let createElement = (~cell, ~onClick, ~children as _, ()) =>
-    React.element(make(~cell, ~onClick, ()));
+    make(~cell, ~onClick, ());
 };
 
 let viewPortRender =
@@ -431,7 +431,7 @@ module GameOfLiveComponent = {
       let (state, dispatch, slots) =
         React.Hooks.reducer(~initialState=state, reducer, slots);
 
-      let _slots: React.Hooks.empty =
+      let slots =
         React.Hooks.effect(
           OnMount,
           () => Some(() => dispatch(StopTimer)),
@@ -449,7 +449,7 @@ module GameOfLiveComponent = {
             dispatch(StartTimer(dispose));
           };
 
-      <Column>
+      (slots, <Column>
         <Row>
           ...{viewPortRender(state.viewPort, state.universe, toggleAlive)}
         </Row>
@@ -490,11 +490,11 @@ module GameOfLiveComponent = {
             onClick={_ => dispatch(ZoomViewPort(ZoomOut))}
           />
         </View>
-      </Column>;
+      </Column>);
     });
 
   let createElement = (~state, ~children as _, ()) =>
-    React.element(make(~state, ()));
+    make(~state, ());
 };
 
 let render = () => {

--- a/examples/Hello.re
+++ b/examples/Hello.re
@@ -22,7 +22,7 @@ module Logo = {
           slots,
         );
 
-      let (rotationY, _slots: React.Hooks.empty) =
+      let (rotationY, slots) =
         Hooks.animation(
           Animated.floatValue(0.),
           {
@@ -39,7 +39,7 @@ module Logo = {
 
       let onMouseUp = _ => setOpacity(1.0);
 
-      <View onMouseDown onMouseUp>
+      (slots, <View onMouseDown onMouseUp>
         <Image
           src="outrun-logo.png"
           style=Style.[
@@ -52,10 +52,10 @@ module Logo = {
             ]),
           ]
         />
-      </View>;
+      </View>);
     });
 
-  let createElement = (~children as _, ()) => React.element(make());
+  let createElement = (~children as _, ()) => make();
 };
 
 module AnimatedText = {
@@ -76,7 +76,7 @@ module AnimatedText = {
           slots,
         );
 
-      let (translate, _slots: React.Hooks.empty) =
+      let (translate, slots) =
         Hooks.animation(
           Animated.floatValue(50.),
           {
@@ -99,11 +99,11 @@ module AnimatedText = {
           transform([Transform.TranslateY(translate)]),
         ];
 
-      <Text style=textHeaderStyle text />;
+      (slots, <Text style=textHeaderStyle text />);
     });
 
   let createElement = (~children as _, ~text: string, ~delay: float, ()) =>
-    React.element(make(~text, ~delay, ()));
+    make(~text, ~delay, ());
 };
 
 let render = () =>

--- a/examples/InputExample.re
+++ b/examples/InputExample.re
@@ -25,10 +25,10 @@ module Example = {
 
   let make = window =>
     component(slots => {
-      let ({first, second}, setValue, _slots: React.Hooks.empty) =
+      let ({first, second}, setValue, slots) =
         React.Hooks.state({first: "", second: ""}, slots);
 
-      <View style=containerStyle>
+      (slots, <View style=containerStyle>
         <Input
           window
           placeholder="Insert text here"
@@ -53,11 +53,11 @@ module Example = {
             ),
           ]
         />
-      </View>;
+      </View>);
     });
 
   let createElement = (~window, ~children as _, ()) =>
-    React.element(make(window));
+    make(window);
 };
 
 let render = window => <Example window />;

--- a/examples/Native.re
+++ b/examples/Native.re
@@ -6,7 +6,7 @@ module NativeExamples = {
   let component = React.component("DefaultButtonWithCounter");
 
   let make = (~window, ()) =>
-    component((_slots: React.Hooks.empty) => {
+    component((slots) => {
       let increment = () => {
         Dialog.alert(window, "Hello, world");
       };
@@ -22,13 +22,13 @@ module NativeExamples = {
           right(0),
         ];
 
-      <View style=containerStyle>
+      (slots, <View style=containerStyle>
         <Button title="Alert" onClick=increment />
-      </View>;
+      </View>);
     });
 
   let createElement = (~children as _, ~window, ()) =>
-    React.element(make(~window, ()));
+    make(~window, ());
 };
 
 let render = window => <NativeExamples window />;

--- a/examples/RadioButtonExample.re
+++ b/examples/RadioButtonExample.re
@@ -6,9 +6,9 @@ module RadioExample = {
   let component = React.component("RadioExample");
   let make = () =>
     component(slots => {
-      let (radioVal, setRadioVal, _slots: React.Hooks.empty) =
+      let (radioVal, setRadioVal, slots) =
         React.Hooks.state("Select a button!", slots);
-      <View
+      (slots, <View
         style=Style.[
           width(500),
           height(500),
@@ -42,9 +42,9 @@ module RadioExample = {
             marginTop(20),
           ]
         />
-      </View>;
+      </View>);
     });
-  let createElement = (~children as _, ()) => React.element(make());
+  let createElement = (~children as _, ()) => make();
 };
 
 let render = () => <RadioExample />;

--- a/examples/ScreenCapture.re
+++ b/examples/ScreenCapture.re
@@ -11,7 +11,7 @@ module ActionButton = {
   let component = React.component("ActionButton");
 
   let make = (~name, ~onClick, ()) =>
-    component((_slots: React.Hooks.empty) => {
+    component((slots) => {
       let wrapperStyle =
         Style.[
           backgroundColor(selectionHighlight),
@@ -24,13 +24,13 @@ module ActionButton = {
           fontSize(14),
           margin(16),
         ];
-      <Clickable style=wrapperStyle onClick>
+      (slots, <Clickable style=wrapperStyle onClick>
         <Text style=textHeaderStyle text=name />
-      </Clickable>;
+      </Clickable>);
     });
 
   let createElement = (~children as _, ~name, ~onClick, ()) =>
-    React.element(make(~name, ~onClick, ()));
+    make(~name, ~onClick, ());
 };
 
 module CaptureArea = {
@@ -39,7 +39,7 @@ module CaptureArea = {
   let make = w =>
     component(slots => {
       let (count, setCount, slots) = React.Hooks.state(0, slots);
-      let (file, setFile, _slots: React.Hooks.empty) =
+      let (file, setFile, slots) =
         React.Hooks.state(None, slots);
 
       let capture = () => {
@@ -63,16 +63,16 @@ module CaptureArea = {
 
       let imageStyle = Style.[width(400), height(300)];
 
-      <View style=viewStyle>
+      (slots, <View style=viewStyle>
         <ActionButton name="Take a screenshot!" onClick=capture />
         {switch (file) {
          | None => <View />
          | Some(src) => <Image style=imageStyle src />
          }}
-      </View>;
+      </View>);
     });
 
-  let createElement = (~w, ~children as _, ()) => React.element(make(w));
+  let createElement = (~w, ~children as _, ()) => make(w);
 };
 
 let render = w => <CaptureArea w />;

--- a/examples/ScrollView.re
+++ b/examples/ScrollView.re
@@ -28,8 +28,8 @@ module Sample = {
   let component = React.component("Sample");
 
   let make = () =>
-    component((_slots: React.Hooks.empty) =>
-      <View style=containerStyle>
+    component((slots) =>
+      (slots, <View style=containerStyle>
         <ScrollView style=outerBox>
           <Image
             src="outrun-logo.png"
@@ -45,9 +45,9 @@ module Sample = {
           />
         </ScrollView>
       </View>
-    );
+    ));
 
-  let createElement = (~children as _, ()) => React.element(make());
+  let createElement = (~children as _, ()) => make();
 };
 
 let render = () => <Sample />;

--- a/examples/Slider.re
+++ b/examples/Slider.re
@@ -10,7 +10,7 @@ module AdjustableLogo = {
     component(slots => {
       let (rotationX, setRotationX, slots) = React.Hooks.state(0., slots);
       let (rotationY, setRotationY, slots) = React.Hooks.state(0., slots);
-      let (rotationZ, setRotationZ, _slots: React.Hooks.empty) =
+      let (rotationZ, setRotationZ, slots) =
         React.Hooks.state(0., slots);
 
       let containerStyle =
@@ -62,7 +62,7 @@ module AdjustableLogo = {
 
       let twoPi = 2. *. pi;
 
-      <View style=containerStyle>
+      (slots, <View style=containerStyle>
         <View>
           <Image
             src="outrun-logo.png"
@@ -113,10 +113,10 @@ module AdjustableLogo = {
             </View>
           </View>
         </View>
-      </View>;
+      </View>);
     });
 
-  let createElement = (~children as _, ()) => React.element(make());
+  let createElement = (~children as _, ()) => make();
 };
 
 let render = () => <AdjustableLogo />;

--- a/examples/Stopwatch.re
+++ b/examples/Stopwatch.re
@@ -53,7 +53,7 @@ module Clock = {
        * We'll make sure to dispatch the 'Stop' action when unmounting,
        * so we don't have a runaway timer!
        */
-      let _slots: React.Hooks.empty =
+      let slots =
         React.Hooks.effect(
           OnMount,
           () => Some(() => dispatch(Stop)),
@@ -81,7 +81,7 @@ module Clock = {
       let getMarcherPosition = t =>
         sin(Time.to_float_seconds(t) *. 2. *. pi) /. 2. +. 0.5;
 
-      <View
+      (slots, <View
         style=Style.[
           position(`Absolute),
           justifyContent(`Center),
@@ -122,10 +122,10 @@ module Clock = {
           />
         </View>
         <Button title=buttonText onClick=startStop />
-      </View>;
+      </View>);
     });
 
-  let createElement = (~children as _, ()) => React.element(make());
+  let createElement = (~children as _, ()) => make();
 };
 
 let render = () => <Clock />;

--- a/examples/TodoExample.re
+++ b/examples/TodoExample.re
@@ -61,8 +61,8 @@ module FilterSection = {
   let component = React.component("FilterSection");
 
   let make = (_children, currentFilter, onPickingFilter) =>
-    component((_slots: React.Hooks.empty) =>
-      <View
+    component((slots) =>
+      (slots, <View
         style=Style.[
           flexDirection(`Row),
           width(500),
@@ -109,10 +109,10 @@ module FilterSection = {
           onClick={() => onPickingFilter(NotCompleted)}
         />
       </View>
-    );
+    ));
 
   let createElement = (~children, ~currentFilter, ~onPickingFilter, ()) =>
-    React.element(make(children, currentFilter, onPickingFilter));
+    make(children, currentFilter, onPickingFilter);
 };
 
 module Example = {
@@ -127,7 +127,7 @@ module Example = {
           slots,
         );
 
-      let _slots: React.Hooks.empty =
+      let slots =
         React.Hooks.effect(
           OnMount,
           () => {
@@ -167,7 +167,7 @@ module Example = {
         );
 
       let listOfTodos = List.map(renderTodo, filteredList);
-      <View
+      (slots, <View
         style=Style.[
           position(`Absolute),
           top(0),
@@ -211,11 +211,11 @@ module Example = {
           ]>
           <View> ...listOfTodos </View>
         </ScrollView>
-      </View>;
+      </View>);
     });
 
   let createElement = (~window, ~children as _, ()) =>
-    React.element(make(window));
+    make(window);
 };
 
 let render = window => <Example window />;

--- a/examples/TreeView.re
+++ b/examples/TreeView.re
@@ -170,13 +170,14 @@ module TreeView = {
     );
 
   let make = (~renderer, ()) =>
-    component((_slots: React.Hooks.empty) =>
-      switch (renderer) {
+    component((slots) => {
+      let c = switch (renderer) {
       | Some(fn) => <Tree tree=animalKingdom nodeRenderer=fn />
       | None =>
         <Tree tree=stringTree nodeRenderer=Tree.default emptyRenderer />
-      }
-    );
+      };
+      (slots, c)
+    });
 
   let customRenderer = (~indent, content) => {
     open Tree;
@@ -210,7 +211,7 @@ module TreeView = {
   };
 
   let createElement = (~children as _, ~renderer=?, ()) =>
-    React.element(make(~renderer, ()));
+    make(~renderer, ());
 };
 
 let titleStyles =

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@opam/cmdliner": "1.0.2",
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
-    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#1c102ab"
+    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#1b8f321"
   },
   "peerDependencies": {
     "ocaml": "^4.7.0"

--- a/src/UI/Primitives.re
+++ b/src/UI/Primitives.re
@@ -24,7 +24,8 @@ module View = {
         ~style=Style.emptyViewStyle,
         children,
       ) =>
-    component((_: UiReact.Hooks.empty) =>
+    component((hooks) => (
+      hooks,
       {
         make: () => {
           let styles = Style.create(~style, ());
@@ -65,7 +66,7 @@ module View = {
         },
         children,
       }
-    );
+));
 
   let createElement =
       (
@@ -81,7 +82,6 @@ module View = {
         ~children,
         (),
       ) =>
-    UiReact.element(
       make(
         ~onMouseDown?,
         ~onMouseMove?,
@@ -93,8 +93,7 @@ module View = {
         ~style,
         ~tabindex?,
         UiReact.listToElement(children),
-      ),
-    );
+      );
 };
 
 module Text = {
@@ -112,7 +111,8 @@ module Text = {
         ~text="",
         children,
       ) =>
-    component((_: UiReact.Hooks.empty) =>
+    component((hooks) => (
+      hooks,
       {
         make: () => {
           let styles = create(~style, ());
@@ -150,7 +150,7 @@ module Text = {
           node;
         },
         children,
-      }
+      })
     );
 
   let createElement =
@@ -165,7 +165,6 @@ module Text = {
         ~children,
         (),
       ) =>
-    UiReact.element(
       make(
         ~onMouseDown?,
         ~onMouseMove?,
@@ -175,8 +174,7 @@ module Text = {
         ~style,
         ~text,
         UiReact.listToElement(children),
-      ),
-    );
+      )
 };
 
 module Image = {
@@ -193,7 +191,8 @@ module Image = {
         ~src="",
         children,
       ) =>
-    component((_: UiReact.Hooks.empty) =>
+    component((hooks) => (
+      hooks,
       {
         make: () => {
           let styles = Style.create(~style, ());
@@ -227,7 +226,7 @@ module Image = {
           node;
         },
         children,
-      }
+      })
     );
 
   let createElement =
@@ -242,7 +241,6 @@ module Image = {
         ~children,
         (),
       ) =>
-    UiReact.element(
       make(
         ~onMouseDown?,
         ~onMouseMove?,
@@ -252,6 +250,5 @@ module Image = {
         ~style,
         ~src,
         UiReact.listToElement(children),
-      ),
-    );
+      );
 };

--- a/src/UI_Components/Button.re
+++ b/src/UI_Components/Button.re
@@ -21,8 +21,8 @@ let make =
       (),
     ) =>
   /* children, */
-  component((_slots: React.Hooks.empty) =>
-    <Clickable onClick={disabled ? noop : onClick} ?onFocus ?onBlur ?tabindex>
+  component((slots) =>
+    (slots, <Clickable onClick={disabled ? noop : onClick} ?onFocus ?onBlur ?tabindex>
       <View
         style=Style.[
           position(`Relative),
@@ -42,7 +42,7 @@ let make =
           text=title
         />
       </View>
-    </Clickable>
+    </Clickable>)
   );
 
 let createElement =
@@ -61,7 +61,6 @@ let createElement =
       ~fontFamily="Roboto-Regular.ttf",
       (),
     ) =>
-  React.element(
     make(
       ~title,
       ~onClick,
@@ -75,5 +74,4 @@ let createElement =
       ~onBlur?,
       ~tabindex?,
       (),
-    ),
   );

--- a/src/UI_Components/Checkbox.re
+++ b/src/UI_Components/Checkbox.re
@@ -12,14 +12,14 @@ let defaultStyle =
 
 let make = (~checked, ~style, ~checkedColor, ~onChange, ()) =>
   component(slots => {
-    let (isChecked, checkBox, _slots: React.Hooks.empty) =
+    let (isChecked, checkBox, slots) =
       React.Hooks.state(checked, slots);
 
     let stylesToUse = Style.merge(~source=defaultStyle, ~target=style);
     let bgColor = isChecked ? checkedColor : Colors.transparentWhite;
     let checkedContent = isChecked ? {||} : "";
 
-    <Clickable
+    (slots, <Clickable
       onClick={() => {
         checkBox(!isChecked);
         onChange(!isChecked);
@@ -44,7 +44,7 @@ let make = (~checked, ~style, ~checkedColor, ~onChange, ()) =>
           ]
         />
       </View>
-    </Clickable>;
+    </Clickable>);
   });
 let noop = _c => ();
 
@@ -57,4 +57,4 @@ let createElement =
       ~onChange=noop,
       (),
     ) =>
-  React.element(make(~checked, ~onChange, ~checkedColor, ~style, ()));
+  make(~checked, ~onChange, ~checkedColor, ~style, ());

--- a/src/UI_Components/Clickable.re
+++ b/src/UI_Components/Clickable.re
@@ -32,7 +32,10 @@ let make =
   component(slots => {
     let (clickableRef, setClickableRefOption, slots) =
       React.Hooks.state(None, slots);
-    let setClickableRef = r => setClickableRefOption(Some(r));
+    let setClickableRef = r => {
+        print_endline ("setting ref");
+        setClickableRefOption(Some(r))
+    };
 
     let (animatedOpacity, setOpacity, slots) =
       React.Hooks.state(0.8, slots);
@@ -53,6 +56,7 @@ let make =
       switch (clickableRef) {
       | Some(clickable) =>
         if (isMouseInsideRef(clickable, mouseX, mouseY)) {
+          print_endline ("CLICKING");
           onClick();
         }
       | None => ()
@@ -63,6 +67,7 @@ let make =
     };
 
     let onMouseDown = _ => {
+        print_endline ("CLICK");
       Mouse.setCapture(
         ~onMouseMove=evt => onMouseMove(evt.mouseX, evt.mouseY),
         ~onMouseUp=evt => onMouseUp(evt.mouseX, evt.mouseY),

--- a/src/UI_Components/Clickable.re
+++ b/src/UI_Components/Clickable.re
@@ -34,7 +34,7 @@ let make =
       React.Hooks.state(None, slots);
     let setClickableRef = r => setClickableRefOption(Some(r));
 
-    let (animatedOpacity, setOpacity, _slots: React.Hooks.empty) =
+    let (animatedOpacity, setOpacity, slots) =
       React.Hooks.state(0.8, slots);
 
     let onMouseMove = (mouseX: float, mouseY: float) => {
@@ -80,6 +80,7 @@ let make =
         )
       );
 
+    (slots,
     <View
       style=mergedStyles
       onMouseDown
@@ -88,7 +89,7 @@ let make =
       tabindex
       ref={r => setClickableRef(r)}>
       children
-    </View>;
+    </View>);
   });
 
 let createElement =
@@ -101,7 +102,6 @@ let createElement =
       ~children,
       (),
     ) =>
-  React.element(
     make(
       ~style,
       ~onClick,
@@ -109,5 +109,4 @@ let createElement =
       ~onFocus?,
       ~tabindex,
       React.listToElement(children),
-    ),
-  );
+    );

--- a/src/UI_Components/Dropdown.re
+++ b/src/UI_Components/Dropdown.re
@@ -46,7 +46,7 @@ let make =
   component(slots => {
     let initialState = {items, selected: List.nth(items, 0), _open: false};
 
-    let (state, dispatch, _slots: React.Hooks.empty) =
+    let (state, dispatch, slots) =
       React.Hooks.reducer(~initialState, reducer, slots);
 
     let items =
@@ -78,7 +78,7 @@ let make =
           )
         : [];
 
-    <View
+    (slots, <View
       style=Style.[
         position(`Relative),
         backgroundColor(Colors.white),
@@ -130,11 +130,9 @@ let make =
         ]>
         ...items
       </View>
-    </View>;
+    </View>);
   });
 
 let createElement =
     (~items, ~onItemSelected=noop, ~width=200, ~height=50, ~children, ()) =>
-  React.element(
-    make(~items, ~onItemSelected, ~width, ~height, ~children, ()),
-  );
+    make(~items, ~onItemSelected, ~width, ~height, ~children, ());

--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -124,7 +124,7 @@ let make =
         slots,
       );
 
-    let (animatedOpacity, _slots: React.Hooks.empty) =
+    let (animatedOpacity, slots) =
       Hooks.animation(
         Animated.floatValue(0.),
         {
@@ -210,14 +210,14 @@ let make =
     /*
        component
      */
-    <Clickable
+    (slots, <Clickable
       onFocus={() => dispatch(SetFocus(true))}
       onBlur={() => dispatch(SetFocus(false))}>
       <View style=viewStyles>
         <Text style=innerTextStyles text=content />
         <View style=inputCursorStyles />
       </View>
-    </Clickable>;
+    </Clickable>);
   });
 
 let createElement =
@@ -232,7 +232,6 @@ let createElement =
       ~onChange=noop,
       (),
     ) =>
-  React.element(
     make(
       ~window,
       ~value,
@@ -242,5 +241,4 @@ let createElement =
       ~placeholderColor,
       ~onChange,
       (),
-    ),
   );

--- a/src/UI_Components/RadioButtons.re
+++ b/src/UI_Components/RadioButtons.re
@@ -26,9 +26,9 @@ let make =
     ) =>
   component(slots => {
     let defaultVal = List.nth(buttons, defaultSelected).value;
-    let (checkedVal, setCheckedVal, _slots: React.Hooks.empty) =
+    let (checkedVal, setCheckedVal, slots) =
       React.Hooks.state(defaultVal, slots);
-    <View style=Style.[justifyContent(`Center), alignItems(`Center)]>
+    (slots, <View style=Style.[justifyContent(`Center), alignItems(`Center)]>
       ...{
            buttons
            |> List.map(button => {
@@ -55,7 +55,7 @@ let make =
                 </Clickable>;
               })
          }
-    </View>;
+    </View>);
   });
 
 let createElement =
@@ -68,6 +68,4 @@ let createElement =
       ~onChange=_ => (),
       (),
     ) =>
-  React.element(
-    make(~defaultSelected, ~buttons, ~iconSize, ~style, ~onChange, ()),
-  );
+    make(~defaultSelected, ~buttons, ~iconSize, ~style, ~onChange, ());

--- a/src/UI_Components/ScrollView.re
+++ b/src/UI_Components/ScrollView.re
@@ -16,7 +16,7 @@ let make =
       React.Hooks.state(scrollTop, slots);
     let (outerRef: option(Revery_UI.node), setOuterRef, slots) =
       React.Hooks.state(None, slots);
-    let (actualScrollLeft, setScrollLeft, _slots: React.Hooks.empty) =
+    let (actualScrollLeft, setScrollLeft, slots) =
       React.Hooks.state(scrollLeft, slots);
 
     let scrollBarThickness = 10;
@@ -147,7 +147,7 @@ let make =
         height(scrollBarThickness),
       ];
 
-    <View style>
+    (slots, <View style>
       <View
         onMouseWheel=scroll
         ref={r => setOuterRef(Some(r))}
@@ -162,10 +162,8 @@ let make =
           horizontalScrollBar
         </View>
       </View>
-    </View>;
+    </View>);
   });
 
 let createElement = (~children, ~style, ~scrollLeft=0, ~scrollTop=0, ()) =>
-  React.element(
-    make(~style, ~scrollLeft, ~scrollTop, React.listToElement(children)),
-  );
+    make(~style, ~scrollLeft, ~scrollTop, React.listToElement(children));

--- a/src/UI_Components/Slider.re
+++ b/src/UI_Components/Slider.re
@@ -42,7 +42,7 @@ let make =
     /* Initial value is used to detect if the 'value' parameter ever changes */
     let (initialValue, setInitialValue, slots) =
       React.Hooks.state(value, slots);
-    let (v, setV, _slots: React.Hooks.empty) =
+    let (v, setV, slots) =
       React.Hooks.state(value, slots);
 
     /*
@@ -184,6 +184,7 @@ let make =
         backgroundColor(sliderBackgroundColor),
       ];
 
+    (slots,
     <View onMouseDown style ref={r => setSlideRef(r)}>
       <View style=beforeTrackStyle />
       <View
@@ -198,7 +199,7 @@ let make =
         ]
       />
       <View style=afterTrackStyle />
-    </View>;
+    </View>);
   });
 
 let createElement =
@@ -218,7 +219,6 @@ let createElement =
       ~thumbColor=Colors.gray,
       (),
     ) =>
-  React.element(
     make(
       ~vertical,
       ~onValueChanged,
@@ -233,5 +233,4 @@ let createElement =
       ~minimumTrackColor,
       ~thumbColor,
       (),
-    ),
   );

--- a/src/UI_Components/Tree.re
+++ b/src/UI_Components/Tree.re
@@ -109,9 +109,9 @@ let rec renderTree = (~indent=0, ~nodeRenderer, ~emptyRenderer, t) => {
 };
 
 let make = (~tree, ~nodeRenderer, ~emptyRenderer) =>
-  component((_slots: React.Hooks.empty) => {
+  component((slots) => {
     let componentTree = renderTree(tree, ~nodeRenderer, ~emptyRenderer);
-    <View> ...componentTree </View>;
+    (slots, <View> ...componentTree </View>);
   });
 
 /*
@@ -121,4 +121,4 @@ let make = (~tree, ~nodeRenderer, ~emptyRenderer) =>
  */
 let createElement =
     (~tree, ~nodeRenderer, ~emptyRenderer=None, ~children as _, ()) =>
-  React.element(make(~tree, ~nodeRenderer, ~emptyRenderer));
+  make(~tree, ~nodeRenderer, ~emptyRenderer);


### PR DESCRIPTION
This upgrades Revery to use the latest `brisk-reconciler`, which changes (streamlines) the API a bit:

- A separate `React.element` call is no longer needed thanks to @jchavarri 's work - going through and updating these!
- Components now return a tuple of `(hooks, <JSX />)`  thanks to @wokalski 's work 

TODO:
- Rename `slots` -> `hooks`
- Remove additional `make`