### PR TITLE
Performance: Remove extra render pass

### DIFF
--- a/src/Draw/RenderPass.re
+++ b/src/Draw/RenderPass.re
@@ -27,55 +27,23 @@ module DrawContext = {
   };
 };
 
-type t =
-  | SolidPass(DrawContext.t)
-  | AlphaPass(DrawContext.t);
-
-let _activePass: ref(option(t)) = ref(None);
+let _activeContext: ref(option(DrawContext.t)) = ref(None);
 
 exception NoActiveRenderPassException;
 
-let getCurrent = () => {
-  switch (_activePass^) {
+let getContext = () => {
+  switch (_activeContext^) {
   | Some(v) => v
   | None => raise(NoActiveRenderPassException)
   };
-};
-
-let getContext = () =>
-  switch (getCurrent()) {
-  | SolidPass(v) => v
-  | AlphaPass(v) => v
-  };
-
-let startSolidPass =
-    (~pixelRatio, ~scaleFactor, ~screenWidth, ~screenHeight, ~projection, ()) => {
-  _activePass :=
-    Some(
-      SolidPass(
-        DrawContext.create(
-          ~pixelRatio,
-          ~scaleFactor,
-          ~screenWidth,
-          ~screenHeight,
-          ~projection,
-          (),
-        ),
-      ),
-    );
-};
-
-let endSolidPass = () => {
-  _activePass := None;
 };
 
 let startAlphaPass =
     (~pixelRatio, ~scaleFactor, ~screenWidth, ~screenHeight, ~projection, ()) => {
   glEnable(GL_BLEND);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  _activePass :=
+  _activeContext :=
     Some(
-      AlphaPass(
         DrawContext.create(
           ~pixelRatio,
           ~scaleFactor,
@@ -84,11 +52,10 @@ let startAlphaPass =
           ~projection,
           (),
         ),
-      ),
-    );
+      );
 };
 
 let endAlphaPass = () => {
   glDisable(GL_BLEND);
-  _activePass := None;
+  _activeContext := None;
 };

--- a/src/Draw/RenderPass.re
+++ b/src/Draw/RenderPass.re
@@ -44,15 +44,15 @@ let startAlphaPass =
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   _activeContext :=
     Some(
-        DrawContext.create(
-          ~pixelRatio,
-          ~scaleFactor,
-          ~screenWidth,
-          ~screenHeight,
-          ~projection,
-          (),
-        ),
-      );
+      DrawContext.create(
+        ~pixelRatio,
+        ~scaleFactor,
+        ~screenWidth,
+        ~screenHeight,
+        ~projection,
+        (),
+      ),
+    );
 };
 
 let endAlphaPass = () => {

--- a/src/Draw/Shapes.re
+++ b/src/Draw/Shapes.re
@@ -22,10 +22,9 @@ let drawRect =
       ~color: Color.t,
       (),
     ) => {
-  let pass = RenderPass.getCurrent();
+  let ctx = RenderPass.getContext();
 
-  switch (pass) {
-  | AlphaPass(ctx) when color.a > 0.001 =>
+  if (color.a > 0.001) {
     let world = Mat4.create();
     Mat4.fromScaling(world, Vec3.create(width, height, 1.0));
 
@@ -50,6 +49,5 @@ let drawRect =
     CompiledShader.setUniform4fv(shader.uniformColor, Color.toVec4(color));
 
     Geometry.draw(quad, shader.compiledShader);
-  | _ => ()
   };
 };

--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -92,82 +92,75 @@ let drawString =
     ) => {
   let ctx = RenderPass.getContext();
 
-    let projection = ctx.projection;
-    let quad = Assets.quad();
+  let projection = ctx.projection;
+  let quad = Assets.quad();
 
-    let (shader, uniformWorld) =
-      _startShader(
-        ~color,
-        ~backgroundColor,
-        ~opacity,
-        ~gamma,
-        ~projection,
-        (),
-      );
+  let (shader, uniformWorld) =
+    _startShader(~color, ~backgroundColor, ~opacity, ~gamma, ~projection, ());
 
-    let font = FontCache.load(fontFamily, _getScaledFontSize(fontSize));
+  let font = FontCache.load(fontFamily, _getScaledFontSize(fontSize));
 
-    let metrics = FontRenderer.getNormalizedMetrics(font);
-    let multiplier = ctx.pixelRatio *. float_of_int(ctx.scaleFactor);
-    /* Position the baseline */
-    let baseline = (metrics.height -. metrics.descenderSize) /. multiplier;
-    ();
+  let metrics = FontRenderer.getNormalizedMetrics(font);
+  let multiplier = ctx.pixelRatio *. float_of_int(ctx.scaleFactor);
+  /* Position the baseline */
+  let baseline = (metrics.height -. metrics.descenderSize) /. multiplier;
+  ();
 
-    let outerTransform = Mat4.create();
-    Mat4.fromTranslation(outerTransform, Vec3.create(0.0, baseline, 0.0));
-    let render = (s: Fontkit.fk_shape, x: float, y: float) => {
-      let glyph = FontRenderer.getGlyph(font, s.glyphId);
+  let outerTransform = Mat4.create();
+  Mat4.fromTranslation(outerTransform, Vec3.create(0.0, baseline, 0.0));
+  let render = (s: Fontkit.fk_shape, x: float, y: float) => {
+    let glyph = FontRenderer.getGlyph(font, s.glyphId);
 
-      let {width, height, bearingX, bearingY, advance, _} = glyph;
+    let {width, height, bearingX, bearingY, advance, _} = glyph;
 
-      let width = float_of_int(width) /. multiplier;
-      let height = float_of_int(height) /. multiplier;
-      let bearingX = float_of_int(bearingX) /. multiplier;
-      let bearingY = float_of_int(bearingY) /. multiplier;
-      let advance = float_of_int(advance) /. multiplier;
+    let width = float_of_int(width) /. multiplier;
+    let height = float_of_int(height) /. multiplier;
+    let bearingX = float_of_int(bearingX) /. multiplier;
+    let bearingY = float_of_int(bearingY) /. multiplier;
+    let advance = float_of_int(advance) /. multiplier;
 
-      glPixelStorei(GL_PACK_ALIGNMENT, 1);
-      glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    glPixelStorei(GL_PACK_ALIGNMENT, 1);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
-      let texture = FontRenderer.getTexture(font, s.glyphId);
-      glBindTexture(GL_TEXTURE_2D, texture);
-      /* TODO: Bind texture */
+    let texture = FontRenderer.getTexture(font, s.glyphId);
+    glBindTexture(GL_TEXTURE_2D, texture);
+    /* TODO: Bind texture */
 
-      let glyphTransform = Mat4.create();
-      Mat4.fromTranslation(
-        glyphTransform,
-        Vec3.create(
-          x +. bearingX +. width /. 2.,
-          y +. height *. 0.5 -. bearingY,
-          0.0,
-        ),
-      );
-
-      let scaleTransform = Mat4.create();
-      Mat4.fromScaling(scaleTransform, Vec3.create(width, height, 1.0));
-
-      let local = Mat4.create();
-      Mat4.multiply(local, glyphTransform, scaleTransform);
-
-      let xform = Mat4.create();
-      Mat4.multiply(xform, outerTransform, local);
-      Mat4.multiply(xform, transform, xform);
-
-      CompiledShader.setUniformMatrix4fv(uniformWorld, xform);
-
-      Geometry.draw(quad, shader);
-
-      x +. advance /. 64.0;
-    };
-
-    let shapedText = FontRenderer.shape(font, text);
-    let startX = ref(x);
-
-    Array.iter(
-      s => {
-        let nextX = render(s, startX^, y);
-        startX := nextX;
-      },
-      shapedText,
+    let glyphTransform = Mat4.create();
+    Mat4.fromTranslation(
+      glyphTransform,
+      Vec3.create(
+        x +. bearingX +. width /. 2.,
+        y +. height *. 0.5 -. bearingY,
+        0.0,
+      ),
     );
+
+    let scaleTransform = Mat4.create();
+    Mat4.fromScaling(scaleTransform, Vec3.create(width, height, 1.0));
+
+    let local = Mat4.create();
+    Mat4.multiply(local, glyphTransform, scaleTransform);
+
+    let xform = Mat4.create();
+    Mat4.multiply(xform, outerTransform, local);
+    Mat4.multiply(xform, transform, xform);
+
+    CompiledShader.setUniformMatrix4fv(uniformWorld, xform);
+
+    Geometry.draw(quad, shader);
+
+    x +. advance /. 64.0;
+  };
+
+  let shapedText = FontRenderer.shape(font, text);
+  let startX = ref(x);
+
+  Array.iter(
+    s => {
+      let nextX = render(s, startX^, y);
+      startX := nextX;
+    },
+    shapedText,
+  );
 };

--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -90,10 +90,8 @@ let drawString =
       ~y=0.,
       text: string,
     ) => {
-  let pass = RenderPass.getCurrent();
+  let ctx = RenderPass.getContext();
 
-  switch (pass) {
-  | AlphaPass(ctx) =>
     let projection = ctx.projection;
     let quad = Assets.quad();
 
@@ -172,6 +170,4 @@ let drawString =
       },
       shapedText,
     );
