### PR TITLE
Performance: Add a node that enables direct access to OpenGL rendering

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -115,6 +115,11 @@ let state: state = {
       render: _ => HoverExample.render(),
       source: "HoverExample.re",
     },
+    {
+      name: "OpenGL Example",
+      render: _ => OpenGLExample.render(),
+      source: "OpenGLExample.re",
+    },
   ],
   selectedExample: "Animation",
 };

--- a/examples/OpenGLExample.re
+++ b/examples/OpenGLExample.re
@@ -1,0 +1,52 @@
+open Reglfw;
+
+open Revery;
+/* open Revery.Draw; */
+open Revery.UI;
+
+let containerStyle =
+  Style.[
+    position(`Absolute),
+    top(0),
+    bottom(0),
+    left(0),
+    right(0),
+    alignItems(`Center),
+    justifyContent(`Center),
+    flexDirection(`Column),
+  ];
+
+let outerBox =
+  Style.[width(450), height(450), backgroundColor(Colors.black)];
+
+module Sample = {
+  let component = React.component("OpenGLSample");
+
+  let createElement = (~children as _, ()) =>
+    component(hooks =>
+      (
+        hooks,
+        <View style=containerStyle>
+          <OpenGL
+            style=outerBox
+            render={(transform, _pctx) => {
+              Glfw.glClearColor(1.0, 0.0, 0.0, 0.0);
+
+              Revery.Draw.Text.drawString(
+                ~transform,
+                ~backgroundColor=Colors.red,
+                ~color=Colors.white,
+                ~fontFamily="Roboto-Regular.ttf",
+                ~fontSize=20,
+                ~x=25.,
+                ~y=25.,
+                "Hello!",
+              );
+            }}
+          />
+        </View>,
+      )
+    );
+};
+
+let render = () => <Sample />;

