### PR TITLE
Performance: Cache uniform locations instead of Dictionary lookups

### DIFF
--- a/examples/OpenGLExample.re
+++ b/examples/OpenGLExample.re
@@ -32,26 +32,35 @@ module Sample = {
             render={(transform, _pctx) => {
               Glfw.glClearColor(1.0, 0.0, 0.0, 1.0);
 
-              Revery.Draw.Text.drawString(
-                ~transform,
-                ~backgroundColor=Colors.red,
-                ~color=Colors.white,
-                ~fontFamily="Roboto-Regular.ttf",
-                ~fontSize=20,
-                ~x=25.,
-                ~y=25.,
-                "Hello!",
-              );
 
-              Revery.Draw.Shapes.drawRect(
-                ~transform,
-                ~color=Colors.green,
-                ~x=25.,
-                ~y=50.,
-                ~width=10.,
-                ~height=20.,
-                (),
-              );
+              let iterations = 50000;
+              let i = ref(0);
+
+              /* Revery.Draw.Text.drawString( */
+              /*   ~transform, */
+              /*   ~backgroundColor=Colors.red, */
+              /*   ~color=Colors.white, */
+              /*   ~fontFamily="Roboto-Regular.ttf", */
+              /*   ~fontSize=20, */
+              /*   ~x=25., */
+              /*   ~y=25., */
+              /*   "Hello!", */
+              /* ); */
+
+              while (i^ < iterations) {
+
+                  Revery.Draw.Shapes.drawRect(
+                    ~transform,
+                    ~color=Colors.green,
+                    ~x=25.,
+                    ~y=50.,
+                    ~width=10.,
+                    ~height=20.,
+                    (),
+                  );
+                  incr(i);
+
+              }
             }}
           />
         </View>,

--- a/examples/OpenGLExample.re
+++ b/examples/OpenGLExample.re
@@ -52,25 +52,23 @@ module Sample = {
                 ~height=20.,
                 (),
               );
-
-
-              /* STRESS TEST:
-              let iterations = 50000;
-              let i = ref(0);
-              while (i^ < iterations) {
-                Revery.Draw.Shapes.drawRect(
-                  ~transform,
-                  ~color=Colors.green,
-                  ~x=25.,
-                  ~y=50.,
-                  ~width=10.,
-                  ~height=20.,
-                  (),
-                );
-                incr(i);
-              };
-              */
             }}
+            /* STRESS TEST:
+               let iterations = 50000;
+               let i = ref(0);
+               while (i^ < iterations) {
+                 Revery.Draw.Shapes.drawRect(
+                   ~transform,
+                   ~color=Colors.green,
+                   ~x=25.,
+                   ~y=50.,
+                   ~width=10.,
+                   ~height=20.,
+                   (),
+                 );
+                 incr(i);
+               };
+               */
           />
         </View>,
       )