-  | _ => ()
-  };
 };

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -21,34 +21,33 @@ class imageNode (imagePath: string) = {
     _super#draw(parentContext);
 
     let ctx = RenderPass.getContext();
-      Shaders.CompiledShader.use(textureShader.compiledShader);
-      let m = ctx.projection;
+    Shaders.CompiledShader.use(textureShader.compiledShader);
+    let m = ctx.projection;
 
-      let dimensions = _this#measurements();
-      let width = float_of_int(dimensions.width);
-      let height = float_of_int(dimensions.height);
-      let quad =
-        Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
+    let dimensions = _this#measurements();
+    let width = float_of_int(dimensions.width);
+    let height = float_of_int(dimensions.height);
+    let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
 
-      let opacity = _super#getStyle().opacity *. parentContext.opacity;
+    let opacity = _super#getStyle().opacity *. parentContext.opacity;
 
-      let world = _this#getWorldTransform();
+    let world = _this#getWorldTransform();
 
-      Shaders.CompiledShader.setUniformMatrix4fv(
-        textureShader.uniformWorld,
-        world,
-      );
-      Shaders.CompiledShader.setUniformMatrix4fv(
-        textureShader.uniformProjection,
-        m,
-      );
+    Shaders.CompiledShader.setUniformMatrix4fv(
+      textureShader.uniformWorld,
+      world,
+    );
+    Shaders.CompiledShader.setUniformMatrix4fv(
+      textureShader.uniformProjection,
+      m,
+    );
 
-      Shaders.CompiledShader.setUniform4fv(
-        textureShader.uniformColor,
-        Vec4.create(1.0, 1.0, 1.0, opacity),
-      );
+    Shaders.CompiledShader.setUniform4fv(
+      textureShader.uniformColor,
+      Vec4.create(1.0, 1.0, 1.0, opacity),
+    );
 
-      glBindTexture(GL_TEXTURE_2D, texture);
-      Geometry.draw(quad, textureShader.compiledShader);
+    glBindTexture(GL_TEXTURE_2D, texture);
+    Geometry.draw(quad, textureShader.compiledShader);
   };
 };

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -20,9 +20,7 @@ class imageNode (imagePath: string) = {
     /* Draw background first */
     _super#draw(parentContext);
 
-    let pass = RenderPass.getCurrent();
-    switch (pass) {
-    | AlphaPass(ctx) =>
+    let ctx = RenderPass.getContext();
       Shaders.CompiledShader.use(textureShader.compiledShader);
       let m = ctx.projection;
 
@@ -52,7 +50,5 @@ class imageNode (imagePath: string) = {
 
       glBindTexture(GL_TEXTURE_2D, texture);
       Geometry.draw(quad, textureShader.compiledShader);
-    | _ => ()
-    };
   };
 };

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -50,11 +50,7 @@ class node (()) = {
     let worldTransform = _this#getWorldTransform();
     let dimensions = _this#measurements();
 
-    let ctx =
-      switch (RenderPass.getCurrent()) {
-      | SolidPass(v) => v
-      | AlphaPass(v) => v
-      };
+    let ctx = RenderPass.getContext();
 
     Overflow.render(
       worldTransform,

--- a/src/UI/Render.re
+++ b/src/UI/Render.re
@@ -70,16 +70,16 @@ let render =
 
     let drawContext = NodeDrawContext.create(~zIndex=0, ~opacity=1.0, ());
 
-    RenderPass.startSolidPass(
-      ~pixelRatio,
-      ~scaleFactor,
-      ~screenHeight=adjustedHeight,
-      ~screenWidth=adjustedWidth,
-      ~projection=_projection,
-      (),
-    );
-    rootNode#draw(drawContext);
-    RenderPass.endSolidPass();
+    /* RenderPass.startSolidPass( */
+    /*   ~pixelRatio, */
+    /*   ~scaleFactor, */
+    /*   ~screenHeight=adjustedHeight, */
+    /*   ~screenWidth=adjustedWidth, */
+    /*   ~projection=_projection, */
+    /*   (), */
+    /* ); */
+    /* rootNode#draw(drawContext); */
+    /* RenderPass.endSolidPass(); */
 
     /* Render all geometry that requires an alpha */
     RenderPass.startAlphaPass(
@@ -91,6 +91,6 @@ let render =
       (),
     );
     rootNode#draw(drawContext);
-    RenderPass.endSolidPass();
+    RenderPass.endAlphaPass();
   });
 };

