### PR TITLE
Refactoring: Move text rendering to Draw module

### DIFF
--- a/src/Draw/RenderPass.re
+++ b/src/Draw/RenderPass.re
@@ -42,10 +42,11 @@ let getCurrent = () => {
   };
 };
 
-let getContext = () => switch (getCurrent()) {
-    | SolidPass(v) => v
-    | AlphaPass(v) => v
-    };
+let getContext = () =>
+  switch (getCurrent()) {
+  | SolidPass(v) => v
+  | AlphaPass(v) => v
+  };
 
 let startSolidPass =
     (~pixelRatio, ~scaleFactor, ~screenWidth, ~screenHeight, ~projection, ()) => {

--- a/src/Draw/RenderPass.re
+++ b/src/Draw/RenderPass.re
@@ -42,6 +42,11 @@ let getCurrent = () => {
   };
 };
 
+let getContext = () => switch (getCurrent()) {
+    | SolidPass(v) => v
+    | AlphaPass(v) => v
+    };
+
 let startSolidPass =
     (~pixelRatio, ~scaleFactor, ~screenWidth, ~screenHeight, ~projection, ()) => {
   _activePass :=

--- a/src/Draw/Revery_Draw.re
+++ b/src/Draw/Revery_Draw.re
@@ -3,3 +3,6 @@ module RenderPass = RenderPass;
 module FontCache = FontCache;
 module FontRenderer = FontRenderer;
 module ImageRenderer = ImageRenderer;
+
+let drawText = TextRenderer.drawText;
+let getLineHeight = TextRenderer.getLineHeight;

--- a/src/Draw/Revery_Draw.re
+++ b/src/Draw/Revery_Draw.re
@@ -3,6 +3,4 @@ module RenderPass = RenderPass;
 module FontCache = FontCache;
 module FontRenderer = FontRenderer;
 module ImageRenderer = ImageRenderer;
-
-let drawText = TextRenderer.drawText;
-let getLineHeight = TextRenderer.getLineHeight;
+module Text = Text;

--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -1,6 +1,6 @@
 /*
  * TextRenderer.re
- * 
+ *
  * Core logic for rendering text to screen.
  */
 
@@ -18,135 +18,123 @@ open Fontkit;
  * with the requested fontSize. For example, in a high DPI that has a 3x pixel
  * ratio, we want to render a 3x size bitmap.
  */
-let _getScaledFontSize = (fontSize) => {
-    let ctx = RenderPass.getContext();
+let _getScaledFontSize = fontSize => {
+  let ctx = RenderPass.getContext();
 
-    int_of_float(
-        (float_of_int(fontSize) *. ctx.pixelRatio *. float_of_int(ctx.scaleFactor)) +. 0.5
-    );
+  int_of_float(
+    float_of_int(fontSize)
+    *. ctx.pixelRatio
+    *. float_of_int(ctx.scaleFactor)
+    +. 0.5,
+  );
 };
 
 let getLineHeight = (~fontFamily, ~fontSize, ~lineHeight, ()) => {
-    let font = FontCache.load(fontFamily, fontSize);
-    let metrics = FontRenderer.getNormalizedMetrics(font);
-    lineHeight *. metrics.height;
-}
+  let font = FontCache.load(fontFamily, fontSize);
+  let metrics = FontRenderer.getNormalizedMetrics(font);
+  lineHeight *. metrics.height;
+};
 
 let measure = (~fontFamily, ~fontSize, text) => {
-    let font = FontCache.load(fontFamily, fontSize);
-    FontRenderer.measure(font, text);
+  let font = FontCache.load(fontFamily, fontSize);
+  FontRenderer.measure(font, text);
 };
 
 let identityMatrix = Mat4.create();
 
-let drawString = (
-    ~fontFamily: string,
-    ~fontSize: int,
-    ~color: Color.t=Colors.white,
-    ~transform: Mat4.t = identityMatrix,
-    ~x=0.,
-    ~y=0.,
-    text: string,
+let drawString =
+    (
+      ~fontFamily: string,
+      ~fontSize: int,
+      ~color: Color.t=Colors.white,
+      ~transform: Mat4.t=identityMatrix,
+      ~x=0.,
+      ~y=0.,
+      text: string,
     ) => {
+  let pass = RenderPass.getCurrent();
 
-    let pass = RenderPass.getCurrent();
+  switch (pass) {
+  | AlphaPass(ctx) =>
+    /* let lineHeightPx = getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ()); */
+    let m = ctx.projection;
+    let quad = Assets.quad();
+    let textureShader = Assets.fontShader();
+    CompiledShader.use(textureShader);
 
-    switch (pass) {
-    | AlphaPass(ctx) => {
+    CompiledShader.setUniformMatrix4fv(textureShader, "uProjection", m);
 
-        /* let lineHeightPx = getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ()); */
-       let m = ctx.projection; 
-      let quad = Assets.quad();
-      let textureShader = Assets.fontShader();
-      CompiledShader.use(textureShader);
+    let font = FontCache.load(fontFamily, _getScaledFontSize(fontSize));
 
-      CompiledShader.setUniformMatrix4fv(
-        textureShader,
-        "uProjection",
-        m,
+    CompiledShader.setUniform4fv(
+      textureShader,
+      "uColor",
+      Color.toVec4(color),
+    );
+
+    let metrics = FontRenderer.getNormalizedMetrics(font);
+    let multiplier = ctx.pixelRatio *. float_of_int(ctx.scaleFactor);
+    /* Position the baseline */
+    let baseline = (metrics.height -. metrics.descenderSize) /. multiplier;
+    ();
+
+    let outerTransform = Mat4.create();
+    Mat4.fromTranslation(outerTransform, Vec3.create(0.0, baseline, 0.0));
+    let render = (s: Fontkit.fk_shape, x: float, y: float) => {
+      let glyph = FontRenderer.getGlyph(font, s.glyphId);
+
+      let {width, height, bearingX, bearingY, advance, _} = glyph;
+
+      let width = float_of_int(width) /. multiplier;
+      let height = float_of_int(height) /. multiplier;
+      let bearingX = float_of_int(bearingX) /. multiplier;
+      let bearingY = float_of_int(bearingY) /. multiplier;
+      let advance = float_of_int(advance) /. multiplier;
+
+      glPixelStorei(GL_PACK_ALIGNMENT, 1);
+      glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+      let texture = FontRenderer.getTexture(font, s.glyphId);
+      glBindTexture(GL_TEXTURE_2D, texture);
+      /* TODO: Bind texture */
+
+      let glyphTransform = Mat4.create();
+      Mat4.fromTranslation(
+        glyphTransform,
+        Vec3.create(
+          x +. bearingX +. width /. 2.,
+          y +. height *. 0.5 -. bearingY,
+          0.0,
+        ),
       );
 
-      let font =
-        FontCache.load(
-          fontFamily,
-          _getScaledFontSize(fontSize),
-          );
+      let scaleTransform = Mat4.create();
+      Mat4.fromScaling(scaleTransform, Vec3.create(width, height, 1.0));
 
-      CompiledShader.setUniform4fv(
-        textureShader,
-        "uColor",
-        Color.toVec4(color),
-      );
+      let local = Mat4.create();
+      Mat4.multiply(local, glyphTransform, scaleTransform);
 
-      let metrics = FontRenderer.getNormalizedMetrics(font);
-      let multiplier = ctx.pixelRatio *. float_of_int(ctx.scaleFactor);
-      /* Position the baseline */
-      let baseline = (metrics.height -. metrics.descenderSize) /. multiplier;
-      ();
+      let xform = Mat4.create();
+      Mat4.multiply(xform, outerTransform, local);
+      Mat4.multiply(xform, transform, xform);
 
-      let outerTransform = Mat4.create();
-      Mat4.fromTranslation(outerTransform, Vec3.create(0.0, baseline, 0.0));
-      let render = (s: Fontkit.fk_shape, x: float, y: float) => {
-        let glyph = FontRenderer.getGlyph(font, s.glyphId);
+      CompiledShader.setUniformMatrix4fv(textureShader, "uWorld", xform);
 
-        let {width, height, bearingX, bearingY, advance, _} = glyph;
+      Geometry.draw(quad, textureShader);
 
-        let width = float_of_int(width) /. multiplier;
-        let height = float_of_int(height) /. multiplier;
-        let bearingX = float_of_int(bearingX) /. multiplier;
-        let bearingY = float_of_int(bearingY) /. multiplier;
-        let advance = float_of_int(advance) /. multiplier;
+      x +. advance /. 64.0;
+    };
 
-        glPixelStorei(GL_PACK_ALIGNMENT, 1);
-        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    let shapedText = FontRenderer.shape(font, text);
+    let startX = ref(x);
 
-        let texture = FontRenderer.getTexture(font, s.glyphId);
-        glBindTexture(GL_TEXTURE_2D, texture);
-        /* TODO: Bind texture */
-
-        let glyphTransform = Mat4.create();
-        Mat4.fromTranslation(
-          glyphTransform,
-          Vec3.create(
-            x +. bearingX +. width /. 2.,
-            y +. height *. 0.5 -. bearingY,
-            0.0,
-          ),
-        );
-
-        let scaleTransform = Mat4.create();
-        Mat4.fromScaling(scaleTransform, Vec3.create(width, height, 1.0));
-
-        let local = Mat4.create();
-        Mat4.multiply(local, glyphTransform, scaleTransform);
-
-        let xform = Mat4.create();
-        Mat4.multiply(xform, outerTransform, local);
-        Mat4.multiply(xform, transform, xform);
-
-        CompiledShader.setUniformMatrix4fv(
-          textureShader,
-          "uWorld",
-          xform,
-        );
-
-        Geometry.draw(quad, textureShader);
-
-        x +. advance /. 64.0;
-      };
-
-          let shapedText = FontRenderer.shape(font, text);
-          let startX = ref(x);
-
-          Array.iter(
-            (s) => {
-              let nextX =
-                render(s, startX^, y);
-              startX := nextX;
-            },
-            shapedText,
-          );
-    }
-    | _ => ();
-    }
+    Array.iter(
+      s => {
+        let nextX = render(s, startX^, y);
+        startX := nextX;
+      },
+      shapedText,
+    );
+  | _ => ()
+  };
 };

--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -32,15 +32,20 @@ let getLineHeight = (~fontFamily, ~fontSize, ~lineHeight, ()) => {
     lineHeight *. metrics.height;
 }
 
+let measure = (~fontFamily, ~fontSize, text) => {
+    let font = FontCache.load(fontFamily, fontSize);
+    FontRenderer.measure(font, text);
+};
+
 let identityMatrix = Mat4.create();
 
-let drawText = (
+let drawString = (
     ~fontFamily: string,
     ~fontSize: int,
     ~color: Color.t=Colors.white,
     ~transform: Mat4.t = identityMatrix,
-    x: float,
-    y: float,
+    ~x=0.,
+    ~y=0.,
     text: string,
     ) => {
 

--- a/src/Draw/TextRenderer.re
+++ b/src/Draw/TextRenderer.re
@@ -1,0 +1,147 @@
+/*
+ * TextRenderer.re
+ * 
+ * Core logic for rendering text to screen.
+ */
+
+open Reglfw.Glfw;
+
+open Revery_Core;
+module Geometry = Revery_Geometry;
+open Revery_Math;
+open Revery_Shaders;
+
+open Fontkit;
+
+/*
+ * Get the size of the bitmap we use for rendering text. This is rarely 1:1
+ * with the requested fontSize. For example, in a high DPI that has a 3x pixel
+ * ratio, we want to render a 3x size bitmap.
+ */
+let _getScaledFontSize = (fontSize) => {
+    let ctx = RenderPass.getContext();
+
+    int_of_float(
+        (float_of_int(fontSize) *. ctx.pixelRatio *. float_of_int(ctx.scaleFactor)) +. 0.5
+    );
+};
+
+let getLineHeight = (~fontFamily, ~fontSize, ~lineHeight, ()) => {
+    let font = FontCache.load(fontFamily, fontSize);
+    let metrics = FontRenderer.getNormalizedMetrics(font);
+    lineHeight *. metrics.height;
+}
+
+let identityMatrix = Mat4.create();
+
+let drawText = (
+    ~fontFamily: string,
+    ~fontSize: int,
+    ~color: Color.t=Colors.white,
+    ~transform: Mat4.t = identityMatrix,
+    x: float,
+    y: float,
+    text: string,
+    ) => {
+
+    let pass = RenderPass.getCurrent();
+
+    switch (pass) {
+    | AlphaPass(ctx) => {
+
+        /* let lineHeightPx = getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ()); */
+       let m = ctx.projection; 
+      let quad = Assets.quad();
+      let textureShader = Assets.fontShader();
+      CompiledShader.use(textureShader);
+
+      CompiledShader.setUniformMatrix4fv(
+        textureShader,
+        "uProjection",
+        m,
+      );
+
+      let font =
+        FontCache.load(
+          fontFamily,
+          _getScaledFontSize(fontSize),
+          );
+
+      CompiledShader.setUniform4fv(
+        textureShader,
+        "uColor",
+        Color.toVec4(color),
+      );
+
+      let metrics = FontRenderer.getNormalizedMetrics(font);
+      let multiplier = ctx.pixelRatio *. float_of_int(ctx.scaleFactor);
+      /* Position the baseline */
+      let baseline = (metrics.height -. metrics.descenderSize) /. multiplier;
+      ();
+
+      let outerTransform = Mat4.create();
+      Mat4.fromTranslation(outerTransform, Vec3.create(0.0, baseline, 0.0));
+      let render = (s: Fontkit.fk_shape, x: float, y: float) => {
+        let glyph = FontRenderer.getGlyph(font, s.glyphId);
+
+        let {width, height, bearingX, bearingY, advance, _} = glyph;
+
+        let width = float_of_int(width) /. multiplier;
+        let height = float_of_int(height) /. multiplier;
+        let bearingX = float_of_int(bearingX) /. multiplier;
+        let bearingY = float_of_int(bearingY) /. multiplier;
+        let advance = float_of_int(advance) /. multiplier;
+
+        glPixelStorei(GL_PACK_ALIGNMENT, 1);
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+        let texture = FontRenderer.getTexture(font, s.glyphId);
+        glBindTexture(GL_TEXTURE_2D, texture);
+        /* TODO: Bind texture */
+
+        let glyphTransform = Mat4.create();
+        Mat4.fromTranslation(
+          glyphTransform,
+          Vec3.create(
+            x +. bearingX +. width /. 2.,
+            y +. height *. 0.5 -. bearingY,
+            0.0,
+          ),
+        );
+
+        let scaleTransform = Mat4.create();
+        Mat4.fromScaling(scaleTransform, Vec3.create(width, height, 1.0));
+
+        let local = Mat4.create();
+        Mat4.multiply(local, glyphTransform, scaleTransform);
+
+        let xform = Mat4.create();
+        Mat4.multiply(xform, outerTransform, local);
+        Mat4.multiply(xform, transform, xform);
+
+        CompiledShader.setUniformMatrix4fv(
+          textureShader,
+          "uWorld",
+          xform,
+        );
+
+        Geometry.draw(quad, textureShader);
+
+        x +. advance /. 64.0;
+      };
+
+          let shapedText = FontRenderer.shape(font, text);
+          let startX = ref(x);
+
+          Array.iter(
+            (s) => {
+              let nextX =
+                render(s, startX^, y);
+              startX := nextX;
+            },
+            shapedText,
+          );
+    }
+    | _ => ();
+    }
+};

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -110,9 +110,9 @@ let start = (window: Window.t, render: renderFunction) => {
     );
 
   let _ =
-    Revery_Core.Event.subscribe(Revery_Draw.FontCache.onFontLoaded, () =>
-      Window.render(window)
-    );
+    Revery_Core.Event.subscribe(Revery_Draw.FontCache.onFontLoaded, () => {
+      uiDirty := true;
+    });
 
   Window.setShouldRenderCallback(window, () =>
     uiDirty^ || Animated.anyActiveAnimations()

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -110,9 +110,9 @@ let start = (window: Window.t, render: renderFunction) => {
     );
 
   let _ =
-    Revery_Core.Event.subscribe(Revery_Draw.FontCache.onFontLoaded, () => {
-      uiDirty := true;
-    });
+    Revery_Core.Event.subscribe(Revery_Draw.FontCache.onFontLoaded, () =>
+      uiDirty := true
+    );
 
   Window.setShouldRenderCallback(window, () =>
     uiDirty^ || Animated.anyActiveAnimations()

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -18,37 +18,29 @@ class textNode (text: string) = {
     /* Draw background first */
     _super#draw(parentContext);
 
-    /* let pass = RenderPass.getCurrent(); */
-
-    /* let quad = Assets.quad(); */
-    /* let textureShader = Assets.fontShader(); */
-
-
-
     let style = _super#getStyle();
 
+    let color = Color.multiplyAlpha(parentContext.opacity, style.color);
+    let fontFamily = style.fontFamily;
+    let fontSize = style.fontSize;
+    let lineHeight = style.lineHeight;
 
-      let color = Color.multiplyAlpha(parentContext.opacity, style.color);
-      let fontFamily = style.fontFamily;
-      let fontSize = style.fontSize;
-      let lineHeight = style.lineHeight;
+    let lineHeightPx =
+      Text.getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ());
 
-      let lineHeightPx = Text.getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ());
-
-      List.iteri(
-        (lineNum, line) => {
-          Text.drawString(
-              ~fontFamily,
-              ~fontSize,
-              ~color=color,
-              ~transform=_this#getWorldTransform(),
-              ~x=0.,
-              ~y=lineHeightPx *. float_of_int(lineNum),
-              line);
-        },
-        _lines^,
-      );
-
+    List.iteri(
+      (lineNum, line) =>
+        Text.drawString(
+          ~fontFamily,
+          ~fontSize,
+          ~color,
+          ~transform=_this#getWorldTransform(),
+          ~x=0.,
+          ~y=lineHeightPx *. float_of_int(lineNum),
+          line,
+        ),
+      _lines^,
+    );
   };
   pub setText = t => text = t;
   pub! getMeasureFunction = (_pixelRatio, _scaleFactor) => {
@@ -63,7 +55,7 @@ class textNode (text: string) = {
       let lineHeight = style.lineHeight;
 
       let lineHeightPx =
-          Text.getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ());
+        Text.getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ());
 
       switch (textWrap) {
       | WhitespaceWrap =>
@@ -86,10 +78,10 @@ class textNode (text: string) = {
 
         dimensions;
       | NoWrap =>
-        let d = Text.measure(~fontFamily, ~fontSize,  text);
+        let d = Text.measure(~fontFamily, ~fontSize, text);
         let dimensions: Layout.LayoutTypes.dimensions = {
           width: d.width,
-          height:  d.height,
+          height: d.height,
         };
 
         _lines := [text];

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -5,9 +5,6 @@ module Geometry = Revery_Geometry;
 module Layout = Layout;
 module LayoutTypes = Layout.LayoutTypes;
 
-open Fontkit;
-open Reglm;
-open Reglfw;
 open Revery_Core;
 
 open ViewNode;
@@ -21,140 +18,52 @@ class textNode (text: string) = {
     /* Draw background first */
     _super#draw(parentContext);
 
-    let pass = RenderPass.getCurrent();
+    /* let pass = RenderPass.getCurrent(); */
 
-    let quad = Assets.quad();
-    let textureShader = Assets.fontShader();
+    /* let quad = Assets.quad(); */
+    /* let textureShader = Assets.fontShader(); */
 
-    switch (pass) {
-    | AlphaPass(ctx) =>
-      let m = ctx.projection;
-      Shaders.CompiledShader.use(textureShader);
 
-      Shaders.CompiledShader.setUniformMatrix4fv(
-        textureShader,
-        "uProjection",
-        m,
-      );
 
-      let style = _super#getStyle();
-      let opacity = style.opacity *. parentContext.opacity;
-      let font =
-        FontCache.load(
-          style.fontFamily,
-          int_of_float(
-            float_of_int(style.fontSize)
-            *. ctx.pixelRatio
-            *. float_of_int(ctx.scaleFactor)
-            +. 0.5,
-          ),
-        );
-      let lineHeightPx =
-        _this#_getLineHeightPx(font, ctx.pixelRatio, ctx.scaleFactor);
-      let color = Color.multiplyAlpha(opacity, style.color);
-      Shaders.CompiledShader.setUniform4fv(
-        textureShader,
-        "uColor",
-        Color.toVec4(color),
-      );
+    let style = _super#getStyle();
 
-      let metrics = FontRenderer.getNormalizedMetrics(font);
 
-      let multiplier = ctx.pixelRatio *. float_of_int(ctx.scaleFactor);
-      /* Position the baseline */
-      let baseline = (metrics.height -. metrics.descenderSize) /. multiplier;
+      let color = Color.multiplyAlpha(parentContext.opacity, style.color);
+      let fontFamily = style.fontFamily;
+      let fontSize = style.fontSize;
+      let lineHeight = style.lineHeight;
 
-      let outerTransform = Mat4.create();
-      Mat4.fromTranslation(outerTransform, Vec3.create(0.0, baseline, 0.0));
-
-      let render = (s: Fontkit.fk_shape, x: float, y: float) => {
-        let glyph = FontRenderer.getGlyph(font, s.glyphId);
-
-        let {width, height, bearingX, bearingY, advance, _} = glyph;
-
-        let width = float_of_int(width) /. multiplier;
-        let height = float_of_int(height) /. multiplier;
-        let bearingX = float_of_int(bearingX) /. multiplier;
-        let bearingY = float_of_int(bearingY) /. multiplier;
-        let advance = float_of_int(advance) /. multiplier;
-
-        Glfw.glPixelStorei(GL_PACK_ALIGNMENT, 1);
-        Glfw.glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-
-        let texture = FontRenderer.getTexture(font, s.glyphId);
-        Glfw.glBindTexture(GL_TEXTURE_2D, texture);
-        /* TODO: Bind texture */
-
-        let glyphTransform = Mat4.create();
-        Mat4.fromTranslation(
-          glyphTransform,
-          Vec3.create(
-            x +. bearingX +. width /. 2.,
-            y +. height *. 0.5 -. bearingY,
-            0.0,
-          ),
-        );
-
-        let scaleTransform = Mat4.create();
-        Mat4.fromScaling(scaleTransform, Vec3.create(width, height, 1.0));
-
-        let local = Mat4.create();
-        Mat4.multiply(local, glyphTransform, scaleTransform);
-
-        let xform = Mat4.create();
-        Mat4.multiply(xform, outerTransform, local);
-        Mat4.multiply(xform, _this#getWorldTransform(), xform);
-
-        Shaders.CompiledShader.setUniformMatrix4fv(
-          textureShader,
-          "uWorld",
-          xform,
-        );
-
-        Geometry.draw(quad, textureShader);
-
-        x +. advance /. 64.0;
-      };
+      let lineHeightPx = Text.getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ());
 
       List.iteri(
         (lineNum, line) => {
-          let shapedText = FontRenderer.shape(font, line);
-          let startX = ref(0.);
-
-          Array.iteri(
-            (_offset, s) => {
-              let nextX =
-                render(s, startX^, lineHeightPx *. float_of_int(lineNum));
-              startX := nextX;
-            },
-            shapedText,
-          );
+          Text.drawString(
+              ~fontFamily,
+              ~fontSize,
+              ~color=color,
+              ~transform=_this#getWorldTransform(),
+              ~x=0.,
+              ~y=lineHeightPx *. float_of_int(lineNum),
+              line);
         },
         _lines^,
       );
 
-    | _ => ()
-    };
   };
   pub setText = t => text = t;
-  pub! getMeasureFunction = (pixelRatio, scaleFactor) => {
+  pub! getMeasureFunction = (_pixelRatio, _scaleFactor) => {
     let measure =
         (_mode, width, _widthMeasureMode, _height, _heightMeasureMode) => {
       /* TODO: Cache font locally in variable */
       let style = _super#getStyle();
       let textWrap = style.textWrap;
-      let font =
-        FontCache.load(
-          style.fontFamily,
-          int_of_float(
-            float_of_int(style.fontSize)
-            *. pixelRatio
-            *. float_of_int(scaleFactor),
-          ),
-        );
+
+      let fontFamily = style.fontFamily;
+      let fontSize = style.fontSize;
+      let lineHeight = style.lineHeight;
 
       let lineHeightPx =
-        _this#_getLineHeightPx(font, pixelRatio, scaleFactor);
+          Text.getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ());
 
       switch (textWrap) {
       | WhitespaceWrap =>
@@ -162,12 +71,7 @@ class textNode (text: string) = {
           TextWrapping.wrapText(
             ~text,
             ~measureWidth=
-              str =>
-                int_of_float(
-                  float_of_int(FontRenderer.measure(font, str).width)
-                  /. pixelRatio
-                  /. float_of_int(scaleFactor),
-                ),
+              str => Text.measure(~fontFamily, ~fontSize, str).width,
             ~maxWidth=width,
             ~wrapHere=TextWrapping.isWhitespaceWrapPoint,
           );
@@ -182,11 +86,10 @@ class textNode (text: string) = {
 
         dimensions;
       | NoWrap =>
-        let d = FontRenderer.measure(font, text);
+        let d = Text.measure(~fontFamily, ~fontSize,  text);
         let dimensions: Layout.LayoutTypes.dimensions = {
-          width:
-            int_of_float(float_of_int(d.width) /. pixelRatio) / scaleFactor,
-          height: int_of_float(lineHeightPx /. pixelRatio) / scaleFactor,
+          width: d.width,
+          height:  d.height,
         };
 
         _lines := [text];
@@ -196,7 +99,7 @@ class textNode (text: string) = {
         let (lines, maxWidthLine) =
           wrapFunc(
             text,
-            str => FontRenderer.measure(font, str).width,
+            str => Text.measure(~fontFamily, ~fontSize, str).width,
             width,
           );
 
@@ -212,13 +115,5 @@ class textNode (text: string) = {
       };
     };
     Some(measure);
-  };
-  pri _getLineHeightPx = (font, pixelRatio, scaleFactor) => {
-    let style = _super#getStyle();
-    let metrics = FontRenderer.getNormalizedMetrics(font);
-    style.lineHeight
-    *. metrics.height
-    /. pixelRatio
-    /. float_of_int(scaleFactor);
   };
 };


### PR DESCRIPTION
This extracts most of the guts of the `TextNode` into `Revery.Draw.Text`, with methods like:
- `drawString`
- `measure`
- `getLineHeight`

This simplifies the `TextNode` proper, and also this logic to be reused once the immediate-mode rendering node is added (for fast text rendering w/o needing layout or reconciliation). Extension of #374 

TODO:
- [x] Validate WebGL build
- [x] Validate in content-scaled environment
- [x] Validate in high DPI environment