### PR TITLE
Feature: Lwt engine integration

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -81,11 +81,8 @@ let startWithState: startFunc('s, 'a) =
     let _ = Glfw.glfwInit();
     let _ = initFunc(appInstance);
 
-    /* open Lwt.Infix; */
-    open Cohttp_lwt_unix;
-
     if (!Environment.webGL) {
-        Lwt_integration.startEventLoop();
+        let _ = Lwt_integration.startEventLoop();
     }
 
     let appLoop = (_t: float) => {

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -81,6 +81,13 @@ let startWithState: startFunc('s, 'a) =
     let _ = Glfw.glfwInit();
     let _ = initFunc(appInstance);
 
+    /* open Lwt.Infix; */
+    open Cohttp_lwt_unix;
+
+    if (!Environment.webGL) {
+        Lwt_integration.startEventLoop();
+    }
+
     let appLoop = (_t: float) => {
       Glfw.glfwPollEvents();
       Tick.Default.pump();

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -82,8 +82,9 @@ let startWithState: startFunc('s, 'a) =
     let _ = initFunc(appInstance);
 
     if (!Environment.webGL) {
-        let _ = Lwt_integration.startEventLoop();
-    }
+      let _ = Lwt_integration.startEventLoop();
+      ();
+    };
 
     let appLoop = (_t: float) => {
       Glfw.glfwPollEvents();

--- a/src/Core/Lwt_integration.re
+++ b/src/Core/Lwt_integration.re
@@ -21,7 +21,7 @@
 let startEventLoop = () => {
     let yielded = Lwt_sequence.create();
 
-    Tick.Default..interval(() => {
+    Tick.Default.interval((_) => {
           Performance.bench("Lwt engine pump", () => {
             Lwt.wakeup_paused(); 
             Lwt_engine.iter(false);
@@ -32,7 +32,7 @@ let startEventLoop = () => {
                 Lwt_sequence.iter_l((wakener) => Lwt.wakeup(wakener, ()), tmp);
             }
           });
-    }, Seconds(0));
-};
+    }, Seconds(0.));
+}
 
 

--- a/src/Core/Lwt_integration.re
+++ b/src/Core/Lwt_integration.re
@@ -1,0 +1,38 @@
+/*
+ * Lwt_integration.re
+ *
+ * Lwt engine loop integration
+ * 
+ * The Revery 'app-model' doesn't fit into the Lwt_main.run model of execution - which
+ * blocks the main thread until the promise is complete.
+ *
+ * However, a slightly lower-level primitive, Lwt_engine, which Lwt_main calls,
+ * lets us fit the event-queue based model into Revery.
+ *
+ * This module is responsible for facilitating that integration.
+ */
+
+
+/*
+ * We're using some Lwt internals, so need to disable this warning...
+ */
+[@ocaml.warning "-3"];
+
+let startEventLoop = () => {
+    let yielded = Lwt_sequence.create();
+
+    Tick.Default..interval(() => {
+          Performance.bench("Lwt engine pump", () => {
+            Lwt.wakeup_paused(); 
+            Lwt_engine.iter(false);
+
+            if (!Lwt_sequence.is_empty(yielded)) {
+                let tmp = Lwt_sequence.create();
+                Lwt_sequence.transfer_r(yielded, tmp);
+                Lwt_sequence.iter_l((wakener) => Lwt.wakeup(wakener, ()), tmp);
+            }
+          });
+    }, Seconds(0));
+};
+
+


### PR DESCRIPTION
This transparently hooks up the `Lwt` event loop in Revery's app loop. This means that Lwt-based libraries no longer need `Lwt_main.run` - this happens implicitly when creating a Revery app.

This should help to enable scenarios like making async HTTP requests, File I/O requests, etc without blocking the app loop. A work-in-progress example of this is https://github.com/revery-ui/revery-fetch - a `fetch`-like API that works in both the browser via JSOO and native reasonml