### PR TITLE
Performance: Don't recreate style for layout, if it hasn't changed

### DIFF
--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -29,7 +29,8 @@ class node ('a) (()) = {
   as _this;
   val _children: ref(list(node('a))) = ref([]);
   val _style: ref(Style.t) = ref(Style.defaultStyle);
-  val _layoutStyle: ref(LayoutTypes.cssStyle) = ref(Layout.LayoutSupport.defaultStyle); 
+  val _layoutStyle: ref(LayoutTypes.cssStyle) =
+    ref(Layout.LayoutSupport.defaultStyle);
   val _events: ref(NodeEvents.t(node('a))) = ref(NodeEvents.make());
   val _layoutNode = ref(Layout.createNode([||], Layout.defaultStyle));
   val _parent: ref(option(node('a))) = ref(None);
@@ -81,12 +82,11 @@ class node ('a) (()) = {
   pub getInternalId = () => _internalId;
   pub getTabIndex = () => _tabIndex^;
   pub setTabIndex = index => _tabIndex := index;
-  pub setStyle = style => {
-      if (style != _style^) {
-          _style := style;
-          _layoutStyle := Style.toLayoutNode(style);
-      }
-  };
+  pub setStyle = style =>
+    if (style != _style^) {
+      _style := style;
+      _layoutStyle := Style.toLayoutNode(style);
+    };
   pub getStyle = () => _style^;
   pub setEvents = events => _events := events;
   pub getEvents = () => _events^;
@@ -304,7 +304,7 @@ class node ('a) (()) = {
 
       let node =
         switch (_this#getMeasureFunction(pixelRatio, scaleFactor)) {
-        | None => Layout.createNode(Array.of_list(childNodes), layoutStyle);
+        | None => Layout.createNode(Array.of_list(childNodes), layoutStyle)
         | Some(m) =>
           Layout.createNodeWithMeasure(
             Array.of_list(childNodes),


### PR DESCRIPTION
If the layout style hasn't changed - don't keep re-generating it. This helps in the case where the render tree hasn't changed and the style is constant - we were always re-generating the layout style, but this isn't necessary. 

Improves the performance of our `Layout: layout node tree (4 deep, 4 wide)` test:

__BEFORE:__
```
+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
|  BENCHMARK                                                   |  TIME              |  MINOR GC  |  MAJOR GC  |  MINOR ALLOC  |  PROMOTED   |  MAJOR ALLOC  |
|--------------------------------------------------------------+--------------------+------------+------------+---------------+-------------+---------------|
|  Node: create single node                                    |  0.00199842453003  |  5         |  0         |  1090240      |  374        |  374          |
|--------------------------------------------------------------+--------------------+------------+------------+---------------+-------------+---------------|
|  Layout: layout single node                                  |  0.0727744102478   |  5         |  0         |  1260481      |  421        |  421          |
|--------------------------------------------------------------+--------------------+------------+------------+---------------+-------------+---------------|
|  Layout: layout node tree (4 deep, 4 wide)                   |  2.89875197411     |  2327      |  865       |  458726216    |  125113447  |  125113447    |
|--------------------------------------------------------------+--------------------+------------+------------+---------------+-------------+---------------|
|  Layout: layout node tree (4 deep, 4 wide) - minimal layout  |  0.135636806488    |  53        |  0         |  13742150     |  2482       |  2482         |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
```

__AFTER:__
```
+----------------------------------------------------------------------------------------------------------------------------------------------------------+
|  BENCHMARK                                                   |  TIME              |  MINOR GC  |  MAJOR GC  |  MINOR ALLOC  |  PROMOTED  |  MAJOR ALLOC  |
|--------------------------------------------------------------+--------------------+------------+------------+---------------+------------+---------------|
|  Node: create single node                                    |  0.00199675559998  |  5         |  0         |  1120349      |  386       |  386          |
|--------------------------------------------------------------+--------------------+------------+------------+---------------+------------+---------------|
|  Layout: layout single node                                  |  0.0797855854034   |  3         |  0         |  700205       |  111       |  111          |
|--------------------------------------------------------------+--------------------+------------+------------+---------------+------------+---------------|
|  Layout: layout node tree (4 deep, 4 wide)                   |  2.29181456566     |  1180      |  310       |  267682900    |  31400825  |  31400825     |
|--------------------------------------------------------------+--------------------+------------+------------+---------------+------------+---------------|
|  Layout: layout node tree (4 deep, 4 wide) - minimal layout  |  0.145054578781    |  53        |  0         |  13742150     |  2482      |  2482         |
+----------------------------------------------------------------------------------------------------------------------------------------------------------+
```

Note the decreased memory pressure / allocations in that test.