--- a/examples/OpenGLExample.re
+++ b/examples/OpenGLExample.re
@@ -45,6 +45,15 @@ module Sample = {
               /*   ~y=25., */
               /*   "Hello!", */
               /* ); */
+                Revery.Draw.Shapes.drawRect(
+                  ~transform,
+                  ~color=Colors.green,
+                  ~x=25.,
+                  ~y=50.,
+                  ~width=10.,
+                  ~height=20.,
+                  (),
+                );
 
               while (i^ < iterations) {
                 Revery.Draw.Shapes.drawRect(

--- a/examples/OpenGLExample.re
+++ b/examples/OpenGLExample.re
@@ -45,15 +45,15 @@ module Sample = {
               /*   ~y=25., */
               /*   "Hello!", */
               /* ); */
-                Revery.Draw.Shapes.drawRect(
-                  ~transform,
-                  ~color=Colors.green,
-                  ~x=25.,
-                  ~y=50.,
-                  ~width=10.,
-                  ~height=20.,
-                  (),
-                );
+              Revery.Draw.Shapes.drawRect(
+                ~transform,
+                ~color=Colors.green,
+                ~x=25.,
+                ~y=50.,
+                ~width=10.,
+                ~height=20.,
+                (),
+              );
 
               while (i^ < iterations) {
                 Revery.Draw.Shapes.drawRect(

--- a/examples/OpenGLExample.re
+++ b/examples/OpenGLExample.re
@@ -32,19 +32,17 @@ module Sample = {
             render={(transform, _pctx) => {
               Glfw.glClearColor(1.0, 0.0, 0.0, 1.0);
 
-              let iterations = 50000;
-              let i = ref(0);
+              Revery.Draw.Text.drawString(
+                ~transform,
+                ~backgroundColor=Colors.red,
+                ~color=Colors.white,
+                ~fontFamily="Roboto-Regular.ttf",
+                ~fontSize=20,
+                ~x=25.,
+                ~y=25.,
+                "Hello!",
+              );
 
-              /* Revery.Draw.Text.drawString( */
-              /*   ~transform, */
-              /*   ~backgroundColor=Colors.red, */
-              /*   ~color=Colors.white, */
-              /*   ~fontFamily="Roboto-Regular.ttf", */
-              /*   ~fontSize=20, */
-              /*   ~x=25., */
-              /*   ~y=25., */
-              /*   "Hello!", */
-              /* ); */
               Revery.Draw.Shapes.drawRect(
                 ~transform,
                 ~color=Colors.green,
@@ -55,6 +53,10 @@ module Sample = {
                 (),
               );
 
+
+              /* STRESS TEST:
+              let iterations = 50000;
+              let i = ref(0);
               while (i^ < iterations) {
                 Revery.Draw.Shapes.drawRect(
                   ~transform,
@@ -67,6 +69,7 @@ module Sample = {
                 );
                 incr(i);
               };
+              */
             }}
           />
         </View>,

--- a/examples/OpenGLExample.re
+++ b/examples/OpenGLExample.re
@@ -32,7 +32,6 @@ module Sample = {
             render={(transform, _pctx) => {
               Glfw.glClearColor(1.0, 0.0, 0.0, 1.0);
 
-
               let iterations = 50000;
               let i = ref(0);
 
@@ -48,19 +47,17 @@ module Sample = {
               /* ); */
 
               while (i^ < iterations) {
-
-                  Revery.Draw.Shapes.drawRect(
-                    ~transform,
-                    ~color=Colors.green,
-                    ~x=25.,
-                    ~y=50.,
-                    ~width=10.,
-                    ~height=20.,
-                    (),
-                  );
-                  incr(i);
-
-              }
+                Revery.Draw.Shapes.drawRect(
+                  ~transform,
+                  ~color=Colors.green,
+                  ~x=25.,
+                  ~y=50.,
+                  ~width=10.,
+                  ~height=20.,
+                  (),
+                );
+                incr(i);
+              };
             }}
           />
         </View>,

--- a/src/Draw/FontShader.re
+++ b/src/Draw/FontShader.re
@@ -4,7 +4,6 @@
  * Simple texture shader
  */
 open Revery_Shaders;
-open Revery_Shaders.Shader;
 
 let attribute: list(ShaderAttribute.t) =
   SolidShader.attribute

--- a/src/Draw/FontShader.re
+++ b/src/Draw/FontShader.re
@@ -3,6 +3,7 @@
  *
  * Simple texture shader
  */
+open Reglfw.Glfw;
 open Revery_Shaders;
 
 let attribute: list(ShaderAttribute.t) =
@@ -55,6 +56,13 @@ let vsShader = SolidShader.vsShader ++ "\n" ++ {|
  * However, it is the fastest and most convenient text rendering-strategy.
  */
 module Default = {
+    type t = {
+        compiledShader: CompiledShader.t,
+        uniformWorld: uniformLocation,
+        uniformProjection: uniformLocation,
+        uniformColor: uniformLocation,
+    };
+
   let fsShader = {|
         vec4 t = texture2D(uSampler, vTexCoord);
         gl_FragColor = vec4(vColor.r, vColor.g, vColor.b, t.a * vColor.a);
@@ -69,7 +77,12 @@ module Default = {
         ~vertexShader=vsShader,
         ~fragmentShader=fsShader,
       );
-    Shader.compile(shader);
+  let compiledShader = Shader.compile(shader);
+  let uniformWorld = CompiledShader.getUniformLocation(compiledShader, "uWorld");
+  let uniformProjection = CompiledShader.getUniformLocation(compiledShader, "uProjection");
+  let uniformColor = CompiledShader.getUniformLocation(compiledShader, "uColor");
+
+  { compiledShader, uniformWorld, uniformProjection, uniformColor }
   };
 };
 
@@ -94,6 +107,15 @@ module GammaCorrected = {
         gl_FragColor = vec4(r, g, b, 1.0);
     |};
 
+    type t = {
+        compiledShader: CompiledShader.t,
+        uniformWorld: uniformLocation,
+        uniformProjection: uniformLocation,
+        uniformColor: uniformLocation,
+        uniformBackgroundColor: uniformLocation,
+        uniformGamma: uniformLocation,
+    };
+
   let create = () => {
     let shader =
       Shader.create(
@@ -103,6 +125,13 @@ module GammaCorrected = {
         ~vertexShader=vsShader,
         ~fragmentShader=fsShader,
       );
-    Shader.compile(shader);
+  let compiledShader = Shader.compile(shader);
+  let uniformWorld = CompiledShader.getUniformLocation(compiledShader, "uWorld");
+  let uniformProjection = CompiledShader.getUniformLocation(compiledShader, "uProjection");
+  let uniformColor = CompiledShader.getUniformLocation(compiledShader, "uColor");
+  let uniformBackgroundColor = CompiledShader.getUniformLocation(compiledShader, "uBackgroundColor");
+  let uniformGamma = CompiledShader.getUniformLocation(compiledShader, "uGamma");
+
+  { compiledShader, uniformWorld, uniformProjection, uniformColor, uniformBackgroundColor, uniformGamma }
   };
 };

--- a/src/Draw/FontShader.re
+++ b/src/Draw/FontShader.re
@@ -56,12 +56,12 @@ let vsShader = SolidShader.vsShader ++ "\n" ++ {|
  * However, it is the fastest and most convenient text rendering-strategy.
  */
 module Default = {
-    type t = {
-        compiledShader: CompiledShader.t,
-        uniformWorld: uniformLocation,
-        uniformProjection: uniformLocation,
-        uniformColor: uniformLocation,
-    };
+  type t = {
+    compiledShader: CompiledShader.t,
+    uniformWorld: uniformLocation,
+    uniformProjection: uniformLocation,
+    uniformColor: uniformLocation,
+  };
 
   let fsShader = {|
         vec4 t = texture2D(uSampler, vTexCoord);
@@ -77,12 +77,15 @@ module Default = {
         ~vertexShader=vsShader,
         ~fragmentShader=fsShader,
       );
-  let compiledShader = Shader.compile(shader);
-  let uniformWorld = CompiledShader.getUniformLocation(compiledShader, "uWorld");
-  let uniformProjection = CompiledShader.getUniformLocation(compiledShader, "uProjection");
-  let uniformColor = CompiledShader.getUniformLocation(compiledShader, "uColor");
+    let compiledShader = Shader.compile(shader);
+    let uniformWorld =
+      CompiledShader.getUniformLocation(compiledShader, "uWorld");
+    let uniformProjection =
+      CompiledShader.getUniformLocation(compiledShader, "uProjection");
+    let uniformColor =
+      CompiledShader.getUniformLocation(compiledShader, "uColor");
 
-  { compiledShader, uniformWorld, uniformProjection, uniformColor }
+    {compiledShader, uniformWorld, uniformProjection, uniformColor};
   };
 };
 
@@ -107,14 +110,14 @@ module GammaCorrected = {
         gl_FragColor = vec4(r, g, b, 1.0);
     |};
 
-    type t = {
-        compiledShader: CompiledShader.t,
-        uniformWorld: uniformLocation,
-        uniformProjection: uniformLocation,
-        uniformColor: uniformLocation,
-        uniformBackgroundColor: uniformLocation,
-        uniformGamma: uniformLocation,
-    };
+  type t = {
+    compiledShader: CompiledShader.t,
+    uniformWorld: uniformLocation,
+    uniformProjection: uniformLocation,
+    uniformColor: uniformLocation,
+    uniformBackgroundColor: uniformLocation,
+    uniformGamma: uniformLocation,
+  };
 
   let create = () => {
     let shader =
@@ -125,13 +128,25 @@ module GammaCorrected = {
         ~vertexShader=vsShader,
         ~fragmentShader=fsShader,
       );
-  let compiledShader = Shader.compile(shader);
-  let uniformWorld = CompiledShader.getUniformLocation(compiledShader, "uWorld");
-  let uniformProjection = CompiledShader.getUniformLocation(compiledShader, "uProjection");
-  let uniformColor = CompiledShader.getUniformLocation(compiledShader, "uColor");
-  let uniformBackgroundColor = CompiledShader.getUniformLocation(compiledShader, "uBackgroundColor");
-  let uniformGamma = CompiledShader.getUniformLocation(compiledShader, "uGamma");
+    let compiledShader = Shader.compile(shader);
+    let uniformWorld =
+      CompiledShader.getUniformLocation(compiledShader, "uWorld");
+    let uniformProjection =
+      CompiledShader.getUniformLocation(compiledShader, "uProjection");
+    let uniformColor =
+      CompiledShader.getUniformLocation(compiledShader, "uColor");
+    let uniformBackgroundColor =
+      CompiledShader.getUniformLocation(compiledShader, "uBackgroundColor");
+    let uniformGamma =
+      CompiledShader.getUniformLocation(compiledShader, "uGamma");
 
-  { compiledShader, uniformWorld, uniformProjection, uniformColor, uniformBackgroundColor, uniformGamma }
+    {
+      compiledShader,
+      uniformWorld,
+      uniformProjection,
+      uniformColor,
+      uniformBackgroundColor,
+      uniformGamma,
+    };
   };
 };

--- a/src/Draw/GradientShader.re
+++ b/src/Draw/GradientShader.re
@@ -5,7 +5,6 @@
  * the gradient is used to draw a box shadow
  */
 open Revery_Shaders;
-open Revery_Shaders.Shader;
 
 let attributes: list(ShaderAttribute.t) =
   SolidShader.attribute

--- a/src/Draw/GradientShader.re
+++ b/src/Draw/GradientShader.re
@@ -4,6 +4,7 @@
  * shader used for specificying a gradient.
  * the gradient is used to draw a box shadow
  */
+open Reglfw.Glfw;
 open Revery_Shaders;
 
 let attributes: list(ShaderAttribute.t) =
@@ -64,6 +65,15 @@ let fragmentShader = {|
   gl_FragColor = vec4(uShadowColor, blur);
 |};
 
+   type t = {
+    compiledShader: CompiledShader.t,
+    uniformProjection: uniformLocation,
+    uniformShadowColor: uniformLocation,
+    uniformShadowAmount: uniformLocation,
+    uniformWorld: uniformLocation,
+   };
+
+
 let create = () => {
   let shader =
     Shader.create(
@@ -73,5 +83,21 @@ let create = () => {
       ~vertexShader,
       ~fragmentShader,
     );
-  Shader.compile(shader);
+  let compiledShader = Shader.compile(shader);
+    let uniformWorld =
+      CompiledShader.getUniformLocation(compiledShader, "uWorld");
+    let uniformProjection =
+      CompiledShader.getUniformLocation(compiledShader, "uProjection");
+    let uniformShadowColor =
+      CompiledShader.getUniformLocation(compiledShader, "uShadowColor");
+    let uniformShadowAmount =
+      CompiledShader.getUniformLocation(compiledShader, "uShadowAmount");
+
+    {
+      compiledShader,
+      uniformWorld,
+      uniformProjection,
+      uniformShadowColor,
+      uniformShadowAmount,
+    };
 };

--- a/src/Draw/GradientShader.re
+++ b/src/Draw/GradientShader.re
@@ -65,14 +65,13 @@ let fragmentShader = {|
   gl_FragColor = vec4(uShadowColor, blur);
 |};
 
-   type t = {
-    compiledShader: CompiledShader.t,
-    uniformProjection: uniformLocation,
-    uniformShadowColor: uniformLocation,
-    uniformShadowAmount: uniformLocation,
-    uniformWorld: uniformLocation,
-   };
-
+type t = {
+  compiledShader: CompiledShader.t,
+  uniformProjection: uniformLocation,
+  uniformShadowColor: uniformLocation,
+  uniformShadowAmount: uniformLocation,
+  uniformWorld: uniformLocation,
+};
 
 let create = () => {
   let shader =
@@ -84,20 +83,20 @@ let create = () => {
       ~fragmentShader,
     );
   let compiledShader = Shader.compile(shader);
-    let uniformWorld =
-      CompiledShader.getUniformLocation(compiledShader, "uWorld");
-    let uniformProjection =
-      CompiledShader.getUniformLocation(compiledShader, "uProjection");
-    let uniformShadowColor =
-      CompiledShader.getUniformLocation(compiledShader, "uShadowColor");
-    let uniformShadowAmount =
-      CompiledShader.getUniformLocation(compiledShader, "uShadowAmount");
+  let uniformWorld =
+    CompiledShader.getUniformLocation(compiledShader, "uWorld");
+  let uniformProjection =
+    CompiledShader.getUniformLocation(compiledShader, "uProjection");
+  let uniformShadowColor =
+    CompiledShader.getUniformLocation(compiledShader, "uShadowColor");
+  let uniformShadowAmount =
+    CompiledShader.getUniformLocation(compiledShader, "uShadowAmount");
 
-    {
-      compiledShader,
-      uniformWorld,
-      uniformProjection,
-      uniformShadowColor,
-      uniformShadowAmount,
-    };
+  {
+    compiledShader,
+    uniformWorld,
+    uniformProjection,
+    uniformShadowColor,
+    uniformShadowAmount,
+  };
 };

--- a/src/Draw/Revery_Draw.re
+++ b/src/Draw/Revery_Draw.re
@@ -5,3 +5,5 @@ module FontRenderer = FontRenderer;
 module ImageRenderer = ImageRenderer;
 module Shapes = Shapes;
 module Text = Text;
+
+module SolidShader = SolidShader;

--- a/src/Draw/Shapes.re
+++ b/src/Draw/Shapes.re
@@ -5,7 +5,6 @@
  */
 
 open Reglm;
-open Reglfw.Glfw;
 
 open Revery_Core;
 open Revery_Shaders;
@@ -43,15 +42,9 @@ let drawRect =
     let shader = Assets.solidShader();
     CompiledShader.use(shader.compiledShader);
 
-    /* if (derp) { */
-    glUniformMatrix4fv(shader.uniformProjection, ctx.projection);
-    glUniformMatrix4fv(shader.uniformWorld, world);
-    glUniform4fv(shader.uniformColor, Color.toVec4(color));
-    /* } */
-    /* CompiledShader.setUniformMatrix4fv(shader, "uProjection", ctx.projection); */
-    /* CompiledShader.setUniformMatrix4fv(shader, "uWorld", world); */
-
-    /* CompiledShader.setUniform4fv(shader, "uColor", Color.toVec4(color)); */
+    CompiledShader.setUniformMatrix4fv(shader.uniformProjection, ctx.projection);
+    CompiledShader.setUniformMatrix4fv(shader.uniformWorld, world);
+    CompiledShader.setUniform4fv(shader.uniformColor, Color.toVec4(color));
 
     Geometry.draw(quad, shader.compiledShader);
   | _ => ()

--- a/src/Draw/Shapes.re
+++ b/src/Draw/Shapes.re
@@ -44,9 +44,9 @@ let drawRect =
     CompiledShader.use(shader.compiledShader);
 
     /* if (derp) { */
-        glUniformMatrix4fv(shader.uniformProjection, ctx.projection);
-        glUniformMatrix4fv(shader.uniformWorld, world);
-        glUniform4fv(shader.uniformColor, Color.toVec4(color));
+    glUniformMatrix4fv(shader.uniformProjection, ctx.projection);
+    glUniformMatrix4fv(shader.uniformWorld, world);
+    glUniform4fv(shader.uniformColor, Color.toVec4(color));
     /* } */
     /* CompiledShader.setUniformMatrix4fv(shader, "uProjection", ctx.projection); */
     /* CompiledShader.setUniformMatrix4fv(shader, "uWorld", world); */

--- a/src/Draw/Shapes.re
+++ b/src/Draw/Shapes.re
@@ -42,7 +42,10 @@ let drawRect =
     let shader = Assets.solidShader();
     CompiledShader.use(shader.compiledShader);
 
-    CompiledShader.setUniformMatrix4fv(shader.uniformProjection, ctx.projection);
+    CompiledShader.setUniformMatrix4fv(
+      shader.uniformProjection,
+      ctx.projection,
+    );
     CompiledShader.setUniformMatrix4fv(shader.uniformWorld, world);
     CompiledShader.setUniform4fv(shader.uniformColor, Color.toVec4(color));
 

--- a/src/Draw/Shapes.re
+++ b/src/Draw/Shapes.re
@@ -5,7 +5,7 @@
  */
 
 open Reglm;
-/* open Reglfw.Glfw; */
+open Reglfw.Glfw;
 
 open Revery_Core;
 open Revery_Shaders;
@@ -41,13 +41,19 @@ let drawRect =
 
     let quad = Assets.quad();
     let shader = Assets.solidShader();
-    CompiledShader.use(shader);
-    CompiledShader.setUniformMatrix4fv(shader, "uProjection", ctx.projection);
-    CompiledShader.setUniformMatrix4fv(shader, "uWorld", world);
+    CompiledShader.use(shader.compiledShader);
 
-    CompiledShader.setUniform4fv(shader, "uColor", Color.toVec4(color));
+    /* if (derp) { */
+        glUniformMatrix4fv(shader.uniformProjection, ctx.projection);
+        glUniformMatrix4fv(shader.uniformWorld, world);
+        glUniform4fv(shader.uniformColor, Color.toVec4(color));
+    /* } */
+    /* CompiledShader.setUniformMatrix4fv(shader, "uProjection", ctx.projection); */
+    /* CompiledShader.setUniformMatrix4fv(shader, "uWorld", world); */
 
-    Geometry.draw(quad, shader);
+    /* CompiledShader.setUniform4fv(shader, "uColor", Color.toVec4(color)); */
+
+    Geometry.draw(quad, shader.compiledShader);
   | _ => ()
   };
 };

--- a/src/Draw/SolidShader.re
+++ b/src/Draw/SolidShader.re
@@ -4,7 +4,6 @@
  * Simple shader demonstrating usage of attributes, uniforms, and varying parameters.
  */
 open Revery_Shaders;
-open Revery_Shaders.Shader;
 
 let attribute: list(ShaderAttribute.t) = [
   {dataType: ShaderDataType.Vector2, name: "aPosition", channel: Position},

--- a/src/Draw/SolidShader.re
+++ b/src/Draw/SolidShader.re
@@ -35,11 +35,11 @@ let fsShader = {|
 |};
 
 type t = {
-    compiledShader: CompiledShader.t,
-    uniformWorld: uniformLocation,
-    uniformProjection: uniformLocation,
-    uniformColor: uniformLocation,
-}
+  compiledShader: CompiledShader.t,
+  uniformWorld: uniformLocation,
+  uniformProjection: uniformLocation,
+  uniformColor: uniformLocation,
+};
 
 let create = () => {
   let shader =
@@ -51,9 +51,12 @@ let create = () => {
       ~fragmentShader=fsShader,
     );
   let compiledShader = Shader.compile(shader);
-  let uniformWorld = CompiledShader.getUniformLocation(compiledShader, "uWorld");
-  let uniformProjection = CompiledShader.getUniformLocation(compiledShader, "uProjection");
-  let uniformColor = CompiledShader.getUniformLocation(compiledShader, "uColor");
+  let uniformWorld =
+    CompiledShader.getUniformLocation(compiledShader, "uWorld");
+  let uniformProjection =
+    CompiledShader.getUniformLocation(compiledShader, "uProjection");
+  let uniformColor =
+    CompiledShader.getUniformLocation(compiledShader, "uColor");
 
-  { compiledShader, uniformWorld, uniformProjection, uniformColor }
+  {compiledShader, uniformWorld, uniformProjection, uniformColor};
 };

--- a/src/Draw/SolidShader.re
+++ b/src/Draw/SolidShader.re
@@ -3,6 +3,7 @@
  *
  * Simple shader demonstrating usage of attributes, uniforms, and varying parameters.
  */
+open Reglfw.Glfw;
 open Revery_Shaders;
 
 let attribute: list(ShaderAttribute.t) = [
@@ -33,6 +34,13 @@ let fsShader = {|
     gl_FragColor = vColor;
 |};
 
+type t = {
+    compiledShader: CompiledShader.t,
+    uniformWorld: uniformLocation,
+    uniformProjection: uniformLocation,
+    uniformColor: uniformLocation,
+}
+
 let create = () => {
   let shader =
     Shader.create(
@@ -42,5 +50,10 @@ let create = () => {
       ~vertexShader=vsShader,
       ~fragmentShader=fsShader,
     );
-  Shader.compile(shader);
+  let compiledShader = Shader.compile(shader);
+  let uniformWorld = CompiledShader.getUniformLocation(compiledShader, "uWorld");
+  let uniformProjection = CompiledShader.getUniformLocation(compiledShader, "uProjection");
+  let uniformColor = CompiledShader.getUniformLocation(compiledShader, "uColor");
+
+  { compiledShader, uniformWorld, uniformProjection, uniformColor }
 };

--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -53,7 +53,7 @@ let _startShader =
   if (backgroundColor.a > 0.99) {
     let shader = Assets.fontGammaCorrectedShader();
     CompiledShader.use(shader.compiledShader);
-CompiledShader.setUniformMatrix4fv(shader.uniformProjection, projection);
+    CompiledShader.setUniformMatrix4fv(shader.uniformProjection, projection);
     CompiledShader.setUniform4fv(shader.uniformColor, Color.toVec4(color));
     CompiledShader.setUniform4fv(
       shader.uniformBackgroundColor,

--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -53,20 +53,20 @@ let _startShader =
   if (backgroundColor.a > 0.99) {
     let shader = Assets.fontGammaCorrectedShader();
     CompiledShader.use(shader.compiledShader);
-    glUniformMatrix4fv(shader.uniformProjection, projection);
-    glUniform4fv(shader.uniformColor, Color.toVec4(color));
-    glUniform4fv(
+CompiledShader.setUniformMatrix4fv(shader.uniformProjection, projection);
+    CompiledShader.setUniform4fv(shader.uniformColor, Color.toVec4(color));
+    CompiledShader.setUniform4fv(
       shader.uniformBackgroundColor,
       Color.toVec4(backgroundColor),
     );
-    glUniform1f(shader.uniformGamma, gamma);
+    CompiledShader.setUniform1f(shader.uniformGamma, gamma);
 
     (shader.compiledShader, shader.uniformWorld);
   } else {
     let shader = Assets.fontDefaultShader();
     CompiledShader.use(shader.compiledShader);
-    glUniformMatrix4fv(shader.uniformProjection, projection);
-    glUniform4fv(shader.uniformColor, Color.toVec4(color));
+    CompiledShader.setUniformMatrix4fv(shader.uniformProjection, projection);
+    CompiledShader.setUniform4fv(shader.uniformColor, Color.toVec4(color));
 
     (shader.compiledShader, shader.uniformWorld);
   };
@@ -141,7 +141,7 @@ let drawString =
       Mat4.multiply(xform, outerTransform, local);
       Mat4.multiply(xform, transform, xform);
 
-      glUniformMatrix4fv(uniformWorld, xform);
+      CompiledShader.setUniformMatrix4fv(uniformWorld, xform);
 
       Geometry.draw(quad, shader);
 

--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -143,8 +143,6 @@ let drawString =
 
       glUniformMatrix4fv(uniformWorld, xform);
 
-      /* Mat4.identity(xform); */
-
       Geometry.draw(quad, shader);
 
       x +. advance /. 64.0;

--- a/src/Draw/TextureShader.re
+++ b/src/Draw/TextureShader.re
@@ -4,7 +4,6 @@
  * Simple texture shader
  */
 open Revery_Shaders;
-open Revery_Shaders.Shader;
 
 let attribute: list(ShaderAttribute.t) =
   SolidShader.attribute

--- a/src/Draw/TextureShader.re
+++ b/src/Draw/TextureShader.re
@@ -3,6 +3,7 @@
  *
  * Simple texture shader
  */
+open Reglfw.Glfw;
 open Revery_Shaders;
 
 let attribute: list(ShaderAttribute.t) =
@@ -43,6 +44,13 @@ let fsShader = {|
     gl_FragColor = vColor * texture2D(uSampler, vTexCoord);
 |};
 
+type t = {
+  compiledShader: CompiledShader.t,
+  uniformWorld: uniformLocation,
+  uniformProjection: uniformLocation,
+  uniformColor: uniformLocation,
+};
+
 let create = () => {
   let shader =
     Shader.create(
@@ -52,5 +60,13 @@ let create = () => {
       ~vertexShader=vsShader,
       ~fragmentShader=fsShader,
     );
-  Shader.compile(shader);
+  let compiledShader = Shader.compile(shader);
+  let uniformWorld =
+    CompiledShader.getUniformLocation(compiledShader, "uWorld");
+  let uniformProjection =
+    CompiledShader.getUniformLocation(compiledShader, "uProjection");
+  let uniformColor =
+    CompiledShader.getUniformLocation(compiledShader, "uColor");
+
+  {compiledShader, uniformWorld, uniformProjection, uniformColor};
 };

--- a/src/Geometry/Builder.re
+++ b/src/Geometry/Builder.re
@@ -1,5 +1,5 @@
 open Reglfw;
-open Revery_Shaders.Shader;
+open Revery_Shaders;
 
 type t = {
   vertexBuffers: ref(list(VertexBuffer.t)),

--- a/src/Geometry/Geometry.re
+++ b/src/Geometry/Geometry.re
@@ -1,5 +1,5 @@
 open Reglfw;
-open Revery_Shaders.Shader;
+open Revery_Shaders;
 
 type t = {
   vertexBuffers: list(VertexBuffer.t),

--- a/src/Geometry/Quad.re
+++ b/src/Geometry/Quad.re
@@ -1,4 +1,4 @@
-open Revery_Shaders.Shader;
+open Revery_Shaders;
 
 let create = (minX, minY, maxX, maxY) => {
   let positions = [|minX, maxY, maxX, maxY, maxX, minY, minX, minY|];

--- a/src/Geometry/Triangle.re
+++ b/src/Geometry/Triangle.re
@@ -1,4 +1,4 @@
-open Revery_Shaders.Shader;
+open Revery_Shaders;
 
 let minOf3 = (x, y, z) =>
   if (x <= y && x <= z) {

--- a/src/Geometry/VertexBuffer.re
+++ b/src/Geometry/VertexBuffer.re
@@ -1,6 +1,6 @@
 open Reglfw;
 
-open Revery_Shaders.Shader;
+open Revery_Shaders;
 
 type t = {
   buffer: Glfw.buffer,

--- a/src/Shaders/BasicShader.re
+++ b/src/Shaders/BasicShader.re
@@ -3,7 +3,7 @@
  *
  * Simple shader demonstrating usage of attributes, uniforms, and varying parameters.
  */
-open Shader;
+open Types;
 
 let attribute: list(ShaderAttribute.t) = [
   {

--- a/src/Shaders/CompiledShader.re
+++ b/src/Shaders/CompiledShader.re
@@ -50,26 +50,22 @@ let getUniformLocation: (t, string) => uniformLocation =
  * Cache to stash global state, so we can
  * minimize calls to OpenGL when possible
  */
-module ShaderCache {
-    type t = {
-       mutable program: option(Glfw.program),
-    };
+module ShaderCache = {
+  type t = {mutable program: option(Glfw.program)};
 
-    let create = () => {
-        program: None,
-    };
+  let create = () => {program: None};
 
-    let useProgramIfNew = (cache: t, program: Glfw.program, f) => {
-        switch (cache.program) {
-        | None =>
-            cache.program = Some(program);
-            f();
-        | Some(v) when v !== program =>
-            cache.program = Some(program);
-            f();
-        | Some(_) => ();
-        }
-    }
+  let useProgramIfNew = (cache: t, program: Glfw.program, f) => {
+    switch (cache.program) {
+    | None =>
+      cache.program = Some(program);
+      f();
+    | Some(v) when v !== program =>
+      cache.program = Some(program);
+      f();
+    | Some(_) => ()
+    };
+  };
 };
 
 let _cache: ref(ShaderCache.t) = ref(ShaderCache.create());
@@ -92,6 +88,6 @@ let setUniformMatrix4fv = (u: uniformLocation, m: Mat4.t) =>
   glUniformMatrix4fv(u, m);
 
 let use = (s: t) => {
-    let (_, _, _, p, _, _, _) = s;
-    ShaderCache.useProgramIfNew(_cache^, p, () => glUseProgram(p))
+  let (_, _, _, p, _, _, _) = s;
+  ShaderCache.useProgramIfNew(_cache^, p, () => glUseProgram(p));
 };

--- a/src/Shaders/CompiledShader.re
+++ b/src/Shaders/CompiledShader.re
@@ -57,25 +57,18 @@ let _setUniformIfAvailable = (s, name, f) => {
 let setUniform1f = (uniform: uniformLocation, v) =>
   glUniform1f(uniform, v);
 
-/* let setUniform2fv = (s: t, name: string, v: Vec2.t) => */
-/*   _setUniformIfAvailable(s, name, u => glUniform2fv(u, v)); */
-
 let setUniform2fv = (uniform: uniformLocation, v: Vec2.t) =>
     glUniform2fv(uniform, v);
-
-/* let setUniform3fv = (s: t, name: string, v: Vec3.t) => */
-/*   _setUniformIfAvailable(s, name, u => glUniform3fv(u, v)); */
-
 
 let setUniform3fv = (uniform: uniformLocation, v: Vec3.t) =>
     glUniform3fv(uniform, v);
 
 let setUniform4f =
-    (s: t, name: string, x: float, y: float, z: float, w: float) =>
-  _setUniformIfAvailable(s, name, u => glUniform4f(u, x, y, z, w));
+    (u: uniformLocation, x: float, y: float, z: float, w: float) =>
+  glUniform4f(u, x, y, z, w);
 
-let setUniform4fv = (s: t, name: string, v: Vec4.t) =>
-  _setUniformIfAvailable(s, name, u => glUniform4fv(u, v));
+let setUniform4fv = (u: uniformLocation, v: Vec4.t) =>
+  glUniform4fv(u, v);
 
 let setUniformMatrix4fv = (s: t, name: string, m: Mat4.t) =>
   _setUniformIfAvailable(s, name, u => glUniformMatrix4fv(u, m));

--- a/src/Shaders/CompiledShader.re
+++ b/src/Shaders/CompiledShader.re
@@ -54,21 +54,19 @@ let _setUniformIfAvailable = (s, name, f) => {
   };
 };
 
-let setUniform1f = (uniform: uniformLocation, v) =>
-  glUniform1f(uniform, v);
+let setUniform1f = (uniform: uniformLocation, v) => glUniform1f(uniform, v);
 
 let setUniform2fv = (uniform: uniformLocation, v: Vec2.t) =>
-    glUniform2fv(uniform, v);
+  glUniform2fv(uniform, v);
 
 let setUniform3fv = (uniform: uniformLocation, v: Vec3.t) =>
-    glUniform3fv(uniform, v);
+  glUniform3fv(uniform, v);
 
 let setUniform4f =
     (u: uniformLocation, x: float, y: float, z: float, w: float) =>
   glUniform4f(u, x, y, z, w);
 
-let setUniform4fv = (u: uniformLocation, v: Vec4.t) =>
-  glUniform4fv(u, v);
+let setUniform4fv = (u: uniformLocation, v: Vec4.t) => glUniform4fv(u, v);
 
 let setUniformMatrix4fv = (s: t, name: string, m: Mat4.t) =>
   _setUniformIfAvailable(s, name, u => glUniformMatrix4fv(u, m));

--- a/src/Shaders/CompiledShader.re
+++ b/src/Shaders/CompiledShader.re
@@ -30,10 +30,10 @@ let attributeChannelToLocation = (s: t, a: VertexChannel.t) => {
 
 exception UniformNotFoundException(string);
 let _getOrThrowUniform = (name, opt) => {
-    switch (opt) {
-    | Some(v) => v
-    | None => raise(UniformNotFoundException(name));
-    }
+  switch (opt) {
+  | Some(v) => v
+  | None => raise(UniformNotFoundException(name))
+  };
 };
 
 let uniformNameToLocation = (s: t, name: string) => {
@@ -41,10 +41,10 @@ let uniformNameToLocation = (s: t, name: string) => {
   Hashtbl.find_opt(u, name);
 };
 
-let getUniformLocation: (t, string) => uniformLocation = (s, a) => {
-    uniformNameToLocation(s, a)
-    |> _getOrThrowUniform(a)
-};
+let getUniformLocation: (t, string) => uniformLocation =
+  (s, a) => {
+    uniformNameToLocation(s, a) |> _getOrThrowUniform(a);
+  };
 
 let _setUniformIfAvailable = (s, name, f) => {
   let uLoc = uniformNameToLocation(s, name);
@@ -73,6 +73,10 @@ let setUniform4fv = (s: t, name: string, v: Vec4.t) =>
 let setUniformMatrix4fv = (s: t, name: string, m: Mat4.t) =>
   _setUniformIfAvailable(s, name, u => glUniformMatrix4fv(u, m));
 
+/*
+ * State changes in OpenGL are expensive!
+ * We want to minimize those, when possible.
+ */
 let _cache: ref(option(Glfw.program)) = ref(None);
 
 let use = (s: t) => {

--- a/src/Shaders/CompiledShader.re
+++ b/src/Shaders/CompiledShader.re
@@ -4,64 +4,63 @@ open Reglm;
 
 open Types;
 
+type attributeNameToLocation = Hashtbl.t(string, attribLocation);
+type attributeChannelToLocation = Hashtbl.t(VertexChannel.t, attribLocation);
+type uniformNameToLocation = Hashtbl.t(string, uniformLocation);
 
-  type attributeNameToLocation = Hashtbl.t(string, attribLocation);
-  type attributeChannelToLocation = Hashtbl.t(VertexChannel.t, attribLocation);
-  type uniformNameToLocation = Hashtbl.t(string, uniformLocation);
+type t = (
+  list(ShaderUniform.t),
+  list(ShaderAttribute.t),
+  list(ShaderVarying.t),
+  Glfw.program,
+  attributeNameToLocation,
+  attributeChannelToLocation,
+  uniformNameToLocation,
+);
 
-  type t = (
-    list(ShaderUniform.t),
-    list(ShaderAttribute.t),
-    list(ShaderVarying.t),
-    Glfw.program,
-    attributeNameToLocation,
-    attributeChannelToLocation,
-    uniformNameToLocation,
-  );
+let attributeNameToLocation = (s: t, a: string) => {
+  let (_, _, _, _, dict, _, _) = s;
+  Hashtbl.find_opt(dict, a);
+};
 
-  let attributeNameToLocation = (s: t, a: string) => {
-    let (_, _, _, _, dict, _, _) = s;
-    Hashtbl.find_opt(dict, a);
+let attributeChannelToLocation = (s: t, a: VertexChannel.t) => {
+  let (_, _, _, _, _, dict, _) = s;
+  Hashtbl.find_opt(dict, a);
+};
+
+let uniformNameToLocation = (s: t, name: string) => {
+  let (_, _, _, _, _, _, u) = s;
+  Hashtbl.find_opt(u, name);
+};
+
+let _setUniformIfAvailable = (s, name, f) => {
+  let uLoc = uniformNameToLocation(s, name);
+  switch (uLoc) {
+  | Some(u) => f(u)
+  | None => ()
   };
+};
 
-  let attributeChannelToLocation = (s: t, a: VertexChannel.t) => {
-    let (_, _, _, _, _, dict, _) = s;
-    Hashtbl.find_opt(dict, a);
-  };
+let setUniform1f = (s: t, name: string, v: float) =>
+  _setUniformIfAvailable(s, name, u => glUniform1f(u, v));
 
-  let uniformNameToLocation = (s: t, name: string) => {
-    let (_, _, _, _, _, _, u) = s;
-    Hashtbl.find_opt(u, name);
-  };
+let setUniform2fv = (s: t, name: string, v: Vec2.t) =>
+  _setUniformIfAvailable(s, name, u => glUniform2fv(u, v));
 
-  let _setUniformIfAvailable = (s, name, f) => {
-    let uLoc = uniformNameToLocation(s, name);
-    switch (uLoc) {
-    | Some(u) => f(u)
-    | None => ()
-    };
-  };
+let setUniform3fv = (s: t, name: string, v: Vec3.t) =>
+  _setUniformIfAvailable(s, name, u => glUniform3fv(u, v));
 
-  let setUniform1f = (s: t, name: string, v: float) =>
-    _setUniformIfAvailable(s, name, u => glUniform1f(u, v));
+let setUniform4f =
+    (s: t, name: string, x: float, y: float, z: float, w: float) =>
+  _setUniformIfAvailable(s, name, u => glUniform4f(u, x, y, z, w));
 
-  let setUniform2fv = (s: t, name: string, v: Vec2.t) =>
-    _setUniformIfAvailable(s, name, u => glUniform2fv(u, v));
+let setUniform4fv = (s: t, name: string, v: Vec4.t) =>
+  _setUniformIfAvailable(s, name, u => glUniform4fv(u, v));
 
-  let setUniform3fv = (s: t, name: string, v: Vec3.t) =>
-    _setUniformIfAvailable(s, name, u => glUniform3fv(u, v));
+let setUniformMatrix4fv = (s: t, name: string, m: Mat4.t) =>
+  _setUniformIfAvailable(s, name, u => glUniformMatrix4fv(u, m));
 
-  let setUniform4f =
-      (s: t, name: string, x: float, y: float, z: float, w: float) =>
-    _setUniformIfAvailable(s, name, u => glUniform4f(u, x, y, z, w));
-
-  let setUniform4fv = (s: t, name: string, v: Vec4.t) =>
-    _setUniformIfAvailable(s, name, u => glUniform4fv(u, v));
-
-  let setUniformMatrix4fv = (s: t, name: string, m: Mat4.t) =>
-    _setUniformIfAvailable(s, name, u => glUniformMatrix4fv(u, m));
-
-  let use = (s: t) => {
-    let (_, _, _, p, _, _, _) = s;
-    glUseProgram(p);
-  };
+let use = (s: t) => {
+  let (_, _, _, p, _, _, _) = s;
+  glUseProgram(p);
+};

--- a/src/Shaders/CompiledShader.re
+++ b/src/Shaders/CompiledShader.re
@@ -54,14 +54,21 @@ let _setUniformIfAvailable = (s, name, f) => {
   };
 };
 
-let setUniform1f = (s: t, name: string, v: float) =>
-  _setUniformIfAvailable(s, name, u => glUniform1f(u, v));
+let setUniform1f = (uniform: uniformLocation, v) =>
+  glUniform1f(uniform, v);
 
-let setUniform2fv = (s: t, name: string, v: Vec2.t) =>
-  _setUniformIfAvailable(s, name, u => glUniform2fv(u, v));
+/* let setUniform2fv = (s: t, name: string, v: Vec2.t) => */
+/*   _setUniformIfAvailable(s, name, u => glUniform2fv(u, v)); */
 
-let setUniform3fv = (s: t, name: string, v: Vec3.t) =>
-  _setUniformIfAvailable(s, name, u => glUniform3fv(u, v));
+let setUniform2fv = (uniform: uniformLocation, v: Vec2.t) =>
+    glUniform2fv(uniform, v);
+
+/* let setUniform3fv = (s: t, name: string, v: Vec3.t) => */
+/*   _setUniformIfAvailable(s, name, u => glUniform3fv(u, v)); */
+
+
+let setUniform3fv = (uniform: uniformLocation, v: Vec3.t) =>
+    glUniform3fv(uniform, v);
 
 let setUniform4f =
     (s: t, name: string, x: float, y: float, z: float, w: float) =>

--- a/src/Shaders/CompiledShader.re
+++ b/src/Shaders/CompiledShader.re
@@ -47,61 +47,30 @@ let getUniformLocation: (t, string) => uniformLocation =
   };
 
 /*
- * State changes in OpenGL are expensive!
- * We want to minimize those, when possible.
+ * Cache to stash global state, so we can
+ * minimize calls to OpenGL when possible
  */
 module ShaderCache {
-    let identityMatrix = Mat4.create();
-
-
-    let cache_size = 32;
-
     type t = {
        mutable program: option(Glfw.program),
-       cachedMat4: array(Mat4.t),
     };
 
     let create = () => {
         program: None,
-        cachedMat4: Array.make(cache_size, identityMatrix),
-    };
-
-    let setMat4IfNew = (cache: t, u: uniformLocation, v: Mat4.t,  f) => {
-        let uInt: int = Obj.magic(u);
-        /* print_endline ("uniform location: " ++ string_of_int(uInt)); */
-        if (uInt >= cache_size) {
-            print_endline ("Setting over cache size");
-           f(); 
-        }
-
-        let currentVal = cache.cachedMat4[uInt];
-        if (currentVal !== v) {
-            /* print_endline ("Setting cached"); */
-            cache.cachedMat4[uInt] = v;
-            f();
-        } else {
-            ();
-            /* print_endline ("not setting CACHED"); */
-        }
     };
 
     let useProgramIfNew = (cache: t, program: Glfw.program, f) => {
         switch (cache.program) {
         | None =>
-            
             cache.program = Some(program);
             f();
         | Some(v) when v !== program =>
             cache.program = Some(program);
             f();
-        | Some(_) => {
-            ();
-            /* print_endline (" NOT SWITCHING CACHED" ); */
-        }
+        | Some(_) => ();
         }
     }
-
-}
+};
 
 let _cache: ref(ShaderCache.t) = ref(ShaderCache.create());
 

--- a/src/Shaders/CompiledShader.re
+++ b/src/Shaders/CompiledShader.re
@@ -1,0 +1,67 @@
+open Reglfw;
+open Reglfw.Glfw;
+open Reglm;
+
+open Types;
+
+
+  type attributeNameToLocation = Hashtbl.t(string, attribLocation);
+  type attributeChannelToLocation = Hashtbl.t(VertexChannel.t, attribLocation);
+  type uniformNameToLocation = Hashtbl.t(string, uniformLocation);
+
+  type t = (
+    list(ShaderUniform.t),
+    list(ShaderAttribute.t),
+    list(ShaderVarying.t),
+    Glfw.program,
+    attributeNameToLocation,
+    attributeChannelToLocation,
+    uniformNameToLocation,
+  );
+
+  let attributeNameToLocation = (s: t, a: string) => {
+    let (_, _, _, _, dict, _, _) = s;
+    Hashtbl.find_opt(dict, a);
+  };
+
+  let attributeChannelToLocation = (s: t, a: VertexChannel.t) => {
+    let (_, _, _, _, _, dict, _) = s;
+    Hashtbl.find_opt(dict, a);
+  };
+
+  let uniformNameToLocation = (s: t, name: string) => {
+    let (_, _, _, _, _, _, u) = s;
+    Hashtbl.find_opt(u, name);
+  };
+
+  let _setUniformIfAvailable = (s, name, f) => {
+    let uLoc = uniformNameToLocation(s, name);
+    switch (uLoc) {
+    | Some(u) => f(u)
+    | None => ()
+    };
+  };
+
+  let setUniform1f = (s: t, name: string, v: float) =>
+    _setUniformIfAvailable(s, name, u => glUniform1f(u, v));
+
+  let setUniform2fv = (s: t, name: string, v: Vec2.t) =>
+    _setUniformIfAvailable(s, name, u => glUniform2fv(u, v));
+
+  let setUniform3fv = (s: t, name: string, v: Vec3.t) =>
+    _setUniformIfAvailable(s, name, u => glUniform3fv(u, v));
+
+  let setUniform4f =
+      (s: t, name: string, x: float, y: float, z: float, w: float) =>
+    _setUniformIfAvailable(s, name, u => glUniform4f(u, x, y, z, w));
+
+  let setUniform4fv = (s: t, name: string, v: Vec4.t) =>
+    _setUniformIfAvailable(s, name, u => glUniform4fv(u, v));
+
+  let setUniformMatrix4fv = (s: t, name: string, m: Mat4.t) =>
+    _setUniformIfAvailable(s, name, u => glUniformMatrix4fv(u, m));
+
+  let use = (s: t) => {
+    let (_, _, _, p, _, _, _) = s;
+    glUseProgram(p);
+  };

--- a/src/Shaders/CompiledShader.re
+++ b/src/Shaders/CompiledShader.re
@@ -68,8 +68,8 @@ let setUniform4f =
 
 let setUniform4fv = (u: uniformLocation, v: Vec4.t) => glUniform4fv(u, v);
 
-let setUniformMatrix4fv = (s: t, name: string, m: Mat4.t) =>
-  _setUniformIfAvailable(s, name, u => glUniformMatrix4fv(u, m));
+let setUniformMatrix4fv = (u: uniformLocation, m: Mat4.t) =>
+  glUniformMatrix4fv(u, m);
 
 /*
  * State changes in OpenGL are expensive!

--- a/src/Shaders/Revery_Shaders.re
+++ b/src/Shaders/Revery_Shaders.re
@@ -1,4 +1,6 @@
+include Types;
+
 module Shader = Shader;
-module CompiledShader = Shader.CompiledShader;
+module CompiledShader = CompiledShader;
 
 module BasicShader = BasicShader;

--- a/src/Shaders/Types.re
+++ b/src/Shaders/Types.re
@@ -99,4 +99,3 @@ module ShaderVarying = {
     ++ v.name
     ++ ";";
 };
-

--- a/src/Shaders/Types.re
+++ b/src/Shaders/Types.re
@@ -1,0 +1,102 @@
+type vertexShaderSource = string;
+type fragmentShaderSource = string;
+
+module Environment = Revery_Core.Environment;
+
+module VertexChannel = {
+  type t =
+    | Position
+    | Normal
+    | Color
+    | TextureCoordinate
+    | Custom(string);
+};
+
+module ShaderPrecision = {
+  type t =
+    | Default
+    | Low
+    | Medium
+    | High;
+
+  let toString = v =>
+    switch (Environment.webGL, v) {
+    | (false, _) => ""
+    | (true, p) =>
+      switch (p) {
+      | Default => ""
+      | Low => "lowp"
+      | Medium => "mediump"
+      | High => "highp"
+      }
+    };
+};
+
+module ShaderDataType = {
+  type t =
+    | Float
+    | Vector2
+    | Vector3
+    | Vector4
+    | Mat4
+    | Sampler2D;
+
+  let toString = v =>
+    switch (v) {
+    | Float => "float"
+    | Vector2 => "vec2"
+    | Vector3 => "vec3"
+    | Vector4 => "vec4"
+    | Mat4 => "mat4"
+    | Sampler2D => "sampler2D"
+    };
+};
+
+module ShaderAttribute = {
+  type t = {
+    channel: VertexChannel.t,
+    dataType: ShaderDataType.t,
+    name: string,
+  };
+
+  let toString = a =>
+    "attribute "
+    ++ ShaderDataType.toString(a.dataType)
+    ++ " "
+    ++ a.name
+    ++ ";";
+};
+
+module ShaderUniform = {
+  type shaderUniformUsage =
+    | VertexShader
+    | FragmentShader
+    | VertexAndFragmentShader;
+
+  type t = {
+    dataType: ShaderDataType.t,
+    usage: shaderUniformUsage,
+    name: string,
+  };
+
+  let toString = u =>
+    "uniform " ++ ShaderDataType.toString(u.dataType) ++ " " ++ u.name ++ ";";
+};
+
+module ShaderVarying = {
+  type t = {
+    dataType: ShaderDataType.t,
+    precision: ShaderPrecision.t,
+    name: string,
+  };
+
+  let toString = v =>
+    "varying "
+    ++ ShaderPrecision.toString(v.precision)
+    ++ " "
+    ++ ShaderDataType.toString(v.dataType)
+    ++ " "
+    ++ v.name
+    ++ ";";
+};
+

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -37,13 +37,11 @@ class imageNode (imagePath: string) = {
       let world = _this#getWorldTransform();
 
       Shaders.CompiledShader.setUniformMatrix4fv(
-        textureShader.compiledShader,
-        "uWorld",
+        textureShader.uniformWorld,
         world,
       );
       Shaders.CompiledShader.setUniformMatrix4fv(
-        textureShader.compiledShader,
-        "uProjection",
+        textureShader.uniformProjection,
         m,
       );
 

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -23,7 +23,7 @@ class imageNode (imagePath: string) = {
     let pass = RenderPass.getCurrent();
     switch (pass) {
     | AlphaPass(ctx) =>
-      Shaders.CompiledShader.use(textureShader);
+      Shaders.CompiledShader.use(textureShader.compiledShader);
       let m = ctx.projection;
 
       let dimensions = _this#measurements();
@@ -37,24 +37,23 @@ class imageNode (imagePath: string) = {
       let world = _this#getWorldTransform();
 
       Shaders.CompiledShader.setUniformMatrix4fv(
-        textureShader,
+        textureShader.compiledShader,
         "uWorld",
         world,
       );
       Shaders.CompiledShader.setUniformMatrix4fv(
-        textureShader,
+        textureShader.compiledShader,
         "uProjection",
         m,
       );
 
       Shaders.CompiledShader.setUniform4fv(
-        textureShader,
-        "uColor",
+        textureShader.uniformColor,
         Vec4.create(1.0, 1.0, 1.0, opacity),
       );
 
       glBindTexture(GL_TEXTURE_2D, texture);
-      Geometry.draw(quad, textureShader);
+      Geometry.draw(quad, textureShader.compiledShader);
     | _ => ()
     };
   };

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -1,7 +1,7 @@
 open Revery_Core;
 open Revery_Draw;
+open Revery_Draw.SolidShader;
 
-module Shaders = Revery_Shaders;
 module Geometry = Revery_Geometry;
 module Layout = Layout;
 module LayoutTypes = Layout.LayoutTypes;
@@ -13,7 +13,7 @@ open Style.Border;
 open Style.BoxShadow;
 
 let renderBorders =
-    (~style, ~width, ~height, ~opacity, ~solidShader, ~m, ~world) => {
+    (~style, ~width, ~height, ~opacity, ~shader: SolidShader.t, ~m, ~world) => {
   let borderStyle = (side, axis, border) =>
     Layout.Encoding.(
       if (side.width !== cssUndefined) {
@@ -26,6 +26,8 @@ let renderBorders =
         (0., Colors.black);
       }
     );
+
+  let solidShader = shader.compiledShader;
 
   let (topBorderWidth, topBorderColor) =
     borderStyle(style.borderTop, style.borderVertical, style.border);
@@ -50,8 +52,7 @@ let renderBorders =
 
   if (topBorderWidth != 0. && tbc.a > 0.001) {
     Shaders.CompiledShader.setUniform4fv(
-      solidShader,
-      "uColor",
+      shader.uniformColor,
       Color.toVec4(tbc),
     );
     let topBorderQuad =
@@ -91,8 +92,7 @@ let renderBorders =
 
   if (leftBorderWidth != 0. && lbc.a > 0.001) {
     Shaders.CompiledShader.setUniform4fv(
-      solidShader,
-      "uColor",
+      shader.uniformColor,
       Color.toVec4(lbc),
     );
     let leftBorderQuad =
@@ -132,8 +132,7 @@ let renderBorders =
 
   if (rightBorderWidth != 0. && rbc.a > 0.001) {
     Shaders.CompiledShader.setUniform4fv(
-      solidShader,
-      "uColor",
+      shader.uniformColor,
       Color.toVec4(rbc),
     );
     let rightBorderQuad =
@@ -173,8 +172,7 @@ let renderBorders =
 
   if (bottomBorderWidth != 0. && bbc.a > 0.001) {
     Shaders.CompiledShader.setUniform4fv(
-      solidShader,
-      "uColor",
+      shader.uniformColor,
       Color.toVec4(bbc),
     );
     let bottomBorderQuad =
@@ -280,7 +278,8 @@ class viewNode (()) = {
     let pass = RenderPass.getCurrent();
     switch (pass) {
     | AlphaPass(ctx) =>
-      let solidShader = Assets.solidShader().compiledShader;
+      let shader = Assets.solidShader();
+    let solidShader = shader.compiledShader;
       let dimensions = _this#measurements();
       let width = float_of_int(dimensions.width);
       let height = float_of_int(dimensions.height);
@@ -298,7 +297,7 @@ class viewNode (()) = {
           ~width,
           ~height,
           ~opacity,
-          ~solidShader,
+          ~shader,
           ~m,
           ~world,
         );
@@ -328,8 +327,7 @@ class viewNode (()) = {
         );
 
         Shaders.CompiledShader.setUniform4fv(
-          solidShader,
-          "uColor",
+          shader.uniformColor,
           Color.toVec4(color),
         );
 

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -300,7 +300,7 @@ class viewNode (()) = {
           ~width,
           ~height,
           ~opacity,
-          ~solidShader=solidShader,
+          ~solidShader,
           ~m,
           ~world,
         );

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -47,8 +47,8 @@ let renderBorders =
   let bbc = Color.multiplyAlpha(opacity, bottomBorderColor);
 
   Shaders.CompiledShader.use(solidShader);
-  Shaders.CompiledShader.setUniformMatrix4fv(solidShader, "uProjection", m);
-  Shaders.CompiledShader.setUniformMatrix4fv(solidShader, "uWorld", world);
+  Shaders.CompiledShader.setUniformMatrix4fv(shader.uniformProjection, m);
+  Shaders.CompiledShader.setUniformMatrix4fv(shader.uniformWorld,world);
 
   if (topBorderWidth != 0. && tbc.a > 0.001) {
     Shaders.CompiledShader.setUniform4fv(
@@ -246,8 +246,7 @@ let renderShadow = (~boxShadow, ~width, ~height, ~world, ~m) => {
   Shaders.CompiledShader.use(gradientShader.compiledShader);
 
   Shaders.CompiledShader.setUniformMatrix4fv(
-    gradientShader.compiledShader,
-    "uProjection",
+    gradientShader.uniformProjection,
     m,
   );
 
@@ -268,8 +267,7 @@ let renderShadow = (~boxShadow, ~width, ~height, ~world, ~m) => {
   );
 
   Shaders.CompiledShader.setUniformMatrix4fv(
-    gradientShader.compiledShader,
-    "uWorld",
+    gradientShader.uniformWorld,
     shadowWorldTransform,
   );
 
@@ -314,13 +312,11 @@ class viewNode (()) = {
       if (color.a > 0.001) {
         Shaders.CompiledShader.use(solidShader);
         Shaders.CompiledShader.setUniformMatrix4fv(
-          solidShader,
-          "uProjection",
+          shader.uniformProjection,
           m,
         );
         Shaders.CompiledShader.setUniformMatrix4fv(
-          solidShader,
-          "uWorld",
+          shader.uniformWorld,
           world,
         );
 

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -251,7 +251,10 @@ let renderShadow = (~boxShadow, ~width, ~height, ~world, ~m) => {
     m,
   );
 
-  Shaders.CompiledShader.setUniform3fv(gradientShader.uniformShadowColor, Color.toVec3(color));
+  Shaders.CompiledShader.setUniform3fv(
+    gradientShader.uniformShadowColor,
+    Color.toVec3(color),
+  );
 
   /* Shaders.CompiledShader.setUniform3fv( */
   /*   gradientShader, */
@@ -259,7 +262,10 @@ let renderShadow = (~boxShadow, ~width, ~height, ~world, ~m) => {
   /*   Color.toVec3(color), */
   /* ); */
 
-  Shaders.CompiledShader.setUniform2fv(gradientShader.uniformShadowAmount, Vec2.create(blurRadius /. width, blurRadius /. height));
+  Shaders.CompiledShader.setUniform2fv(
+    gradientShader.uniformShadowAmount,
+    Vec2.create(blurRadius /. width, blurRadius /. height),
+  );
 
   Shaders.CompiledShader.setUniformMatrix4fv(
     gradientShader.compiledShader,
@@ -279,7 +285,7 @@ class viewNode (()) = {
     switch (pass) {
     | AlphaPass(ctx) =>
       let shader = Assets.solidShader();
-    let solidShader = shader.compiledShader;
+      let solidShader = shader.compiledShader;
       let dimensions = _this#measurements();
       let width = float_of_int(dimensions.width);
       let height = float_of_int(dimensions.height);
@@ -292,15 +298,7 @@ class viewNode (()) = {
       let m = ctx.projection;
 
       let (minX, minY, maxX, maxY) =
-        renderBorders(
-          ~style,
-          ~width,
-          ~height,
-          ~opacity,
-          ~shader,
-          ~m,
-          ~world,
-        );
+        renderBorders(~style, ~width, ~height, ~opacity, ~shader, ~m, ~world);
 
       let mainQuad = Assets.quad(~minX, ~maxX, ~minY, ~maxY, ());
 

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -245,33 +245,31 @@ let renderShadow = (~boxShadow, ~width, ~height, ~world, ~m) => {
 
   let gradientShader = Assets.gradientShader();
 
-  Shaders.CompiledShader.use(gradientShader);
+  Shaders.CompiledShader.use(gradientShader.compiledShader);
 
   Shaders.CompiledShader.setUniformMatrix4fv(
-    gradientShader,
+    gradientShader.compiledShader,
     "uProjection",
     m,
   );
 
-  Shaders.CompiledShader.setUniform3fv(
-    gradientShader,
-    "uShadowColor",
-    Color.toVec3(color),
-  );
+  Shaders.CompiledShader.setUniform3fv(gradientShader.uniformShadowColor, Color.toVec3(color));
 
-  Shaders.CompiledShader.setUniform2fv(
-    gradientShader,
-    "uShadowAmount",
-    Vec2.create(blurRadius /. width, blurRadius /. height),
-  );
+  /* Shaders.CompiledShader.setUniform3fv( */
+  /*   gradientShader, */
+  /*   "uShadowColor", */
+  /*   Color.toVec3(color), */
+  /* ); */
+
+  Shaders.CompiledShader.setUniform2fv(gradientShader.uniformShadowAmount, Vec2.create(blurRadius /. width, blurRadius /. height));
 
   Shaders.CompiledShader.setUniformMatrix4fv(
-    gradientShader,
+    gradientShader.compiledShader,
     "uWorld",
     shadowWorldTransform,
   );
 
-  Geometry.draw(quad, gradientShader);
+  Geometry.draw(quad, gradientShader.compiledShader);
   ();
 };
 

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -48,7 +48,7 @@ let renderBorders =
 
   Shaders.CompiledShader.use(solidShader);
   Shaders.CompiledShader.setUniformMatrix4fv(shader.uniformProjection, m);
-  Shaders.CompiledShader.setUniformMatrix4fv(shader.uniformWorld,world);
+  Shaders.CompiledShader.setUniformMatrix4fv(shader.uniformWorld, world);
 
   if (topBorderWidth != 0. && tbc.a > 0.001) {
     Shaders.CompiledShader.setUniform4fv(

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -282,7 +282,7 @@ class viewNode (()) = {
     let pass = RenderPass.getCurrent();
     switch (pass) {
     | AlphaPass(ctx) =>
-      let solidShader = Assets.solidShader();
+      let solidShader = Assets.solidShader().compiledShader;
       let dimensions = _this#measurements();
       let width = float_of_int(dimensions.width);
       let height = float_of_int(dimensions.height);
@@ -300,7 +300,7 @@ class viewNode (()) = {
           ~width,
           ~height,
           ~opacity,
-          ~solidShader,
+          ~solidShader=solidShader,
           ~m,
           ~world,
         );


### PR DESCRIPTION
__Issue:__ One performance bottleneck we have remaining with lots of draws is setting _uniforms_ (shader parameters). The issue is that, every time we'd set up a shader uniform, we'd need to look up the location in a hash table.

This really isn't necessary - we can look these up once when we compile the shader, and then use them during rendering. Setting shader attributes happens quite a bit, especially since we don't do a good job batching draw calls right now (a next step performance optimization).

This updates each of our built-in shaders to cache the shader uniforms, and make those available. This also updates dependent code paths to use these cached uniforms instead of the string variant (and updates the call to `CompiledShader.setUniformX` to just be a pass-through).

I also refactored the `Revery_Shader` module a bit:
- Moved `CompiledShader` to its own module
- Moved a bunch of the types to a `Types` module

This helps alleviate the need to `open Revery_Shaders.Shaders`, since now most of the items live on the top-level `Revery_Shaders` module.

