### PR TITLE
Fix #342: Slider not updating values as mouse moves

### DIFF
--- a/src/UI_Components/Slider.re
+++ b/src/UI_Components/Slider.re
@@ -15,40 +15,6 @@ let noop = () => ();
 type valueChangedFunction = float => unit;
 let noopValueChanged = _f => ();
 
-type sliderSessionState = {
-  startPosition: int,
-  endPosition: int,
-  availableWidth: int,
-};
-
-type state = {
-  initialValue: float,
-  value: float,
-  sliderSession: option(sliderSessionState),
-};
-
-let createInitialState: float => state =
-  v => {initialValue: v, value: v, sliderSession: None};
-
-type mouseMove = {
-  mouseX: float,
-  mouseY: float,
-};
-
-type actions =
-  | UpdateInitialValue(float)
-  | Start
-  | MouseMove(mouseMove)
-  | End;
-
-let reducer = (_action: actions, s: state) => s;
-
-let isActive = (v: state) =>
-  switch (v.sliderSession) {
-  | Some(_) => true
-  | None => false
-  };
-
 let component = React.component("Slider");
 
 let createElement =
@@ -69,10 +35,6 @@ let createElement =
       (),
     ) =>
   component(hooks => {
-    let initialState = createInitialState(value);
-    let (_state, _dispatch, hooks) =
-      React.Hooks.reducer(~initialState, reducer, hooks);
-
     let (slideRef, setSlideRefOption, hooks) =
       React.Hooks.state(None, hooks);
     let (thumbRef, setThumbRefOption, hooks) =

--- a/src/UI_Components/Slider.re
+++ b/src/UI_Components/Slider.re
@@ -86,6 +86,32 @@ let createElement =
       | _ => None
       };
 
+    let getValue = (x, min, max) =>
+      if (x < min) {
+        min;
+      } else if (x > max) {
+        max;
+      } else {
+        x;
+      };
+
+        let sliderUpdate = (w, startPosition, endPosition, mouseX, mouseY) => {
+          let mousePosition = vertical ? mouseY : mouseX;
+          let thumbPosition = getValue(mousePosition, startPosition, endPosition) -. startPosition;
+
+          let normalizedValue =
+            thumbPosition
+            /. w
+            *. (maximumValue -. minimumValue)
+            +. minimumValue;
+          setV(normalizedValue);
+          onValueChanged(normalizedValue);
+        };
+
+        let sliderComplete = () => {
+            setActive(false);
+        }
+
     let onMouseDown = (evt: NodeEvents.mouseButtonEventParams) =>
       switch (slideRef, availableWidth) {
       | (Some(slider), Some(w)) =>
@@ -97,37 +123,15 @@ let createElement =
             : Vec2.get_x(sliderDimensions.min);
         let endPosition = startPosition +. w;
 
-        let getValue = x =>
-          if (x < startPosition) {
-            startPosition;
-          } else if (x > endPosition) {
-            endPosition;
-          } else {
-            x;
-          };
-
-        let update = (mouseX, mouseY) => {
-          let mousePosition = vertical ? mouseY : mouseX;
-          let thumbPosition = getValue(mousePosition) -. startPosition;
-
-          let normalizedValue =
-            thumbPosition
-            /. w
-            *. (maximumValue -. minimumValue)
-            +. minimumValue;
-          setV(normalizedValue);
-          onValueChanged(normalizedValue);
-        };
-
-        update(evt.mouseX, evt.mouseY);
+        sliderUpdate(w, startPosition, endPosition, evt.mouseX, evt.mouseY);
         setActive(true);
 
         Mouse.setCapture(
-          ~onMouseMove=evt => update(evt.mouseX, evt.mouseY),
+          ~onMouseMove=evt => sliderUpdate(w, startPosition, endPosition, evt.mouseX, evt.mouseY),
           ~onMouseUp=
             _evt => {
               Mouse.releaseCapture();
-              setActive(false);
+              sliderComplete();
             },
           (),
         );


### PR DESCRIPTION
This fixes #342 - slider not updating as mouse moves. Thanks @wokalski for the help troubleshooting and debugging!

This uses the `effect` hook per @wokalski 's suggestion so that the functions for `onMouseMove` and `onMouseUp` always have the latest variables provided by the hooks (so they never call a stale setter)