### PR TITLE
[WIP] Performance: Cache layout nodes

### DIFF
--- a/ReveryBench.opam
+++ b/ReveryBench.opam
@@ -1,0 +1,7 @@
+opam-version: "1.2"
+version: "dev"
+maintainer: "bryphe@outlook.com"
+author: ["Bryan Phelps"]
+build: [
+
+]

--- a/bench.json
+++ b/bench.json
@@ -1,0 +1,12 @@
+{
+  "source": "./package.json",
+  "override": {
+      "build": ["dune build --root . -j4"],
+      "dependencies": {
+        "reperf": "^1.2.0"
+      },
+      "install": [
+          "esy-installer ReveryBench.install"
+      ]
+  }
+}

--- a/bench.json
+++ b/bench.json
@@ -3,7 +3,7 @@
   "override": {
       "build": ["dune build --root . -j4"],
       "dependencies": {
-        "reperf": "^1.2.0"
+        "reperf": "*"
       },
       "install": [
           "esy-installer ReveryBench.install"

--- a/bench/exe/Bench.re
+++ b/bench/exe/Bench.re
@@ -1,0 +1,1 @@
+ReveryBench.BenchFramework.cli();

--- a/bench/exe/dune
+++ b/bench/exe/dune
@@ -1,0 +1,6 @@
+(executable
+    (name bench)
+    (public_name ReveryBench)
+    (libraries ReveryBench.lib)
+    (package ReveryBench)
+)

--- a/bench/lib/BenchFramework.re
+++ b/bench/lib/BenchFramework.re
@@ -1,0 +1,3 @@
+include Reperf.Make({
+  let config = Reperf.Config.create(~snapshotDir="bench/__snapshots__", ());
+});

--- a/bench/lib/LayoutBench.re
+++ b/bench/lib/LayoutBench.re
@@ -8,9 +8,60 @@ let createNode = () => {
     let _ = (new node)();
 };
 
+let setupNode = (~style, ()) => {
+     let n = (new node)();
+     n#setStyle(style);
+     n;
+};
+
+let rec setupNodeTree = (~depth: int, ~breadth: int, ~style=Style.make(~width=400, ~height=400, ()), ()) => {
+
+    let i = ref(breadth);
+
+    let n = setupNode(~style, ());
+
+    while (i^ > 0 && depth > 0) {
+
+        let newNode = setupNodeTree(~depth=depth-1, ~breadth, ());
+        n#addChild(newNode);
+
+        decr(i);
+    }
+
+    n;
+}
+
+let layoutNode = (n: node) => {
+   Layout.layout(n, 1.0, 1); 
+}
+
 bench(
-  ~name="Node: create",
+  ~name="Node: create single node",
   ~options,
+  ~setup={() => ()},
   ~f=createNode,
+  (),
+);
+
+bench(
+  ~name="Layout: layout single node",
+  ~options,
+  ~setup=setupNode(~style=Style.make(~width=100, ~height=100, ())),
+  ~f=layoutNode,
+  (),
+);
+
+bench(
+  ~name="Layout: layout node tree (4 deep, 4 wide)",
+  ~options,
+  ~setup=setupNodeTree(~depth=4, ~breadth=4),
+  ~f=layoutNode,
+  (),
+);
+bench(
+  ~name="Layout: layout node tree (4 deep, 4 wide) - minimal layout",
+  ~options,
+  ~setup=setupNodeTree(~depth=4, ~breadth=4, ~style=Style.make(~width=400, ~height=400, ~layoutMode=Style.LayoutMode.Minimal, ())),
+  ~f=layoutNode,
   (),
 );

--- a/bench/lib/LayoutBench.re
+++ b/bench/lib/LayoutBench.re
@@ -1,0 +1,16 @@
+open BenchFramework;
+
+open Revery.UI;
+
+let options = Reperf.Options.create(~iterations=10000, ());
+
+let createNode = () => {
+    let _ = (new node)();
+};
+
+bench(
+  ~name="Node: create",
+  ~options,
+  ~f=createNode,
+  (),
+);

--- a/bench/lib/dune
+++ b/bench/lib/dune
@@ -1,0 +1,6 @@
+(library
+    (name ReveryBench)
+    (public_name ReveryBench.lib)
+    (ocamlopt_flags -linkall)
+    (libraries Revery reperf.lib)
+)

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "ocaml": "^4.7.0",
     "@opam/merlin": "*",
     "@opam/dune": "^1.5.0",
-    "@opam/odoc": "*"
+    "@opam/odoc": "*",
+    "reperf": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "@opam/cmdliner": "1.0.2",
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
-    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#daa00be"
+    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#daa00be",
+    "reperf": "link:../reperf"
   },
   "peerDependencies": {
     "ocaml": "^4.7.0"
@@ -61,6 +62,6 @@
     "@opam/merlin": "*",
     "@opam/dune": "^1.5.0",
     "@opam/odoc": "*",
-    "reperf": "^1.2.0"
+    "reperf": "*"
   }
 }

