### PR TITLE
API: Move 'Revery.Core' into 'Revery'

### DIFF
--- a/examples/AnalogClock.re
+++ b/examples/AnalogClock.re
@@ -1,4 +1,4 @@
-open Revery.Core;
+open Revery;
 open Revery.Math;
 open Revery.UI;
 

--- a/examples/Autocomplete.re
+++ b/examples/Autocomplete.re
@@ -1,5 +1,4 @@
 open Revery;
-open Revery.Core;
 open Revery.UI;
 
 /* Define our app state */

--- a/examples/Border.re
+++ b/examples/Border.re
@@ -1,5 +1,5 @@
+open Revery;
 open Revery.UI;
-open Revery.Core;
 
 let defaultStyle =
   Style.[

--- a/examples/Boxshadow.re
+++ b/examples/Boxshadow.re
@@ -1,5 +1,5 @@
+open Revery;
 open Revery.UI;
-open Revery.Core;
 
 let parentStyles =
   Style.[

--- a/examples/Calculator.re
+++ b/examples/Calculator.re
@@ -1,7 +1,6 @@
-/* open Revery; */
-open Revery.Core;
-open Revery.Core.Events;
-open Revery.Core.Window;
+open Revery;
+open Revery.Events;
+open Revery.Window;
 open Revery.UI;
 open Revery.UI.Components;
 

--- a/examples/CheckboxExample.re
+++ b/examples/CheckboxExample.re
@@ -1,4 +1,4 @@
-open Revery.Core;
+open Revery;
 open Revery.UI;
 open Revery.UI.Components;
 

--- a/examples/DefaultButton.re
+++ b/examples/DefaultButton.re
@@ -1,6 +1,6 @@
+open Revery;
 open Revery.UI;
 open Revery.UI.Components;
-open Revery.Core;
 
 module DefaultButtonWithCounter = {
   let component = React.component("DefaultButtonWithCounter");

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -1,6 +1,4 @@
 open Revery;
-open Revery.Core;
-/* open Revery.Math; */
 open ExampleStubs;
 
 module SliderExample = Slider;

--- a/examples/Flexbox.re
+++ b/examples/Flexbox.re
@@ -1,5 +1,5 @@
+open Revery;
 open Revery.UI;
-open Revery.Core;
 
 let parentWidth = 400;
 let childWidth = 300;

--- a/examples/Focus.re
+++ b/examples/Focus.re
@@ -1,4 +1,4 @@
-open Revery.Core;
+open Revery;
 open Revery.UI;
 open Revery.UI.Components;
 

--- a/examples/GameOfLife.re
+++ b/examples/GameOfLife.re
@@ -1,4 +1,4 @@
-open Revery.Core;
+open Revery;
 open Revery.Time;
 open Revery.UI;
 open Revery.UI.Components;

--- a/examples/Hello.re
+++ b/examples/Hello.re
@@ -1,4 +1,4 @@
-open Revery.Core;
+open Revery;
 open Revery.Math;
 open Revery.UI;
 

--- a/examples/HoverExample.re
+++ b/examples/HoverExample.re
@@ -1,4 +1,4 @@
-open Revery.Core;
+open Revery;
 open Revery.UI;
 
 type state = {

--- a/examples/InputExample.re
+++ b/examples/InputExample.re
@@ -1,5 +1,5 @@
+open Revery;
 open Revery.UI;
-open Revery.Core;
 open Revery.UI.Components;
 
 let containerStyle =

--- a/examples/RadioButtonExample.re
+++ b/examples/RadioButtonExample.re
@@ -1,4 +1,4 @@
-open Revery.Core;
+open Revery;
 open Revery.UI;
 open Revery.UI.Components;
 

--- a/examples/ScreenCapture.re
+++ b/examples/ScreenCapture.re
@@ -1,6 +1,6 @@
+open Revery;
 open Revery.UI;
 open Revery.UI.Components;
-open Revery.Core;
 
 let backgroundColor = Color.hex("#212733");
 let activeBackgroundColor = Color.hex("#2E3440");

--- a/examples/ScrollView.re
+++ b/examples/ScrollView.re
@@ -1,5 +1,5 @@
+open Revery;
 open Revery.UI;
-open Revery.Core;
 open Revery.UI.Components;
 
 let containerStyle =

--- a/examples/Slider.re
+++ b/examples/Slider.re
@@ -1,4 +1,4 @@
-open Revery.Core;
+open Revery;
 open Revery.Math;
 open Revery.UI;
 open Revery.UI.Components;

--- a/examples/Stopwatch.re
+++ b/examples/Stopwatch.re
@@ -1,6 +1,5 @@
-/* open Revery; */
+open Revery;
 open Revery.Time;
-open Revery.Core;
 open Revery.Math;
 open Revery.UI;
 open Revery.UI.Components;

--- a/examples/TextExample.re
+++ b/examples/TextExample.re
@@ -1,5 +1,5 @@
+open Revery;
 open Revery.UI;
-open Revery.Core;
 open Revery.UI.Components;
 
 let containerStyle =

--- a/examples/TodoExample.re
+++ b/examples/TodoExample.re
@@ -1,5 +1,5 @@
+open Revery;
 open Revery.UI;
-open Revery.Core;
 open Revery.UI.Components;
 
 type todo = {

--- a/examples/TreeView.re
+++ b/examples/TreeView.re
@@ -1,4 +1,4 @@
-open Revery.Core;
+open Revery;
 open Revery.UI;
 open Revery.UI.Components;
 

--- a/src/Revery.re
+++ b/src/Revery.re
@@ -1,4 +1,10 @@
-module Core = Revery_Core;
+
+/*
+ * Include Revery_Core in the top level 'Revery' module
+ * Otherwise it's confusing when to open 'Revery' vs 'Revery.Core'
+ */
+include Revery_Core;
+
 module Geometry = Revery_Geometry;
 module Math = Revery_Math;
 module Shaders = Revery_Shaders;
@@ -6,8 +12,8 @@ module UI = {
   include Revery_UI;
 
   /*
-     Include Components such that consumers access it via:
-     Revery.UI.Components
+   * Include Components such that consumers access it via:
+   * Revery.UI.Components
    */
   module Components = Revery_UI_Components;
 };

--- a/src/Revery.re
+++ b/src/Revery.re
@@ -1,4 +1,3 @@
-
 /*
  * Include Revery_Core in the top level 'Revery' module
  * Otherwise it's confusing when to open 'Revery' vs 'Revery.Core'

--- a/src/Revery.re
+++ b/src/Revery.re
@@ -17,9 +17,6 @@ module UI = {
    */
   module Components = Revery_UI_Components;
 };
-module App = Core.App;
-module Window = Core.Window;
-module Time = Core.Time;
 
 module Platform = {
   include Platform;


### PR DESCRIPTION
The `Revery.Core` vs `Revery` module is confusing - it's not clear when to `open Revery` or `open Revery.Core`. 

This change moves the entirety of `Revery.Core` into `Revery`, to remove that confusion.