### PR TITLE
ImageNode: Move GPU operations to draw method

### DIFF
--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -13,12 +13,12 @@ open ViewNode;
 
 class imageNode (imagePath: string) = {
   as _this;
-  val textureShader = Assets.textureShader();
-  val texture = ImageRenderer.getTexture(imagePath);
   inherit (class node)() as _super;
   pub! draw = (parentContext: NodeDrawContext.t) => {
     /* Draw background first */
     _super#draw(parentContext);
+    let textureShader = Assets.textureShader();
+    let texture = ImageRenderer.getTexture(imagePath);
 
     let ctx = RenderPass.getContext();
     Shaders.CompiledShader.use(textureShader.compiledShader);


### PR DESCRIPTION
For the interactive playground, part of the rendering happens in a Worker. When `ImageNode`'s are created - they try and grab a shader / OpenGL texture. We should defer that until actual rendering to allow the node hierarchy to exist in the worker.