### PR TITLE
Refactoring: Remove minimal layout mode

### DIFF
--- a/bench/lib/LayoutBench.re
+++ b/bench/lib/LayoutBench.re
@@ -79,22 +79,3 @@ bench(
   ~f=layoutNode(false),
   (),
 );
-
-bench(
-  ~name="Layout: layout node tree (4 deep, 4 wide) - force, minimal layout",
-  ~options,
-  ~setup=
-    setupNodeTree(
-      ~depth=4,
-      ~breadth=4,
-      ~style=
-        Style.make(
-          ~width=400,
-          ~height=400,
-          ~layoutMode=Style.LayoutMode.Minimal,
-          (),
-        ),
-    ),
-  ~f=layoutNode(true),
-  (),
-);

--- a/src/UI/Layout.re
+++ b/src/UI/Layout.re
@@ -34,11 +34,7 @@ let createNodeWithMeasure = (children, style, measure) =>
 let layout = (~force=false, node) =>
   Performance.bench("layout", () => {
     let layoutNode = node#toLayoutNode(~force, ());
-    switch (layoutNode) {
-    | None => ()
-    | Some(v) =>
-      Layout.layoutNode(v, Encoding.cssUndefined, Encoding.cssUndefined, Ltr)
-    };
+    Layout.layoutNode(v, Encoding.cssUndefined, Encoding.cssUndefined, Ltr)
   });
 let printCssNode = root =>
   LayoutPrint.printCssNode((

--- a/src/UI/Layout.re
+++ b/src/UI/Layout.re
@@ -34,7 +34,7 @@ let createNodeWithMeasure = (children, style, measure) =>
 let layout = (~force=false, node) =>
   Performance.bench("layout", () => {
     let layoutNode = node#toLayoutNode(~force, ());
-    Layout.layoutNode(v, Encoding.cssUndefined, Encoding.cssUndefined, Ltr)
+    Layout.layoutNode(layoutNode, Encoding.cssUndefined, Encoding.cssUndefined, Ltr)
   });
 let printCssNode = root =>
   LayoutPrint.printCssNode((

--- a/src/UI/Layout.re
+++ b/src/UI/Layout.re
@@ -34,7 +34,12 @@ let createNodeWithMeasure = (children, style, measure) =>
 let layout = (~force=false, node) =>
   Performance.bench("layout", () => {
     let layoutNode = node#toLayoutNode(~force, ());
-    Layout.layoutNode(layoutNode, Encoding.cssUndefined, Encoding.cssUndefined, Ltr)
+    Layout.layoutNode(
+      layoutNode,
+      Encoding.cssUndefined,
+      Encoding.cssUndefined,
+      Ltr,
+    );
   });
 let printCssNode = root =>
   LayoutPrint.printCssNode((

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -71,21 +71,14 @@ class node (()) = {
     );
   };
   pub measurements = () => {
-    let style = _this#getStyle();
-    let ret: Dimensions.t =
-      switch (style.layoutMode) {
-      | Style.LayoutMode.Minimal => _miniLayout^
-      | Style.LayoutMode.Default =>
-        let layout = _layoutNode^.layout;
-        Dimensions.create(
-          ~left=layout.left,
-          ~top=layout.top,
-          ~width=layout.width,
-          ~height=layout.height,
-          (),
-        );
-      };
-    ret;
+    let layout = _layoutNode^.layout;
+    Dimensions.create(
+      ~left=layout.left,
+      ~top=layout.top,
+      ~width=layout.width,
+      ~height=layout.height,
+      (),
+    );
   };
   pub getInternalId = () => _internalId;
   pub getTabIndex = () => _tabIndex^;
@@ -306,7 +299,6 @@ class node (()) = {
     List.iter(n => n#_minimalLayout(style), _children^);
   };
   pub toLayoutNode = (~force, ()) => {
-    let style = _style^;
     let layoutStyle = _layoutStyle^;
 
     let f = v =>
@@ -321,12 +313,9 @@ class node (()) = {
       | None => Layout.createNode([||], layoutStyle)
       };
 
-    switch (style.layoutMode, _isLayoutDirty^ || force) {
-    | (Style.LayoutMode.Minimal, _) =>
-      _this#_minimalLayout(style);
-      None;
-    | (Style.LayoutMode.Default, false) => Some(_layoutNode^)
-    | (Style.LayoutMode.Default, true) =>
+    switch (_isLayoutDirty^ || force) {
+    | false => Some(_layoutNode^)
+    | true =>
       let childNodes =
         List.map(c => c#toLayoutNode(~force, ()), _children^)
         |> List.filter(f)

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -304,8 +304,7 @@ class node (()) = {
     switch (_isLayoutDirty^ || force) {
     | false => _layoutNode^
     | true =>
-      let childNodes =
-        List.map(c => c#toLayoutNode(~force, ()), _children^);
+      let childNodes = List.map(c => c#toLayoutNode(~force, ()), _children^);
 
       let node =
         switch (_this#getMeasureFunction()) {

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -301,25 +301,11 @@ class node (()) = {
   pub toLayoutNode = (~force, ()) => {
     let layoutStyle = _layoutStyle^;
 
-    let f = v =>
-      switch (v) {
-      | Some(_) => true
-      | None => false
-      };
-
-    let m = v =>
-      switch (v) {
-      | Some(v) => v
-      | None => Layout.createNode([||], layoutStyle)
-      };
-
     switch (_isLayoutDirty^ || force) {
-    | false => Some(_layoutNode^)
+    | false => _layoutNode^
     | true =>
       let childNodes =
-        List.map(c => c#toLayoutNode(~force, ()), _children^)
-        |> List.filter(f)
-        |> List.map(m);
+        List.map(c => c#toLayoutNode(~force, ()), _children^);
 
       let node =
         switch (_this#getMeasureFunction()) {
@@ -333,7 +319,7 @@ class node (()) = {
         };
 
       _layoutNode := node;
-      Some(node);
+      node;
     };
   };
   pri _queueCallback = (cb: callback) => {

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -26,22 +26,6 @@ module BoxShadow = {
   };
 };
 
-module LayoutMode = {
-  /**
-     * LayoutMode allows finer-grained control over how nodes are layout.
-     * The default is 'Flex' which uses a yoga-like flex-box interpretation of the styles.
-     * However, for performance, sometimes a more streamlined strategy is doable -
-     * the 'Minimal' strategy only respects the following properties:
-        - width
-        - height
-        - transform
-    * But it also incurs much reduced overhead compared to the default layout strategy.
-    */
-  type t =
-    | Default
-    | Minimal;
-};
-
 type t = {
   backgroundColor: Color.t,
   color: Color.t,
@@ -63,7 +47,6 @@ type t = {
   fontFamily,
   fontSize: int,
   lineHeight: float,
-  layoutMode: LayoutMode.t,
   textWrap: TextWrapping.wrapType,
   marginTop: int,
   marginLeft: int,
@@ -121,7 +104,6 @@ let make =
       ~right=Encoding.cssUndefined,
       ~fontFamily="",
       ~fontSize=Encoding.cssUndefined,
-      ~layoutMode=LayoutMode.Default,
       ~lineHeight=1.2,
       ~textWrap=TextWrapping.WhitespaceWrap,
       ~marginTop=Encoding.cssUndefined,
@@ -184,7 +166,6 @@ let make =
     right,
     fontFamily,
     fontSize,
-    layoutMode,
     lineHeight,
     textWrap,
     transform,
@@ -304,7 +285,6 @@ type coreStyleProps = [
   | `Right(int)
   | `Bottom(int)
   | `Left(int)
-  | `LayoutMode(LayoutMode.t)
   | `MarginTop(int)
   | `MarginLeft(int)
   | `MarginRight(int)
@@ -442,15 +422,6 @@ let position = p => {
   `Position(value);
 };
 
-let layoutMode = v => {
-  let p =
-    switch (v) {
-    | `Default => LayoutMode.Default
-    | `Minimal => LayoutMode.Minimal
-    };
-  `LayoutMode(p);
-};
-
 let margin = m => `Margin(m);
 let marginLeft = m => `MarginLeft(m);
 let marginRight = m => `MarginRight(m);
@@ -535,7 +506,6 @@ let applyStyle = (style, styleRule) =>
   | `FlexGrow(flexGrow) => {...style, flexGrow}
   | `FlexDirection(flexDirection) => {...style, flexDirection}
   | `FlexWrap(flexWrap) => {...style, flexWrap}
-  | `LayoutMode(layoutMode) => {...style, layoutMode}
   | `Position(position) => {...style, position}
   | `Margin(margin) => {...style, margin}
   | `MarginTop(marginTop) => {...style, marginTop}


### PR DESCRIPTION
An experimental 'minimal layout mode' was added to try and squeeze extra performance out for Onivim 2 (where we were running layout on every node in the minimap and text). However, we ended up delegating those pieces to use the `<OpenGL />` node - so it seems like the 'minimal' layout mode was too niche to be useful (and just adds complexity).

I'd like to explore, though, the flutter-like idea of having nodes control child layout - I think that design is really interesting. Pulling this out means a little less complexity when we go to implement / explore that piece.