### PR TITLE
Bugfix: Improve text rendering when parent context has transparency

### DIFF
--- a/src/Draw/FontShader.re
+++ b/src/Draw/FontShader.re
@@ -30,6 +30,7 @@ let uniform: list(ShaderUniform.t) =
       usage: FragmentShader,
     },
     {dataType: ShaderDataType.Float, name: "uGamma", usage: FragmentShader},
+    {dataType: ShaderDataType.Float, name: "uOpacity", usage: FragmentShader},
   ];
 
 let varying =
@@ -107,7 +108,7 @@ module GammaCorrected = {
         float g = pow(g0, INV_GAMMA);
         float b = pow(b0, INV_GAMMA);
 
-        gl_FragColor = vec4(r, g, b, 1.0);
+        gl_FragColor = vec4(r, g, b, uOpacity);
     |};
 
   type t = {
@@ -117,6 +118,7 @@ module GammaCorrected = {
     uniformColor: uniformLocation,
     uniformBackgroundColor: uniformLocation,
     uniformGamma: uniformLocation,
+    uniformOpacity: uniformLocation,
   };
 
   let create = () => {
@@ -140,6 +142,9 @@ module GammaCorrected = {
     let uniformGamma =
       CompiledShader.getUniformLocation(compiledShader, "uGamma");
 
+    let uniformOpacity =
+      CompiledShader.getUniformLocation(compiledShader, "uOpacity");
+
     {
       compiledShader,
       uniformWorld,
@@ -147,6 +152,7 @@ module GammaCorrected = {
       uniformColor,
       uniformBackgroundColor,
       uniformGamma,
+      uniformOpacity,
     };
   };
 };

--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -69,7 +69,10 @@ let _startShader =
     let colorMultipliedAlpha = Color.multiplyAlpha(opacity, color);
     CompiledShader.use(shader.compiledShader);
     CompiledShader.setUniformMatrix4fv(shader.uniformProjection, projection);
-    CompiledShader.setUniform4fv(shader.uniformColor, Color.toVec4(colorMultipliedAlpha));
+    CompiledShader.setUniform4fv(
+      shader.uniformColor,
+      Color.toVec4(colorMultipliedAlpha),
+    );
 
     (shader.compiledShader, shader.uniformWorld);
   };
@@ -95,7 +98,14 @@ let drawString =
     let quad = Assets.quad();
 
     let (shader, uniformWorld) =
-      _startShader(~color, ~backgroundColor, ~opacity, ~gamma, ~projection, ());
+      _startShader(
+        ~color,
+        ~backgroundColor,
+        ~opacity,
+        ~gamma,
+        ~projection,
+        (),
+      );
 
     let font = FontCache.load(fontFamily, _getScaledFontSize(fontSize));
 

--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -46,6 +46,7 @@ let _startShader =
     (
       ~color: Color.t,
       ~backgroundColor: Color.t,
+      ~opacity: float,
       ~projection: Mat4.t,
       ~gamma: float,
       (),
@@ -60,13 +61,15 @@ let _startShader =
       Color.toVec4(backgroundColor),
     );
     CompiledShader.setUniform1f(shader.uniformGamma, gamma);
+    CompiledShader.setUniform1f(shader.uniformOpacity, opacity);
 
     (shader.compiledShader, shader.uniformWorld);
   } else {
     let shader = Assets.fontDefaultShader();
+    let colorMultipliedAlpha = Color.multiplyAlpha(opacity, color);
     CompiledShader.use(shader.compiledShader);
     CompiledShader.setUniformMatrix4fv(shader.uniformProjection, projection);
-    CompiledShader.setUniform4fv(shader.uniformColor, Color.toVec4(color));
+    CompiledShader.setUniform4fv(shader.uniformColor, Color.toVec4(colorMultipliedAlpha));
 
     (shader.compiledShader, shader.uniformWorld);
   };
@@ -78,6 +81,7 @@ let drawString =
       ~color: Color.t=Colors.white,
       ~backgroundColor: Color.t=Colors.transparentBlack,
       ~transform: Mat4.t=identityMatrix,
+      ~opacity=1.0,
       ~gamma=2.2,
       ~x=0.,
       ~y=0.,
@@ -91,7 +95,7 @@ let drawString =
     let quad = Assets.quad();
 
     let (shader, uniformWorld) =
-      _startShader(~color, ~backgroundColor, ~gamma, ~projection, ());
+      _startShader(~color, ~backgroundColor, ~opacity, ~gamma, ~projection, ());
 
     let font = FontCache.load(fontFamily, _getScaledFontSize(fontSize));
 

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -7,6 +7,7 @@ module LayoutTypes = Layout.LayoutTypes;
 
 open Revery_Core;
 
+open Style;
 open ViewNode;
 
 class textNode (text: string) = {
@@ -22,12 +23,8 @@ class textNode (text: string) = {
 
     let style = _super#getStyle();
 
-    let color = Color.multiplyAlpha(parentContext.opacity, style.color);
-    let backgroundColor =
-      Color.multiplyAlpha(parentContext.opacity, style.backgroundColor);
-    let fontFamily = style.fontFamily;
-    let fontSize = style.fontSize;
-    let lineHeight = style.lineHeight;
+    let { color, backgroundColor, fontFamily, fontSize, lineHeight, _ } = style;
+    let opacity = parentContext.opacity;
 
     let lineHeightPx =
       Text.getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ());
@@ -45,6 +42,7 @@ class textNode (text: string) = {
           ~gamma,
           ~color,
           ~backgroundColor,
+          ~opacity,
           ~transform=_this#getWorldTransform(),
           ~x=0.,
           ~y=lineHeightPx *. float_of_int(lineNum),

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -23,7 +23,7 @@ class textNode (text: string) = {
 
     let style = _super#getStyle();
 
-    let { color, backgroundColor, fontFamily, fontSize, lineHeight, _ } = style;
+    let {color, backgroundColor, fontFamily, fontSize, lineHeight, _} = style;
     let opacity = parentContext.opacity;
 
     let lineHeightPx =


### PR DESCRIPTION
__Issue:__ Even if a background/foreground color is specified, if there is transparency from the parent context, the text rendering would still take the degraded non-gamma-corrected path.

__Defect:__ We'd always multiply the parentContext's opacity into the foreground/background colors, and then use that to decide if we should take the gamma-corrected route or not. 

__Fix:__ When there is parent opacity, we'll apply it after doing the alpha blending of the text in linear space. This is better than the previous experience, where we wouldn't render with gamma correction at all if there was an opacity in the hierarchy. 