### PR TITLE
Add harfbuzz to list of dependencies and a note about the minimum required version

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,16 @@ Install the following packages with your package manager of choice:
 * `xorg-dev`
 * `libglu1-mesa-dev`
 * `libharfbuzz-dev`
-> __NOTE:__ `reason-fontkit` (a dependency of `revery`) requires `harfbuzz` 1.7.7+.
+  
+##### For `Fedora` you may need these additional packages
+* `libpng-devel`
+* `bzip2-devel`
+* `m4`
+* `xorg-x11-server-devel`
+* `mesa-libGLU-devel`
+* `harfbuzz-devel`
+
+> __NOTE:__ `reason-fontkit` (a dependency of `revery`) requires `harfbuzz` 1.7.7+. This means `revery` requires Fedora 29+
 
 
 #### For `Windows` native

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Install the following packages with your package manager of choice:
 * `m4`
 * `xorg-dev`
 * `libglu1-mesa-dev`
+* `libharfbuzz-dev`
+> __NOTE:__ `reason-fontkit` (a dependency of `revery`) requires `harfbuzz` 1.7.7+.
+
 
 #### For `Windows` native
 


### PR DESCRIPTION
This is to prevent any issues in the future, like #339 with Fedora 28. @bryphe noted that this could also be fixed with linker flags, but I think this is a good (temporary) solution.