### PR TITLE
Fix #347: High-dpi display text rendering issues

### DIFF
--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -195,6 +195,6 @@ class textNode (text: string) = {
   };
   pri _getLineHeightPx = pixelRatio => {
     let style = _super#getStyle();
-    style.lineHeight *. float_of_int(style.fontSize) *. pixelRatio;
+    style.lineHeight *. float_of_int(style.fontSize) /. pixelRatio;
   };
 };

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -146,7 +146,7 @@ class textNode (text: string) = {
         let (lines, maxWidthLine) =
           TextWrapping.wrapText(
             ~text,
-            ~measureWidth=str => FontRenderer.measure(font, str).width,
+            ~measureWidth=str => int_of_float(float_of_int(FontRenderer.measure(font, str).width) /. pixelRatio),
             ~maxWidth=width,
             ~wrapHere=TextWrapping.isWhitespaceWrapPoint,
           );

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -41,7 +41,8 @@ class textNode (text: string) = {
             float_of_int(style.fontSize) *. parentContext.pixelRatio +. 0.5,
           ),
         );
-      let lineHeightPx = _this#_getLineHeightPx(font, parentContext.pixelRatio);
+      let lineHeightPx =
+        _this#_getLineHeightPx(font, parentContext.pixelRatio);
       let color = Color.multiplyAlpha(opacity, style.color);
       Shaders.CompiledShader.setUniform4fv(
         textureShader,
@@ -147,7 +148,12 @@ class textNode (text: string) = {
         let (lines, maxWidthLine) =
           TextWrapping.wrapText(
             ~text,
-            ~measureWidth=str => int_of_float(float_of_int(FontRenderer.measure(font, str).width) /. pixelRatio),
+            ~measureWidth=
+              str =>
+                int_of_float(
+                  float_of_int(FontRenderer.measure(font, str).width)
+                  /. pixelRatio,
+                ),
             ~maxWidth=width,
             ~wrapHere=TextWrapping.isWhitespaceWrapPoint,
           );
@@ -157,9 +163,7 @@ class textNode (text: string) = {
         let dimensions: Layout.LayoutTypes.dimensions = {
           width: int_of_float(float_of_int(maxWidthLine)),
           height:
-            int_of_float(
-              float_of_int(List.length(lines)) *. lineHeightPx,
-            ),
+            int_of_float(float_of_int(List.length(lines)) *. lineHeightPx),
         };
 
         dimensions;

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -155,10 +155,10 @@ class textNode (text: string) = {
         _lines := lines;
 
         let dimensions: Layout.LayoutTypes.dimensions = {
-          width: int_of_float(float_of_int(maxWidthLine) /. pixelRatio),
+          width: int_of_float(float_of_int(maxWidthLine)),
           height:
             int_of_float(
-              float_of_int(List.length(lines)) *. lineHeightPx /. pixelRatio,
+              float_of_int(List.length(lines)) *. lineHeightPx,
             ),
         };
 

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -34,7 +34,6 @@ class textNode (text: string) = {
 
       let style = _super#getStyle();
       let opacity = style.opacity *. parentContext.opacity;
-      let lineHeightPx = _this#_getLineHeightPx(parentContext.pixelRatio);
       let font =
         FontCache.load(
           style.fontFamily,
@@ -42,6 +41,7 @@ class textNode (text: string) = {
             float_of_int(style.fontSize) *. parentContext.pixelRatio +. 0.5,
           ),
         );
+      let lineHeightPx = _this#_getLineHeightPx(font, parentContext.pixelRatio);
       let color = Color.multiplyAlpha(opacity, style.color);
       Shaders.CompiledShader.setUniform4fv(
         textureShader,
@@ -134,12 +134,13 @@ class textNode (text: string) = {
       /* TODO: Cache font locally in variable */
       let style = _super#getStyle();
       let textWrap = style.textWrap;
-      let lineHeightPx = _this#_getLineHeightPx(pixelRatio);
       let font =
         FontCache.load(
           style.fontFamily,
           int_of_float(float_of_int(style.fontSize) *. pixelRatio),
         );
+
+      let lineHeightPx = _this#_getLineHeightPx(font, pixelRatio);
 
       switch (textWrap) {
       | WhitespaceWrap =>
@@ -193,8 +194,9 @@ class textNode (text: string) = {
     };
     Some(measure);
   };
-  pri _getLineHeightPx = pixelRatio => {
+  pri _getLineHeightPx = (font, pixelRatio) => {
     let style = _super#getStyle();
-    style.lineHeight *. float_of_int(style.fontSize) /. pixelRatio;
+    let metrics = FontRenderer.getNormalizedMetrics(font);
+    style.lineHeight *. metrics.height /. pixelRatio;
   };
 };


### PR DESCRIPTION
There were a couple of issues with text-rendering on high-dpi displays. These stem from the fact that if the `pixelRatio` is `2`, `3`, we actually request a glyph thats 2x or 3x bigger than the screen-space coordinates - otherwise, we'll end up with a font glyph that is low-resolution. On a Macbook retina display, for example, if our screen-space Window is 800x600, it might actually have a framebuffer size of 1600x1200 or 2400x1800. 

Then, if we render a glyph for font size 14px, we actually want to render it at either a 28px or 42px size, so we get the full glyph resolution. This is challenging for layout because it means the font metrics we get are actually scaled up, which we actually have to scale back down by dividing by the pixel ratio.

__Fixes:__
1) The `lineHeightPx` method wasn't taking into account the measured height of the font (which could be different than the actual pixel height) 
2) The `measureWidth` was using the up-scaled font size, so we need to convert that back down 
3) With the above fixes for 1/2, the pixelRatio was applied again for the size of the measured box - so we need to remove those applications

