### PR TITLE
Bugfix: Fix crash in gamma corrected text shader

### DIFF
--- a/src/Draw/FontShader.re
+++ b/src/Draw/FontShader.re
@@ -77,7 +77,7 @@ module Default = {
 module GammaCorrected = {
   let fsShader = {|
         vec4 t = texture2D(uSampler, vTexCoord);
-        vec4 alpha = t.a;
+        float alpha = t.a;
         vec4 fg = vColor;
         vec4 bg = uBackgroundColor;
 


### PR DESCRIPTION
Thanks @tcoopman for catching this!

__Issue:__ Some examples would crash with:
```
Fatal error: exception Revery_Shaders__Shader.ShaderCompilationException("0:9(2): error: initializer of type float cannot be assigned to variable of type vec4\n0:16(2): error: initializer of type vec4 cannot be assigned to variable of type float\n0:17(2): error: initializer of type vec4 cannot be assigned to variable of type float\n0:18(2): error: initializer of type vec4 cannot be assigned to variable of type float\n")
```

__Defect:__ In cases where we use correct gamma-corrected text (ie, when there is a solid background color), the shader compilation would crash. This was a bug in the shader - we were trying to assign a `float` to a `vec4` and the shader complains. Some platforms handle this differently (ie, will silently ignore the failure....)

__Fix:__ Correct the shader so that we are properly assigning the value.