### PR TITLE
Performance: ViewNode background drawing

### DIFF
--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -283,7 +283,6 @@ class viewNode (()) = {
     switch (pass) {
     | AlphaPass(ctx) =>
       let shader = Assets.solidShader();
-      let solidShader = shader.compiledShader;
       let dimensions = _this#measurements();
       let width = float_of_int(dimensions.width);
       let height = float_of_int(dimensions.height);
@@ -298,8 +297,6 @@ class viewNode (()) = {
       let (minX, minY, maxX, maxY) =
         renderBorders(~style, ~width, ~height, ~opacity, ~shader, ~m, ~world);
 
-      let mainQuad = Assets.quad(~minX, ~maxX, ~minY, ~maxY, ());
-
       let color = Color.multiplyAlpha(opacity, style.backgroundColor);
 
       switch (style.boxShadow) {
@@ -310,22 +307,32 @@ class viewNode (()) = {
 
       /* Only render if _not_ transparent */
       if (color.a > 0.001) {
-        Shaders.CompiledShader.use(solidShader);
-        Shaders.CompiledShader.setUniformMatrix4fv(
-          shader.uniformProjection,
-          m,
-        );
-        Shaders.CompiledShader.setUniformMatrix4fv(
-          shader.uniformWorld,
-          world,
-        );
 
-        Shaders.CompiledShader.setUniform4fv(
-          shader.uniformColor,
-          Color.toVec4(color),
-        );
+        Shapes.drawRect(~transform=world, 
+                        ~x=minX,
+                        ~y=minY,
+                        ~width=(maxX -. minX),
+                        ~height=(maxY -. minY),
+                        ~color=color,
+                        ());
+        
 
-        Geometry.draw(mainQuad, solidShader);
+/*         Shaders.CompiledShader.use(solidShader); */
+/*         Shaders.CompiledShader.setUniformMatrix4fv( */
+/*           shader.uniformProjection, */
+/*           m, */
+/*         ); */
+/*         Shaders.CompiledShader.setUniformMatrix4fv( */
+/*           shader.uniformWorld, */
+/*           world, */
+/*         ); */
+
+/*         Shaders.CompiledShader.setUniform4fv( */
+/*           shader.uniformColor, */
+/*           Color.toVec4(color), */
+/*         ); */
+
+/*         Geometry.draw(mainQuad, solidShader); */
       };
     | _ => ()
     };

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -307,32 +307,15 @@ class viewNode (()) = {
 
       /* Only render if _not_ transparent */
       if (color.a > 0.001) {
-
-        Shapes.drawRect(~transform=world, 
-                        ~x=minX,
-                        ~y=minY,
-                        ~width=(maxX -. minX),
-                        ~height=(maxY -. minY),
-                        ~color=color,
-                        ());
-        
-
-/*         Shaders.CompiledShader.use(solidShader); */
-/*         Shaders.CompiledShader.setUniformMatrix4fv( */
-/*           shader.uniformProjection, */
-/*           m, */
-/*         ); */
-/*         Shaders.CompiledShader.setUniformMatrix4fv( */
-/*           shader.uniformWorld, */
-/*           world, */
-/*         ); */
-
-/*         Shaders.CompiledShader.setUniform4fv( */
-/*           shader.uniformColor, */
-/*           Color.toVec4(color), */
-/*         ); */
-
-/*         Geometry.draw(mainQuad, solidShader); */
+        Shapes.drawRect(
+          ~transform=world,
+          ~x=minX,
+          ~y=minY,
+          ~width=maxX -. minX,
+          ~height=maxY -. minY,
+          ~color,
+          (),
+        );
       };
     | _ => ()
     };


### PR DESCRIPTION
This switches our ViewNode background drawing from manually making OpenGL calls to using `Shapes.drawRect`. The previous strategy uses `Assets.quad(...)` which isn't very efficient - it uses a hashtable to look-up an existing quad, or creates one. This is especially noticeable in the JSOO builds, where the Hashtable `find_opt` call shows up in performance profiles - but it also impacts native builds, too.

`Shapes.drawRect` is faster - it just uses the unit quad and incorporates the correct transform. It also makes the background drawing code simpler.