### PR TITLE
Bugfix: TextNode opacity from style is not correct

### DIFF
--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -52,6 +52,7 @@ let _startShader =
       (),
     ) =>
   if (backgroundColor.a > 0.99) {
+    print_endline(" - gamma shader.");
     let shader = Assets.fontGammaCorrectedShader();
     CompiledShader.use(shader.compiledShader);
     CompiledShader.setUniformMatrix4fv(shader.uniformProjection, projection);
@@ -66,6 +67,7 @@ let _startShader =
     (shader.compiledShader, shader.uniformWorld);
   } else {
     let shader = Assets.fontDefaultShader();
+    print_endline(" - default shader: " ++ string_of_float(opacity));
     let colorMultipliedAlpha = Color.multiplyAlpha(opacity, color);
     CompiledShader.use(shader.compiledShader);
     CompiledShader.setUniformMatrix4fv(shader.uniformProjection, projection);
@@ -94,6 +96,7 @@ let drawString =
 
   switch (pass) {
   | AlphaPass(ctx) =>
+    print_endline("Starting for text: " ++ text);
     let projection = ctx.projection;
     let quad = Assets.quad();
 

--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -52,7 +52,6 @@ let _startShader =
       (),
     ) =>
   if (backgroundColor.a > 0.99) {
-    print_endline(" - gamma shader.");
     let shader = Assets.fontGammaCorrectedShader();
     CompiledShader.use(shader.compiledShader);
     CompiledShader.setUniformMatrix4fv(shader.uniformProjection, projection);
@@ -67,7 +66,6 @@ let _startShader =
     (shader.compiledShader, shader.uniformWorld);
   } else {
     let shader = Assets.fontDefaultShader();
-    print_endline(" - default shader: " ++ string_of_float(opacity));
     let colorMultipliedAlpha = Color.multiplyAlpha(opacity, color);
     CompiledShader.use(shader.compiledShader);
     CompiledShader.setUniformMatrix4fv(shader.uniformProjection, projection);
@@ -96,7 +94,6 @@ let drawString =
 
   switch (pass) {
   | AlphaPass(ctx) =>
-    print_endline("Starting for text: " ++ text);
     let projection = ctx.projection;
     let quad = Assets.quad();
 

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -24,7 +24,7 @@ class textNode (text: string) = {
     let style = _super#getStyle();
 
     let {color, backgroundColor, fontFamily, fontSize, lineHeight, _} = style;
-    let opacity = parentContext.opacity;
+    let opacity = parentContext.opacity *. style.opacity;
 
     let lineHeightPx =
       Text.getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ());


### PR DESCRIPTION
Thanks @CrossR for catching and reporting this!

__Issue:__ The `revery-quick-start` text was no longer 'fading in' in latest Revery builds. The opacity is always set to `1` when drawing.

__Defect:__ When we refactored the text to use the `Draw` module and split into a default and gamma corrected shader, we did not use the correct opacity value. We only considered the parent's opacity but not the opacity set on the style.

__Fix:__ Incorporate `style.opacity` in final opacity calculation when rendering the text.