### PR TITLE
API: Use polymorphic variant for Overflow

### DIFF
--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -424,11 +424,12 @@ let transform = t => `Transform(t);
 let boxShadow = (~xOffset, ~yOffset, ~spreadRadius, ~blurRadius, ~color) =>
   `BoxShadow(BoxShadow.{xOffset, yOffset, spreadRadius, blurRadius, color});
 
-let overflow = o => switch(o) {
-| `Visible => `Overflow(LayoutTypes.Visible)  
-| `Hidden => `Overflow(LayoutTypes.Hidden)  
-| `Scroll => `Overflow(LayoutTypes.Scroll)
-};
+let overflow = o =>
+  switch (o) {
+  | `Visible => `Overflow(LayoutTypes.Visible)
+  | `Hidden => `Overflow(LayoutTypes.Hidden)
+  | `Scroll => `Overflow(LayoutTypes.Scroll)
+  };
 
 let color = o => `Color(o);
 let backgroundColor = o => `BackgroundColor(o);

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -423,7 +423,13 @@ let opacity = o => `Opacity(o);
 let transform = t => `Transform(t);
 let boxShadow = (~xOffset, ~yOffset, ~spreadRadius, ~blurRadius, ~color) =>
   `BoxShadow(BoxShadow.{xOffset, yOffset, spreadRadius, blurRadius, color});
-let overflow = o => `Overflow(o);
+
+let overflow = o => switch(o) {
+| `Visible => `Overflow(LayoutTypes.Visible)  
+| `Hidden => `Overflow(LayoutTypes.Hidden)  
+| `Scroll => `Overflow(LayoutTypes.Scroll)
+};
+
 let color = o => `Color(o);
 let backgroundColor = o => `BackgroundColor(o);
 

--- a/src/UI_Components/Dropdown.re
+++ b/src/UI_Components/Dropdown.re
@@ -102,7 +102,7 @@ let createElement =
               style=Style.[
                 width(float_of_int(w) *. 0.8 |> int_of_float),
                 justifyContent(`Center),
-                overflow(LayoutTypes.Hidden),
+                overflow(`Hidden),
               ]>
               <Text style=textStyles text={state.selected.label} />
             </View>
@@ -127,7 +127,7 @@ let createElement =
               ~width=float_of_int(h) *. 0.05 |> int_of_float,
               ~color=Colors.black,
             ),
-            overflow(LayoutTypes.Hidden),
+            overflow(`Hidden),
           ]>
           ...items
         </View>

--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -116,7 +116,7 @@ let make =
             flexDirection(`Row),
             alignItems(`Center),
             justifyContent(`FlexStart),
-            overflow(LayoutTypes.Hidden),
+            overflow(`Hidden),
             cursor(MouseCursors.text),
             ...defaultStyles,
           ],

--- a/src/UI_Components/ScrollView.re
+++ b/src/UI_Components/ScrollView.re
@@ -209,7 +209,7 @@ let make =
           style=Style.[
             flexGrow(1),
             position(`Relative),
-            overflow(LayoutTypes.Scroll),
+            overflow(`Scroll),
           ]>
           <View style=innerStyle> children </View>
           <View style=verticalScrollbarContainerStyle>

--- a/src/UI_Components/ScrollView.re
+++ b/src/UI_Components/ScrollView.re
@@ -206,11 +206,7 @@ let make =
         <View
           onMouseWheel=scroll
           ref={r => setOuterRef(Some(r))}
-          style=Style.[
-            flexGrow(1),
-            position(`Relative),
-            overflow(`Scroll),
-          ]>
+          style=Style.[flexGrow(1), position(`Relative), overflow(`Scroll)]>
           <View style=innerStyle> children </View>
           <View style=verticalScrollbarContainerStyle>
             verticalScrollBar


### PR DESCRIPTION
Most of our style properties use polymorphic variants now, like `Style.[position('Absolute)]`. However, `overflow` was still using the `LayoutTypes` which is confusing and not very discoverable. This switches the `overflow` style property to use the polymorphic variant style.