--- a/src/UI/Layout.re
+++ b/src/UI/Layout.re
@@ -34,12 +34,17 @@ let createNodeWithMeasure = (children, style, measure) =>
 let layout = (node, pixelRatio, scaleFactor) =>
   Performance.bench("layout", () => {
     let layoutNode = node#toLayoutNode(pixelRatio, scaleFactor);
-    Layout.layoutNode(
-      layoutNode,
-      Encoding.cssUndefined,
-      Encoding.cssUndefined,
-      Ltr,
-    );
+    switch (layoutNode) {
+    | None => ()
+    | Some(v) => {
+        Layout.layoutNode(
+          v,
+          Encoding.cssUndefined,
+          Encoding.cssUndefined,
+          Ltr,
+        );
+        }
+    };
   });
 let printCssNode = root =>
   LayoutPrint.printCssNode((

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -26,6 +26,23 @@ module BoxShadow = {
   };
 };
 
+module LayoutMode {
+
+    /**
+     * LayoutMode allows finer-grained control over how nodes are layout.
+     * The default is 'Flex' which uses a yoga-like flex-box interpretation of the styles.
+     * However, for performance, sometimes a more streamlined strategy is doable -
+     * the 'Minimal' strategy only respects the following properties:
+        - width
+        - height
+        - transform
+    * But it also incurs much reduced overhead compared to the default layout strategy.
+    */
+    type t =
+    | Default
+    | Minimal;
+}
+
 type t = {
   backgroundColor: Color.t,
   color: Color.t,
@@ -47,6 +64,7 @@ type t = {
   fontFamily,
   fontSize: int,
   lineHeight: float,
+  layoutMode: LayoutMode.t,
   textWrap: TextWrapping.wrapType,
   marginTop: int,
   marginLeft: int,
@@ -97,6 +115,7 @@ let make =
       ~right=Encoding.cssUndefined,
       ~fontFamily="",
       ~fontSize=Encoding.cssUndefined,
+      ~layoutMode=LayoutMode.Default,
       ~lineHeight=1.2,
       ~textWrap=TextWrapping.WhitespaceWrap,
       ~marginTop=Encoding.cssUndefined,
@@ -153,6 +172,7 @@ let make =
     right,
     fontFamily,
     fontSize,
+    layoutMode,
     lineHeight,
     textWrap,
     transform,
@@ -263,6 +283,7 @@ type coreStyleProps = [
   | `Right(int)
   | `Bottom(int)
   | `Left(int)
+  | `LayoutMode(LayoutMode.t)
   | `MarginTop(int)
   | `MarginLeft(int)
   | `MarginRight(int)
@@ -376,6 +397,14 @@ let position = p => {
   `Position(value);
 };
 
+let layoutMode = v => {
+    let p = switch (v) {
+    | `Default => LayoutMode.Default
+    | `Minimal => LayoutMode.Minimal
+    };
+    `LayoutMode(p);
+};
+
 let margin = m => `Margin(m);
 let marginLeft = m => `MarginLeft(m);
 let marginRight = m => `MarginRight(m);
@@ -451,6 +480,7 @@ let applyStyle = (style, styleRule) =>
   | `FlexGrow(flexGrow) => {...style, flexGrow}
   | `FlexDirection(flexDirection) => {...style, flexDirection}
   | `FlexWrap(flexWrap) => {...style, flexWrap}
+  | `LayoutMode(layoutMode) => {...style, layoutMode}
   | `Position(position) => {...style, position}
   | `Margin(margin) => {...style, margin}
   | `MarginTop(marginTop) => {...style, marginTop}


### PR DESCRIPTION
This builds on @lpalmes change to cache layout nodes here: https://github.com/revery-ui/revery/tree/lpalmes/cache-layout-nodes to see if we can improve the performance of layout.

When you look at the performance of [Onivim 2](https://github.com/onivim/oni2) and the performance of some of our heavier examples like Game-of-Life, layout is a clear bottleneck. For Oni2, we have measurements like this:

```
[DEBUG - STATE] Mode: normal editor font measured width: 8 editor font measured height: 16
--[BEGIN: reconcile]
---[BEGIN: RenderedElement.update]
---[END: RenderedElement.update] Time: 2.4486ms Memory: | minor: 967760 | major: 0 | promoted: 0 |
---[BEGIN: RenderedElement.flushPendingUpdates]
---[END: RenderedElement.flushPendingUpdates] Time: 1.8872ms Memory: | minor: 542416 | major: 0 | promoted: 0 |
---[BEGIN: RenderedElement.executeHostViewEffects]
---[END: RenderedElement.executeHostViewEffects] Time: 4.6177ms Memory: | minor: 1654207 | major: 0 | promoted: 0 |
---[BEGIN: RenderedElement.executePendingEffects]
---[END: RenderedElement.executePendingEffects] Time: 0.327499999999ms Memory: | minor: 44 | major: 0 | promoted: 0 |
--[END: reconcile] Time: 10.9783ms Memory: | minor: 3165053 | major: 0 | promoted: 0 |
--[BEGIN: layout]
--[END: layout] Time: 35.3311ms Memory: | minor: 402819 | major: 1014077 | promoted: 1013716 |
--[BEGIN: recalculate]
--[END: recalculate] Time: 4.8547ms Memory: | minor: 405837 | major: 0 | promoted: 0 |
--[BEGIN: flush]
--[END: flush] Time: 0.5852ms Memory: | minor: 23 | major: 0 | promoted: 0 |
--[BEGIN: draw]
--[END: draw] Time: 8.2337ms Memory: | minor: 690413 | major: 0 | promoted: 0 |
-[END: renderWindows] Time: 63.3339ms Memory: | minor: 4665091 | major: 1014077 | promoted: 1013716 |
-[BEGIN: gc: minor]
-[END: gc: minor] Time: 6.458ms Memory: | minor: 25 | major: 128590 | promoted: 128590 |
-[BEGIN: gc: full]
-[END: gc: full] Time: 15.6721ms Memory: | minor: 34 | major: 27 | promoted: 27 |
```

In this case, layout is taking __35ms__ - our render budget is only __16ms__ so this is clearly a problem! 

Our current strategy for layout is very wasteful (although its fun to see how far you can push native code perf 😄 ) - we regenerate the _entire layout tree every render_ and ask flex to layout _the entire layout tree_.  You can see by the major allocations in the layout phase that just the memory impact alone is rough. For Onivim2 - every block in the minimap is a layout node, which is wasteful:

![image](https://user-images.githubusercontent.com/13532591/53350254-958fe080-38d3-11e9-98a9-8663344ab376.png)


A couple ideas:
- Reuse layout nodes when possible (when styles haven't been updated)
- Allow nodes to opt-out of layout (if we know they have no impact on the measurements, and are just transformed / positioned, they don't need the full power of layout).