### PR TITLE
Performance: Layout subtree

### DIFF
--- a/bench/lib/LayoutBench.re
+++ b/bench/lib/LayoutBench.re
@@ -36,8 +36,8 @@ let rec setupNodeTree =
   n;
 };
 
-let layoutNode = (n: node) => {
-  Layout.layout(n, 1.0, 1);
+let layoutNode = (force: bool, n: node) => {
+  Layout.layout(~force, n);
 };
 
 bench(
@@ -49,10 +49,26 @@ bench(
 );
 
 bench(
+  ~name="Layout: layout single node (force re-layout)",
+  ~options,
+  ~setup=setupNode(~style=Style.make(~width=100, ~height=100, ())),
+  ~f=layoutNode(true),
+  (),
+);
+
+bench(
+  ~name="Layout: layout node tree (4 deep, 4 wide) (force re-layout))",
+  ~options,
+  ~setup=setupNodeTree(~depth=4, ~breadth=4),
+  ~f=layoutNode(true),
+  (),
+);
+
+bench(
   ~name="Layout: layout single node",
   ~options,
   ~setup=setupNode(~style=Style.make(~width=100, ~height=100, ())),
-  ~f=layoutNode,
+  ~f=layoutNode(false),
   (),
 );
 
@@ -60,11 +76,12 @@ bench(
   ~name="Layout: layout node tree (4 deep, 4 wide)",
   ~options,
   ~setup=setupNodeTree(~depth=4, ~breadth=4),
-  ~f=layoutNode,
+  ~f=layoutNode(false),
   (),
 );
+
 bench(
-  ~name="Layout: layout node tree (4 deep, 4 wide) - minimal layout",
+  ~name="Layout: layout node tree (4 deep, 4 wide) - force, minimal layout",
   ~options,
   ~setup=
     setupNodeTree(
@@ -78,6 +95,6 @@ bench(
           (),
         ),
     ),
-  ~f=layoutNode,
+  ~f=layoutNode(true),
   (),
 );

--- a/src/UI/Layout.re
+++ b/src/UI/Layout.re
@@ -31,6 +31,21 @@ let createNodeWithMeasure = (children, style, measure) =>
     ~andMeasure=measure,
     rootContext,
   );
+let updateCachedNode = (node: LayoutTypes.node) => {
+        node
+       /* ...node, */
+        /* isDirty: true, */
+        /* isDirty: true, */
+        /* selfRef: Nativeint.zero, */
+        /* hasNewLayout: true, */
+        /* isDirty: true, */
+        /* lineIndex: 0, */
+        /* layout: LayoutSupport.createLayout(), */
+        /* parent: LayoutSupport.theNullNode, */
+        /* nextChild: LayoutSupport.theNullNode, */
+}
+
+
 let layout = (node, pixelRatio, scaleFactor) =>
   Performance.bench("layout", () => {
     let layoutNode = node#toLayoutNode(pixelRatio, scaleFactor);

--- a/src/UI/Layout.re
+++ b/src/UI/Layout.re
@@ -31,7 +31,7 @@ let createNodeWithMeasure = (children, style, measure) =>
     ~andMeasure=measure,
     rootContext,
   );
-let layout = (~force, node) =>
+let layout = (~force=false, node) =>
   Performance.bench("layout", () => {
     let layoutNode = node#toLayoutNode(~force, ());
     switch (layoutNode) {

--- a/src/UI/Layout.re
+++ b/src/UI/Layout.re
@@ -46,9 +46,9 @@ let updateCachedNode = (node: LayoutTypes.node) => {
 }
 
 
-let layout = (node, pixelRatio, scaleFactor) =>
+let layout = (node) =>
   Performance.bench("layout", () => {
-    let layoutNode = node#toLayoutNode(pixelRatio, scaleFactor);
+    let layoutNode = node#toLayoutNode(~force=false, ());
     switch (layoutNode) {
     | None => ()
     | Some(v) =>

--- a/src/UI/Layout.re
+++ b/src/UI/Layout.re
@@ -31,24 +31,9 @@ let createNodeWithMeasure = (children, style, measure) =>
     ~andMeasure=measure,
     rootContext,
   );
-let updateCachedNode = (node: LayoutTypes.node) => {
-        node
-       /* ...node, */
-        /* isDirty: true, */
-        /* isDirty: true, */
-        /* selfRef: Nativeint.zero, */
-        /* hasNewLayout: true, */
-        /* isDirty: true, */
-        /* lineIndex: 0, */
-        /* layout: LayoutSupport.createLayout(), */
-        /* parent: LayoutSupport.theNullNode, */
-        /* nextChild: LayoutSupport.theNullNode, */
-}
-
-
-let layout = (node) =>
+let layout = (~force, node) =>
   Performance.bench("layout", () => {
-    let layoutNode = node#toLayoutNode(~force=false, ());
+    let layoutNode = node#toLayoutNode(~force, ());
     switch (layoutNode) {
     | None => ()
     | Some(v) =>

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -92,9 +92,7 @@ class node (()) = {
   pub setTabIndex = index => _tabIndex := index;
   pub markLayoutDirty = () => {
     switch (_isLayoutDirty^) {
-    | true => {
-        prerr_endline ("DIRTY: " ++ string_of_int(_this#getInternalId()));
-    }
+    | true => ()
     | false => {
         switch (_this#getParent()) {
         | Some(p) => p#markLayoutDirty();
@@ -329,7 +327,7 @@ class node (()) = {
     | (Style.LayoutMode.Minimal, _) =>
       _this#_minimalLayout(style);
       None;
-    | (Style.LayoutMode.Default, false) => Some(Layout.updateCachedNode(_layoutNode^))
+    | (Style.LayoutMode.Default, false) => Some(_layoutNode^)
     | (Style.LayoutMode.Default, true) =>
       let childNodes =
         List.map(c => c#toLayoutNode(~force, ()), _children^)

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -91,30 +91,28 @@ class node (()) = {
   pub getTabIndex = () => _tabIndex^;
   pub setTabIndex = index => _tabIndex := index;
   pub markLayoutDirty = () => {
-    switch (_isLayoutDirty^) {
-    | true => ()
-    | false => {
+    _isLayoutDirty^
+      ? ()
+      : {
         switch (_this#getParent()) {
-        | Some(p) => p#markLayoutDirty();
-        | None => ();
-        }
-       _isLayoutDirty := true;
-    }
-    } 
+        | Some(p) => p#markLayoutDirty()
+        | None => ()
+        };
+        _isLayoutDirty := true;
+      };
   };
-  pub setStyle = style => {
+  pub setStyle = style =>
     if (style != _style^) {
       _style := style;
 
       let lastLayoutStyle = _layoutStyle^;
-      let newLayoutStyle= Style.toLayoutNode(style);
+      let newLayoutStyle = Style.toLayoutNode(style);
       _layoutStyle := newLayoutStyle;
 
       if (lastLayoutStyle != _layoutStyle^) {
-          _this#markLayoutDirty();
-      }
-    }
-  };
+        _this#markLayoutDirty();
+      };
+    };
   pub getStyle = () => _style^;
   pub setEvents = events => _events := events;
   pub getEvents = () => _events^;
@@ -323,7 +321,7 @@ class node (()) = {
       | None => Layout.createNode([||], layoutStyle)
       };
 
-    switch ((style.layoutMode, _isLayoutDirty^ || force)) {
+    switch (style.layoutMode, _isLayoutDirty^ || force) {
     | (Style.LayoutMode.Minimal, _) =>
       _this#_minimalLayout(style);
       None;

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -251,7 +251,7 @@ class node (()) = {
   pub firstChild = () => List.hd(_children^);
   pub getParent = () => _parent^;
   pub getChildren = () => _children^;
-  pub getMeasureFunction = (_pixelRatio: float, _scaleFactor: int) => None;
+  pub getMeasureFunction = () => None;
   pub handleEvent = (evt: NodeEvents.event) => {
     let _ =
       switch (evt, _this#getEvents()) {
@@ -309,7 +309,7 @@ class node (()) = {
     };
     List.iter(n => n#_minimalLayout(style), _children^);
   };
-  pub toLayoutNode = (pixelRatio: float, scaleFactor: int) => {
+  pub toLayoutNode = (~force, ()) => {
     let style = _style^;
     let layoutStyle = _layoutStyle^;
 
@@ -325,19 +325,19 @@ class node (()) = {
       | None => Layout.createNode([||], layoutStyle)
       };
 
-    switch ((style.layoutMode, _isLayoutDirty^)) {
+    switch ((style.layoutMode, _isLayoutDirty^ || force)) {
     | (Style.LayoutMode.Minimal, _) =>
       _this#_minimalLayout(style);
       None;
     | (Style.LayoutMode.Default, false) => Some(Layout.updateCachedNode(_layoutNode^))
     | (Style.LayoutMode.Default, true) =>
       let childNodes =
-        List.map(c => c#toLayoutNode(pixelRatio, scaleFactor), _children^)
+        List.map(c => c#toLayoutNode(~force, ()), _children^)
         |> List.filter(f)
         |> List.map(m);
 
       let node =
-        switch (_this#getMeasureFunction(pixelRatio, scaleFactor)) {
+        switch (_this#getMeasureFunction()) {
         | None => Layout.createNode(Array.of_list(childNodes), layoutStyle)
         | Some(m) =>
           Layout.createNodeWithMeasure(

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -111,10 +111,13 @@ let start = (window: Window.t, render: renderFunction) => {
     );
 
   let _ =
-    Revery_Core.Event.subscribe(Revery_Draw.FontCache.onFontLoaded, () => {
-      uiDirty := true
-      forceLayout := true;
-    });
+    Revery_Core.Event.subscribe(
+      Revery_Draw.FontCache.onFontLoaded,
+      () => {
+        uiDirty := true;
+        forceLayout := true;
+      },
+    );
 
   Window.setShouldRenderCallback(window, () =>
     uiDirty^ || Animated.anyActiveAnimations()
@@ -129,7 +132,7 @@ let start = (window: Window.t, render: renderFunction) => {
        */
       uiDirty := false;
 
-      /* 
+      /*
        * The forceLayout event also needs to be cleared prior to rendering,
        * as we might get an event during rendering - like font loaded -
        * that would be ignored if we cleared after.

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -31,6 +31,7 @@ open UiContainer;
 
 let start = (window: Window.t, render: renderFunction) => {
   let uiDirty = ref(false);
+  let forceLayout = ref(false);
 
   let onStale = () => {
     uiDirty := true;
@@ -112,7 +113,7 @@ let start = (window: Window.t, render: renderFunction) => {
   let _ =
     Revery_Core.Event.subscribe(Revery_Draw.FontCache.onFontLoaded, () => {
       uiDirty := true
-      /* print_endline ("!! FONT LOADED!"); */
+      forceLayout := true;
     });
 
   Window.setShouldRenderCallback(window, () =>
@@ -127,8 +128,17 @@ let start = (window: Window.t, render: renderFunction) => {
        * meaning that we'll need to re-render again next frame.
        */
       uiDirty := false;
+
+      /* 
+       * The forceLayout event also needs to be cleared prior to rendering,
+       * as we might get an event during rendering - like font loaded -
+       * that would be ignored if we cleared after.
+       */
+      let fl = forceLayout^;
+      forceLayout := false;
+
       let component = Performance.bench("component render", () => render());
-      UiRender.render(ui, component);
+      UiRender.render(~forceLayout=fl, ui, component);
     },
   );
 };

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -110,9 +110,10 @@ let start = (window: Window.t, render: renderFunction) => {
     );
 
   let _ =
-    Revery_Core.Event.subscribe(Revery_Draw.FontCache.onFontLoaded, () =>
+    Revery_Core.Event.subscribe(Revery_Draw.FontCache.onFontLoaded, () => {
       uiDirty := true
-    );
+      /* print_endline ("!! FONT LOADED!"); */
+    });
 
   Window.setShouldRenderCallback(window, () =>
     uiDirty^ || Animated.anyActiveAnimations()

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -54,7 +54,7 @@ class textNode (text: string) = {
           _this#markLayoutDirty();
       }
   };
-  pub! getMeasureFunction = (_pixelRatio, _scaleFactor) => {
+  pub! getMeasureFunction = () => {
     let measure =
         (_mode, width, _widthMeasureMode, _height, _heightMeasureMode) => {
       /* TODO: Cache font locally in variable */

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -48,27 +48,22 @@ class textNode (text: string) = {
     );
   };
   pub setGamma = g => gamma = g;
-
-  pub! setStyle = (style) => {
-
+  pub! setStyle = style => {
     let lastStyle = _this#getStyle();
-    _super#setStyle(style); 
+    _super#setStyle(style);
     let newStyle = _this#getStyle();
 
-    if (lastStyle.lineHeight != newStyle.lineHeight 
+    if (lastStyle.lineHeight != newStyle.lineHeight
         || lastStyle.fontSize != newStyle.fontSize
-|| !String.equal(lastStyle.fontFamily, newStyle.fontFamily)) {
-    _this#markLayoutDirty();
-}
-
-
+        || !String.equal(lastStyle.fontFamily, newStyle.fontFamily)) {
+      _this#markLayoutDirty();
+    };
   };
-  pub setText = t => {
-      if (!String.equal(t, text)) {
-          text = t;
-          _this#markLayoutDirty();
-      }
-  };
+  pub setText = t =>
+    if (!String.equal(t, text)) {
+      text = t;
+      _this#markLayoutDirty();
+    };
   pub! getMeasureFunction = () => {
     let measure =
         (_mode, width, _widthMeasureMode, _height, _heightMeasureMode) => {

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -48,6 +48,21 @@ class textNode (text: string) = {
     );
   };
   pub setGamma = g => gamma = g;
+
+  pub! setStyle = (style) => {
+
+    let lastStyle = _this#getStyle();
+    _super#setStyle(style); 
+    let newStyle = _this#getStyle();
+
+    if (lastStyle.lineHeight != newStyle.lineHeight 
+        || lastStyle.fontSize != newStyle.fontSize
+|| !String.equal(lastStyle.fontFamily, newStyle.fontFamily)) {
+    _this#markLayoutDirty();
+}
+
+
+  };
   pub setText = t => {
       if (!String.equal(t, text)) {
           text = t;
@@ -67,8 +82,6 @@ class textNode (text: string) = {
 
       let lineHeightPx =
         Text.getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ());
-
-      print_endline ("MEASURE TEXT: " ++ text ++ " line height: " ++ string_of_float(lineHeightPx));
 
       switch (textWrap) {
       | WhitespaceWrap =>

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -68,7 +68,7 @@ class textNode (text: string) = {
       let lineHeightPx =
         Text.getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ());
 
-      /* print_endline ("MEASURE TEXT: " ++ text ++ " line height: " ++ string_of_float(lineHeightPx)); */
+      print_endline ("MEASURE TEXT: " ++ text ++ " line height: " ++ string_of_float(lineHeightPx));
 
       switch (textWrap) {
       | WhitespaceWrap =>

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -48,7 +48,12 @@ class textNode (text: string) = {
     );
   };
   pub setGamma = g => gamma = g;
-  pub setText = t => text = t;
+  pub setText = t => {
+      if (!String.equal(t, text)) {
+          text = t;
+          _this#markLayoutDirty();
+      }
+  };
   pub! getMeasureFunction = (_pixelRatio, _scaleFactor) => {
     let measure =
         (_mode, width, _widthMeasureMode, _height, _heightMeasureMode) => {
@@ -62,6 +67,8 @@ class textNode (text: string) = {
 
       let lineHeightPx =
         Text.getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ());
+
+      /* print_endline ("MEASURE TEXT: " ++ text ++ " line height: " ++ string_of_float(lineHeightPx)); */
 
       switch (textWrap) {
       | WhitespaceWrap =>

--- a/src/UI/UiRender.re
+++ b/src/UI/UiRender.re
@@ -15,7 +15,8 @@ module LayoutTypes = Layout.LayoutTypes;
 
 let _projection = Mat4.create();
 
-let render = (container: UiContainer.t, component: UiReact.syntheticElement) => {
+let render = (~forceLayout=false, container: UiContainer.t, component: UiReact.syntheticElement) => {
+    print_endline ("Render: " ++ string_of_bool(forceLayout));
   let {rootNode, window, container, _} = container;
 
   AnimationTicker.tick();
@@ -40,7 +41,7 @@ let render = (container: UiContainer.t, component: UiReact.syntheticElement) => 
       (),
     ),
   );
-  Layout.layout(rootNode);
+  Layout.layout(~force=forceLayout, rootNode);
 
   /* Recalculate cached parameters */
   Performance.bench("recalculate", () => rootNode#recalculate());

--- a/src/UI/UiRender.re
+++ b/src/UI/UiRender.re
@@ -40,7 +40,7 @@ let render = (container: UiContainer.t, component: UiReact.syntheticElement) => 
       (),
     ),
   );
-  Layout.layout(rootNode, pixelRatio, scaleFactor);
+  Layout.layout(rootNode);
 
   /* Recalculate cached parameters */
   Performance.bench("recalculate", () => rootNode#recalculate());

--- a/src/UI/UiRender.re
+++ b/src/UI/UiRender.re
@@ -21,7 +21,6 @@ let render =
       container: UiContainer.t,
       component: UiReact.syntheticElement,
     ) => {
-  print_endline("Render: " ++ string_of_bool(forceLayout));
   let {rootNode, window, container, _} = container;
 
   AnimationTicker.tick();

--- a/src/UI/UiRender.re
+++ b/src/UI/UiRender.re
@@ -15,8 +15,13 @@ module LayoutTypes = Layout.LayoutTypes;
 
 let _projection = Mat4.create();
 
-let render = (~forceLayout=false, container: UiContainer.t, component: UiReact.syntheticElement) => {
-    print_endline ("Render: " ++ string_of_bool(forceLayout));
+let render =
+    (
+      ~forceLayout=false,
+      container: UiContainer.t,
+      component: UiReact.syntheticElement,
+    ) => {
+  print_endline("Render: " ++ string_of_bool(forceLayout));
   let {rootNode, window, container, _} = container;
 
   AnimationTicker.tick();

--- a/test/UI/MouseTest.re
+++ b/test/UI/MouseTest.re
@@ -6,7 +6,7 @@ open UiEvents;
 let createNodeWithStyle = style => {
   let node = (new node)();
   node#setStyle(style);
-  Layout.layout(node, 1.0, 1);
+  Layout.layout(node);
   node#recalculate();
   node;
 };

--- a/test/UI/NodeTests.re
+++ b/test/UI/NodeTests.re
@@ -31,7 +31,7 @@ test("NodeTests", () => {
     test("simple hitTest returns true case", () => {
       let node = (new node)();
       node#setStyle(Style.make(~width=400, ~height=500, ()));
-      Layout.layout(node, 1.0, 1);
+      Layout.layout(node);
       node#recalculate();
 
       expect(node#hitTest(Vec2.create(200., 250.))).toBe(true);
@@ -41,7 +41,7 @@ test("NodeTests", () => {
       let node = (new node)();
       node#setStyle(Style.make(~width=400, ~height=500, ()));
 
-      Layout.layout(node, 1.0, 1);
+      Layout.layout(node);
       node#recalculate();
 
       expect(node#hitTest(Vec2.create(401., 250.))).toBe(false);
@@ -50,7 +50,7 @@ test("NodeTests", () => {
     test("left / top are taken into account", () => {
       let node = (new node)();
       node#setStyle(Style.make(~top=5, ~left=5, ~height=2, ~width=2, ()));
-      Layout.layout(node, 1.0, 1);
+      Layout.layout(node);
       node#recalculate();
 
       expect(node#hitTest(Vec2.create(1., 1.))).toBe(false);
@@ -67,7 +67,7 @@ test("NodeTests", () => {
       childNode#setStyle(Style.make(~width=25, ~height=25, ()));
       parentNode#addChild(childNode);
 
-      Layout.layout(parentNode, 1.0, 1);
+      Layout.layout(parentNode);
       parentNode#recalculate();
 
       expect(childNode#hitTest(Vec2.create(0., 0.))).toBe(false);

--- a/test/UI/ReconcilerTests.re
+++ b/test/UI/ReconcilerTests.re
@@ -108,7 +108,7 @@ test("Reconciler", () => {
     let update1 =
       React.Container.update(container, <View onDimensionsChanged style />);
 
-    Layout.layout(rootNode, 1.0, 1);
+    Layout.layout(rootNode);
     rootNode#recalculate();
     rootNode#flushCallbacks();
 
@@ -120,7 +120,7 @@ test("Reconciler", () => {
     let update2 =
       React.Container.update(update1, <View onDimensionsChanged style />);
 
-    Layout.layout(rootNode, 1.0, 1);
+    Layout.layout(rootNode);
     rootNode#recalculate();
     rootNode#flushCallbacks();
 
@@ -133,7 +133,7 @@ test("Reconciler", () => {
     React.Container.update(update2, <View onDimensionsChanged style />)
     |> ignore;
 
-    Layout.layout(rootNode, 1.0, 1);
+    Layout.layout(rootNode);
     rootNode#recalculate();
     rootNode#flushCallbacks();
 


### PR DESCRIPTION
__Issue:__ Layout performance is a bottleneck for Revery as applications grow (like our Example app) - it's easy to see in our JS sandbox - every frame triggers layout.

__Defect:__ We currently have a very naive layout strategy.... we re-layout the entire application every frame. We've been able to get away with this so far, by virtue of the speed of the technology and the `flex` library, but it won't scale to more complex applications.

__Fix:__ This implements an incremental layout, where we only bother re-laying out items if a layout style property has changed. This presents a large performance increase, especially in cases where we're animating with only things like transform properties (in which case layout won't be triggered at all).

This is an iteration on some of the work done here:
- https://github.com/revery-ui/revery/tree/lpalmes/cache-layout-nodes
- #368 

__TODO:__
- [x] Trigger a `force` layout when a font is loaded
- [x] Call `markLayoutDirty` when a text metric changes (line height, fontsize, font family)