--- a/examples/OpenGLExample.re
+++ b/examples/OpenGLExample.re
@@ -30,7 +30,7 @@ module Sample = {
           <OpenGL
             style=outerBox
             render={(transform, _pctx) => {
-              Glfw.glClearColor(1.0, 0.0, 0.0, 0.0);
+              Glfw.glClearColor(1.0, 0.0, 0.0, 1.0);
 
               Revery.Draw.Text.drawString(
                 ~transform,

--- a/src/UI/OpenGLNode.re
+++ b/src/UI/OpenGLNode.re
@@ -1,11 +1,14 @@
+open Reglm;
+
 module Shaders = Revery_Shaders;
 module Geometry = Revery_Geometry;
+module RenderPass = Revery_Draw.RenderPass;
 module Layout = Layout;
 module LayoutTypes = Layout.LayoutTypes;
 
 open ViewNode;
 
-type renderCallback = (NodeDrawContext.t) => unit;
+type renderCallback = (Mat4.t, NodeDrawContext.t) => unit;
 
 /*
  * OpenGLNode
@@ -13,18 +16,31 @@ type renderCallback = (NodeDrawContext.t) => unit;
  * Very simple node that just takes in a `render` callback
  * and calls it during draw.
  */
-class openGLNode () = {
+class openGLNode (()) = {
   as _this;
   val mutable render: option(renderCallback) = None;
   inherit (class viewNode)() as _super;
   pub! draw = (parentContext: NodeDrawContext.t) => {
     _super#draw(parentContext);
 
-    switch (render) {
-    | Some(r) => r(parentContext);
-    | None => ();
-    }
-  };
+    let ctx = RenderPass.getContext();
+    let worldTransform = _this#getWorldTransform();
+    let dimensions = _this#measurements();
 
-  pub setRender = (r) => render = r;
+    switch (render) {
+    | Some(r) =>
+      Overflow.render(
+        worldTransform,
+        LayoutTypes.Hidden,
+        dimensions,
+        ctx.screenHeight,
+        ctx.pixelRatio,
+        ctx.scaleFactor,
+        () =>
+        r(worldTransform, parentContext)
+      )
+    | None => ()
+    };
+  };
+  pub setRender = r => render = r;
 };

--- a/src/UI/OpenGLNode.re
+++ b/src/UI/OpenGLNode.re
@@ -1,17 +1,11 @@
-open Reglm;
-open Reglfw.Glfw;
-
-open Revery_Draw;
-
 module Shaders = Revery_Shaders;
 module Geometry = Revery_Geometry;
 module Layout = Layout;
 module LayoutTypes = Layout.LayoutTypes;
 
-open Node;
 open ViewNode;
 
-type renderCallback = (parentContext: NodeDrawContext.t) => unit;
+type renderCallback = (NodeDrawContext.t) => unit;
 
 /*
  * OpenGLNode
@@ -19,10 +13,10 @@ type renderCallback = (parentContext: NodeDrawContext.t) => unit;
  * Very simple node that just takes in a `render` callback
  * and calls it during draw.
  */
-class openGLNode (imagePath: string) = {
+class openGLNode () = {
   as _this;
   val mutable render: option(renderCallback) = None;
-  inherit (class node)() as _super;
+  inherit (class viewNode)() as _super;
   pub! draw = (parentContext: NodeDrawContext.t) => {
     _super#draw(parentContext);
 
@@ -31,4 +25,6 @@ class openGLNode (imagePath: string) = {
     | None => ();
     }
   };
+
+  pub setRender = (r) => render = r;
 };

--- a/src/UI/OpenGLNode.re
+++ b/src/UI/OpenGLNode.re
@@ -1,0 +1,34 @@
+open Reglm;
+open Reglfw.Glfw;
+
+open Revery_Draw;
+
+module Shaders = Revery_Shaders;
+module Geometry = Revery_Geometry;
+module Layout = Layout;
+module LayoutTypes = Layout.LayoutTypes;
+
+open Node;
+open ViewNode;
+
+type renderCallback = (parentContext: NodeDrawContext.t) => unit;
+
+/*
+ * OpenGLNode
+ *
+ * Very simple node that just takes in a `render` callback
+ * and calls it during draw.
+ */
+class openGLNode (imagePath: string) = {
+  as _this;
+  val mutable render: option(renderCallback) = None;
+  inherit (class node)() as _super;
+  pub! draw = (parentContext: NodeDrawContext.t) => {
+    _super#draw(parentContext);
+
+    switch (render) {
+    | Some(r) => r(parentContext);
+    | None => ();
+    }
+  };
+};

--- a/src/UI/Primitives.re
+++ b/src/UI/Primitives.re
@@ -305,3 +305,136 @@ module Image = {
       UiReact.listToElement(children),
     );
 };
+
+module OpenGL = {
+  let component = UiReact.nativeComponent("OpenGL");
+
+  let make =
+      (
+        ~key=?,
+        ~onMouseDown=?,
+        ~onMouseMove=?,
+        ~onMouseUp=?,
+        ~onMouseWheel=?,
+        ~onMouseEnter=?,
+        ~onMouseLeave=?,
+        ~onMouseOver=?,
+        ~onMouseOut=?,
+        ~onBlur=?,
+        ~onFocus=?,
+        ~onKeyDown=?,
+        ~onKeyUp=?,
+        ~onKeyPress=?,
+        ~onDimensionsChanged=?,
+        ~ref=?,
+        ~render=?,
+        ~style=Style.emptyViewStyle,
+        children,
+      ) =>
+    component(~key?, hooks =>
+      (
+        hooks,
+        {
+          make: () => {
+            let styles = Style.create(~style, ());
+            let events =
+              NodeEvents.make(
+                ~ref?,
+                ~onMouseDown?,
+                ~onMouseMove?,
+                ~onMouseUp?,
+                ~onMouseWheel?,
+                ~onMouseEnter?,
+                ~onMouseLeave?,
+                ~onMouseOver?,
+                ~onMouseOut?,
+                ~onBlur?,
+                ~onFocus?,
+                ~onKeyDown?,
+                ~onKeyUp?,
+                ~onKeyPress?,
+                ~onDimensionsChanged?,
+                (),
+              );
+            let node = (new OpenGLNode.openGLNode)();
+            node#setEvents(events);
+            node#setStyle(styles);
+            node#setRender(render);
+            Obj.magic(node);
+          },
+          configureInstance: (~isFirstRender as _, node) => {
+            let styles = Style.create(~style, ());
+            let events =
+              NodeEvents.make(
+                ~ref?,
+                ~onMouseDown?,
+                ~onMouseMove?,
+                ~onMouseUp?,
+                ~onMouseWheel?,
+                ~onMouseEnter?,
+                ~onMouseLeave?,
+                ~onMouseOver?,
+                ~onMouseOut?,
+                ~onBlur?,
+                ~onFocus?,
+                ~onKeyDown?,
+                ~onKeyUp?,
+                ~onKeyPress?,
+                ~onDimensionsChanged?,
+                (),
+              );
+            let oglNode: OpenGLNode.openGLNode = Obj.magic(node);
+            node#setEvents(events);
+            node#setStyle(styles);
+            oglNode#setRender(render);
+            node
+          },
+          children,
+        },
+      )
+    );
+
+  let createElement =
+      (
+        ~onMouseDown=?,
+        ~onMouseMove=?,
+        ~onMouseUp=?,
+        ~onMouseWheel=?,
+        ~onMouseEnter=?,
+        ~onMouseLeave=?,
+        ~onMouseOver=?,
+        ~onMouseOut=?,
+        ~onBlur=?,
+        ~onFocus=?,
+        ~ref=?,
+        ~style=Style.emptyViewStyle,
+        ~children,
+        ~onKeyDown=?,
+        ~onKeyUp=?,
+        ~onKeyPress=?,
+        ~onDimensionsChanged=?,
+        ~render=?,
+        (),
+      ) =>
+    make(
+      ~onMouseDown?,
+      ~onMouseMove?,
+      ~onMouseUp?,
+      ~onMouseWheel?,
+      ~onMouseEnter?,
+      ~onMouseLeave?,
+      ~onMouseOver?,
+      ~onMouseOut?,
+      ~onBlur?,
+      ~onFocus?,
+      ~ref?,
+      ~style,
+      ~onKeyDown?,
+      ~onKeyUp?,
+      ~onKeyPress?,
+      ~onDimensionsChanged?,
+      ~render?,
+      UiReact.listToElement(children),
+    );
+};
+

--- a/src/UI/Primitives.re
+++ b/src/UI/Primitives.re
@@ -387,7 +387,7 @@ module OpenGL = {
             node#setEvents(events);
             node#setStyle(styles);
             oglNode#setRender(render);
-            node
+            node;
           },
           children,
         },
@@ -437,4 +437,3 @@ module OpenGL = {
       UiReact.listToElement(children),
     );
 };
-


### PR DESCRIPTION
This change starts an `<OpenGL />` node that enables a user to drop-out of the reconciler tree and switch to immediate-mode rendering for part of the subtree. This saves performance in both reconciliation and layout when there are purely graphical components to render.

The usage is like:
```
        <View style=containerStyle>
          <OpenGL
            style=outerBox
            render={(_, _) => {
              glClearColor(1.0, 0.0, 0.0, 1.0);
           }} />
        </View>
```
And added an example that also does some text rendering.

I'm planning on leveraging this in Oni2 to draw both the buffer window and the minimap, to maximize performance and avoid overhead related to reconciliation / layout for those pieces (which aren't really need anyway!)

In the future - we'll want to also have a way to initialize and dispose graphical resources (buffers, textures, etc) - this is not implemented yet in this basic implementation.