--- a/src/UI/Render.re
+++ b/src/UI/Render.re
@@ -70,18 +70,6 @@ let render =
 
     let drawContext = NodeDrawContext.create(~zIndex=0, ~opacity=1.0, ());
 
-    /* RenderPass.startSolidPass( */
-    /*   ~pixelRatio, */
-    /*   ~scaleFactor, */
-    /*   ~screenHeight=adjustedHeight, */
-    /*   ~screenWidth=adjustedWidth, */
-    /*   ~projection=_projection, */
-    /*   (), */
-    /* ); */
-    /* rootNode#draw(drawContext); */
-    /* RenderPass.endSolidPass(); */
-
-    /* Render all geometry that requires an alpha */
     RenderPass.startAlphaPass(
       ~pixelRatio,
       ~scaleFactor,

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -302,9 +302,7 @@ class viewNode (()) = {
   as _this;
   inherit (class node)() as _super;
   pub! draw = (parentContext: NodeDrawContext.t) => {
-    let pass = RenderPass.getCurrent();
-    switch (pass) {
-    | AlphaPass(ctx) =>
+    let ctx = RenderPass.getContext();
       let dimensions = _this#measurements();
       let width = float_of_int(dimensions.width);
       let height = float_of_int(dimensions.height);
@@ -338,8 +336,6 @@ class viewNode (()) = {
           (),
         );
       };
-    | _ => ()
-    };
 
     _super#draw(parentContext);
   };

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -303,39 +303,39 @@ class viewNode (()) = {
   inherit (class node)() as _super;
   pub! draw = (parentContext: NodeDrawContext.t) => {
     let ctx = RenderPass.getContext();
-      let dimensions = _this#measurements();
-      let width = float_of_int(dimensions.width);
-      let height = float_of_int(dimensions.height);
+    let dimensions = _this#measurements();
+    let width = float_of_int(dimensions.width);
+    let height = float_of_int(dimensions.height);
 
-      let style = _super#getStyle();
-      let opacity = style.opacity *. parentContext.opacity;
+    let style = _super#getStyle();
+    let opacity = style.opacity *. parentContext.opacity;
 
-      let world = _this#getWorldTransform();
+    let world = _this#getWorldTransform();
 
-      let m = ctx.projection;
-      let (minX, minY, maxX, maxY) =
-        renderBorders(~style, ~width, ~height, ~opacity, ~m, ~world);
+    let m = ctx.projection;
+    let (minX, minY, maxX, maxY) =
+      renderBorders(~style, ~width, ~height, ~opacity, ~m, ~world);
 
-      let color = Color.multiplyAlpha(opacity, style.backgroundColor);
+    let color = Color.multiplyAlpha(opacity, style.backgroundColor);
 
-      switch (style.boxShadow) {
-      | {xOffset: 0., yOffset: 0., blurRadius: 0., spreadRadius: 0., color: _} =>
-        ()
-      | boxShadow => renderShadow(~boxShadow, ~width, ~height, ~world, ~m)
-      };
+    switch (style.boxShadow) {
+    | {xOffset: 0., yOffset: 0., blurRadius: 0., spreadRadius: 0., color: _} =>
+      ()
+    | boxShadow => renderShadow(~boxShadow, ~width, ~height, ~world, ~m)
+    };
 
-      /* Only render if _not_ transparent */
-      if (color.a > 0.001) {
-        Shapes.drawRect(
-          ~transform=world,
-          ~x=minX,
-          ~y=minY,
-          ~width=maxX -. minX,
-          ~height=maxY -. minY,
-          ~color,
-          (),
-        );
-      };
+    /* Only render if _not_ transparent */
+    if (color.a > 0.001) {
+      Shapes.drawRect(
+        ~transform=world,
+        ~x=minX,
+        ~y=minY,
+        ~width=maxX -. minX,
+        ~height=maxY -. minY,
+        ~color,
+        (),
+      );
+    };
 
     _super#draw(parentContext);
   };


### PR DESCRIPTION
__Issue:__ We do two render-passes across nodes - one for Solid rendering and one for Alpha blending. The original intention with this was to eliminate _overdraw_ (alpha blending is expensive - so if a pixel has a solid value with a higher z-index, we can avoid that cost). However, our current rendering pipeline only does work during the Alpha phase - meaning the traversing and work we do during the Solid is essentially wasted (and even though we don't draw - we make several GL calls, still).

__Fix:__ For now, remove this unused pass. We can revisit splitting these at some point if we see overdraw as a bottleneck.