### PR TITLE
[Prototype] Intermediate Representation for Scene

### DIFF
--- a/src/Draw/IntermediateRepresentation.re
+++ b/src/Draw/IntermediateRepresentation.re
@@ -1,0 +1,63 @@
+/*
+ * IntermediateRepresentation.re
+ *
+ * Typing for API calls, such that the Nodes can issue a set of GFX commands,
+ * and then have the actual rendering happen in another thread.
+ */
+
+/*
+ * TODO: Text measurement?
+ */
+
+module DrawStringOptions {
+    type t = {
+        fontFamily: string,
+        fontSize: string,
+        gamma: float,
+        color: Color.t,
+        backgroundColor: Color.t,
+        opacity: float,
+        transform: Mat4.t,
+        x: float,
+        y: float,
+        text: string,
+    }
+}
+
+module DrawRectOptions {
+    type t = {
+        transform: Mat4.t,
+        x: float,
+        y: float,
+        width: float,
+        height: float,
+        color: float,
+    }
+}
+
+module DrawImageOptions {
+    type t = {
+       imagePath: string 
+       transform: Mat4.t,
+       x: float,
+       y: float,
+       width: float,
+       height: float,
+       opacity: float,
+    }
+}
+
+type leaves =
+| SetViewport(int, int, int, int)
+| SetDepthTestEnabled(bool)
+| Clear(float, float, float, float)
+| DrawString(DrawStringOptions.t) 
+| DrawRect(DrawRectOptions.t)
+| DrawImage(DrawImageOptions.t)
+
+type nodes =
+| Scissor(int, int, int, int);
+
+type renderTree = 
+| Leaf(leaves)
+| Node(nodes, list(renderTree));


### PR DESCRIPTION
This is some prototyping for #411 to support a threaded renderer, and ability to support running part of Revery apps in a worker thread in JS.

Instead of `Node`'s making direct calls against OpenGL in their `draw` methods - they'd return a set of instructions (an intermediate representation) - an immutable scene tree - that is serializable across native threads / JS workers.

This allows us to run take that immutable scene tree, and hand it off to a renderer thread to do the actual work of making the OpenGL calls (or in the future - Skia calls 😉 )