### PR TITLE
Cleanup: Remove autosize

### DIFF
--- a/examples/Autocomplete.re
+++ b/examples/Autocomplete.re
@@ -158,7 +158,7 @@ let init = app => {
     </View>;
   };
 
-  UI.start(~createOptions={autoSize: true}, w, render);
+  UI.start(w, render);
 };
 
 App.startWithState(initialState, reducer, init);

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -31,7 +31,6 @@ open UiContainer;
 
 let start =
     (
-      ~createOptions=UiContainer.Options.default,
       window: Window.t,
       render: renderFunction,
     ) => {
@@ -52,7 +51,6 @@ let start =
       rootNode,
       container,
       mouseCursor,
-      createOptions,
     );
 
   let scaleFactor = Revery_Core.Monitor.getScaleFactor();

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -29,11 +29,7 @@ type renderFunction = unit => UiReact.syntheticElement;
 
 open UiContainer;
 
-let start =
-    (
-      window: Window.t,
-      render: renderFunction,
-    ) => {
+let start = (window: Window.t, render: renderFunction) => {
   let uiDirty = ref(false);
 
   let onStale = () => {
@@ -45,13 +41,7 @@ let start =
   let rootNode = (new viewNode)();
   let mouseCursor: Mouse.Cursor.t = Mouse.Cursor.make();
   let container = React.Container.create(rootNode);
-  let ui =
-    UiContainer.create(
-      window,
-      rootNode,
-      container,
-      mouseCursor,
-    );
+  let ui = UiContainer.create(window, rootNode, container, mouseCursor);
 
   let scaleFactor = Revery_Core.Monitor.getScaleFactor();
 

--- a/src/UI/UiContainer.re
+++ b/src/UI/UiContainer.re
@@ -7,32 +7,16 @@
 
 module Window = Revery_Core.Window;
 
-/*
- * Options specific to the Window <-> UI link
- */
-module Options = {
-  type t = {
-    /*
-     * autoSize: Resize the window to match the layout
-     */
-    autoSize: bool,
-  };
-
-  let default: t = {autoSize: false};
-};
-
 type t = {
   rootNode: ViewNode.viewNode,
   container: ref(UiReact.Container.t),
   window: Window.t,
   mouseCursor: Mouse.Cursor.t,
-  options: Options.t,
 };
 
-let create = (window, rootNode, container, mouseCursor, options) => {
+let create = (window, rootNode, container, mouseCursor) => {
   window,
   rootNode,
   container: ref(container),
   mouseCursor,
-  options,
 };

--- a/src/UI/UiRender.re
+++ b/src/UI/UiRender.re
@@ -19,7 +19,7 @@ open RenderPass;
 let _projection = Mat4.create();
 
 let render = (container: UiContainer.t, component: UiReact.syntheticElement) => {
-  let {rootNode, window, container, options, _} = container;
+  let {rootNode, window, container, _} = container;
 
   AnimationTicker.tick();
 
@@ -35,27 +35,15 @@ let render = (container: UiContainer.t, component: UiReact.syntheticElement) => 
   let adjustedHeight = size.height / scaleFactor;
   let adjustedWidth = size.width / scaleFactor;
 
-  switch (options.autoSize) {
-  | false =>
-    rootNode#setStyle(
-      Style.make(
-        ~position=LayoutTypes.Relative,
-        ~width=adjustedWidth,
-        ~height=adjustedHeight,
-        (),
-      ),
-    );
-    Layout.layout(rootNode, pixelRatio, scaleFactor);
-  | true =>
-    rootNode#setStyle(Style.make());
-    Layout.layout(rootNode, pixelRatio, scaleFactor);
-    let measurements = rootNode#measurements();
-    let size: Window.windowSize = {
-      width: measurements.width / scaleFactor,
-      height: measurements.height / scaleFactor,
-    };
-    Window.setSize(window, size.width, size.height);
-  };
+rootNode#setStyle(
+  Style.make(
+    ~position=LayoutTypes.Relative,
+    ~width=adjustedWidth,
+    ~height=adjustedHeight,
+    (),
+  ),
+);
+Layout.layout(rootNode, pixelRatio, scaleFactor);
 
   /* Recalculate cached parameters */
   Performance.bench("recalculate", () => rootNode#recalculate());

--- a/src/UI/UiRender.re
+++ b/src/UI/UiRender.re
@@ -35,15 +35,15 @@ let render = (container: UiContainer.t, component: UiReact.syntheticElement) => 
   let adjustedHeight = size.height / scaleFactor;
   let adjustedWidth = size.width / scaleFactor;
 
-rootNode#setStyle(
-  Style.make(
-    ~position=LayoutTypes.Relative,
-    ~width=adjustedWidth,
-    ~height=adjustedHeight,
-    (),
-  ),
-);
-Layout.layout(rootNode, pixelRatio, scaleFactor);
+  rootNode#setStyle(
+    Style.make(
+      ~position=LayoutTypes.Relative,
+      ~width=adjustedWidth,
+      ~height=adjustedHeight,
+      (),
+    ),
+  );
+  Layout.layout(rootNode, pixelRatio, scaleFactor);
 
   /* Recalculate cached parameters */
   Performance.bench("recalculate", () => rootNode#recalculate());


### PR DESCRIPTION
This removes the `autoSize` option from the UI. This simplifies the layout / rendering aspect. The feature was only used in the `Autocomplete` example but isn't used anywhere else - and there were a few issues with it. 

With GLFW 3.3, there will be a better way to handle this scenario - there's support for window transparency and framebuffer transparency, which will be a more robust way to create overlay-style apps that change size.