### PR TITLE
GC: Use 'major_slice' instead of 'minor'

### DIFF
--- a/src/Core/GarbageCollector.re
+++ b/src/Core/GarbageCollector.re
@@ -6,7 +6,16 @@
  * Revery app model.
  */
 
+/* Increase minor heap size: 256kb -> 8MB */
+/*
+ * Some more info on why this is helpful:
+ * https://md.ekstrandom.net/blog/2010/06/ocaml-memory-tuning
+ */
 let minorHeapSize = 8 * 1024 * 1024;
+
+/*
+ * Amortize major collections across frames
+ */
 let defaultSliceSize = minorHeapSize / 60;
 
 let tune = () =>
@@ -14,11 +23,6 @@ let tune = () =>
   if (Environment.isNative) {
     let settings = Gc.get();
 
-    /* Increase minor heap size: 256kb -> 8MB */
-    /*
-     * Some more info on why this is helpful:
-     * https://md.ekstrandom.net/blog/2010/06/ocaml-memory-tuning
-     */
     Gc.set({...settings, minor_heap_size: minorHeapSize});
   };
 

--- a/src/Core/GarbageCollector.re
+++ b/src/Core/GarbageCollector.re
@@ -6,6 +6,9 @@
  * Revery app model.
  */
 
+let minorHeapSize = 8 * 1024 * 1024;
+let defaultSliceSize = minorHeapSize / 60;
+
 let tune = () =>
   /* Gc tuning is only applicable in the native space */
   if (Environment.isNative) {
@@ -16,13 +19,12 @@ let tune = () =>
      * Some more info on why this is helpful:
      * https://md.ekstrandom.net/blog/2010/06/ocaml-memory-tuning
      */
-    let minorHeapSize = 8 * 1024 * 1024;
     Gc.set({...settings, minor_heap_size: minorHeapSize});
   };
 
 let minor = () =>
   if (Environment.isNative) {
-    Gc.minor();
+    let _ = Gc.major_slice(defaultSliceSize);
   };
 
 let full = () =>

--- a/src/Core/GarbageCollector.re
+++ b/src/Core/GarbageCollector.re
@@ -29,6 +29,7 @@ let tune = () =>
 let minor = () =>
   if (Environment.isNative) {
     let _ = Gc.major_slice(defaultSliceSize);
+    ();
   };
 
 let full = () =>


### PR DESCRIPTION
Profiling Oni2 - we were hitting cases where we'd get surprise collections while scrolling through the buffer.

OCaml's GC has a unique feature where it allows amortized major collections - the `Gc.major_slice` call lets you do a minor collection _and_ a slice of a major collection. We've set up the default to amortize this cost across 60 frames. This helps give us more predictability in major collections and stave off surprising collections (the downside is there is a bit more fixed cost per frame, but it's still <1ms in general).

It's still important to minimize allocations in hot paths, but this helps keep us from hitting as many major allocations for now.