### PR TITLE
API: Image - ResizeMode

### DIFF
--- a/src/Draw/Image.re
+++ b/src/Draw/Image.re
@@ -56,8 +56,34 @@ let drawImage =
         let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
         Geometry.draw(quad, textureShader.compiledShader);
     | Repeat =>
-        let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=float_of_int(imgInfo.width), ~maxY=float_of_int(imgInfo.height), ());
-        Geometry.draw(quad, textureShader.compiledShader);
+
+        let x = ref (0);
+        let y = ref (0);
+
+        let xDiv = int_of_float(ceil(width /. float_of_int(imgInfo.width)));
+        let yDiv = int_of_float(ceil(height /. float_of_int(imgInfo.height)));
+
+        let localTransform = Mat4.create();
+
+        while (y^ < yDiv) {
+            while (x^ < xDiv) {
+
+
+                let xPos = float_of_int(x^ * imgInfo.width);
+                let yPos = float_of_int(y^ * imgInfo.height);
+                let v = Vec3.create(xPos, yPos, 0.);
+
+                Mat4.fromTranslation(localTransform, v);
+                Mat4.multiply(localTransform, world, localTransform);
+                CompiledShader.setUniformMatrix4fv(textureShader.uniformWorld, localTransform);
+                
+                    let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=float_of_int(imgInfo.width), ~maxY=float_of_int(imgInfo.height), ());
+                    Geometry.draw(quad, textureShader.compiledShader);
+
+                incr(x);
+            }
+            incr(y)
+        }
 
     }
   };

--- a/src/Draw/Image.re
+++ b/src/Draw/Image.re
@@ -21,15 +21,16 @@ let drawImage =
       ~height: float,
       ~opacity=1.0,
       ~tint=Colors.white,
+      ~resizeMode=ImageResizeMode.Stretch,
       (),
     ) => {
+  let textureShader = Assets.textureShader();
+  let imgInfo: ImageRenderer.t = ImageRenderer.getTexture(imagePath);
 
-    let textureShader = Assets.textureShader();
-    let imgInfo: ImageRenderer.t = ImageRenderer.getTexture(imagePath);
-
-    switch (imgInfo.hasLoaded) {
-     | false => ()
-    | true => let ctx = RenderPass.getContext();
+  switch (imgInfo.hasLoaded) {
+  | false => ()
+  | true =>
+    let ctx = RenderPass.getContext();
     CompiledShader.use(textureShader.compiledShader);
     let m = ctx.projection;
 
@@ -37,14 +38,8 @@ let drawImage =
 
     let world = transform;
 
-    CompiledShader.setUniformMatrix4fv(
-      textureShader.uniformWorld,
-      world,
-    );
-    CompiledShader.setUniformMatrix4fv(
-      textureShader.uniformProjection,
-      m,
-    );
+    CompiledShader.setUniformMatrix4fv(textureShader.uniformWorld, world);
+    CompiledShader.setUniformMatrix4fv(textureShader.uniformProjection, m);
 
     CompiledShader.setUniform4fv(
       textureShader.uniformColor,
@@ -53,5 +48,5 @@ let drawImage =
 
     glBindTexture(GL_TEXTURE_2D, imgInfo.texture);
     Geometry.draw(quad, textureShader.compiledShader);
-    };
+  };
 };

--- a/src/Draw/Image.re
+++ b/src/Draw/Image.re
@@ -1,0 +1,57 @@
+/*
+ * Image.re
+ *
+ * Core logic for rendering images to the screen
+ */
+
+open Reglm;
+open Reglfw.Glfw;
+
+open Revery_Core;
+open Revery_Shaders;
+module Geometry = Revery_Geometry;
+
+let identityMatrix = Mat4.create();
+
+let drawImage =
+    (
+      ~imagePath: string,
+      ~transform: Mat4.t=identityMatrix,
+      ~width: float,
+      ~height: float,
+      ~opacity=1.0,
+      ~tint=Colors.white,
+      (),
+    ) => {
+
+    let textureShader = Assets.textureShader();
+    let imgInfo: ImageRenderer.t = ImageRenderer.getTexture(imagePath);
+
+    switch (imgInfo.hasLoaded) {
+     | false => ()
+    | true => let ctx = RenderPass.getContext();
+    CompiledShader.use(textureShader.compiledShader);
+    let m = ctx.projection;
+
+    let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
+
+    let world = transform;
+
+    CompiledShader.setUniformMatrix4fv(
+      textureShader.uniformWorld,
+      world,
+    );
+    CompiledShader.setUniformMatrix4fv(
+      textureShader.uniformProjection,
+      m,
+    );
+
+    CompiledShader.setUniform4fv(
+      textureShader.uniformColor,
+      Vec4.create(tint.r, tint.g, tint.b, opacity *. tint.a),
+    );
+
+    glBindTexture(GL_TEXTURE_2D, imgInfo.texture);
+    Geometry.draw(quad, textureShader.compiledShader);
+    };
+};

--- a/src/Draw/Image.re
+++ b/src/Draw/Image.re
@@ -51,7 +51,6 @@ let drawImage =
         let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
         Geometry.draw(quad, textureShader.compiledShader);
     | Repeat =>
-
         let x = ref (0);
         let y = ref (0);
 

--- a/src/Draw/Image.re
+++ b/src/Draw/Image.re
@@ -34,8 +34,6 @@ let drawImage =
     CompiledShader.use(textureShader.compiledShader);
     let m = ctx.projection;
 
-    let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
-
     let world = transform;
 
     CompiledShader.setUniformMatrix4fv(textureShader.uniformWorld, world);
@@ -47,6 +45,20 @@ let drawImage =
     );
 
     glBindTexture(GL_TEXTURE_2D, imgInfo.texture);
-    Geometry.draw(quad, textureShader.compiledShader);
+
+    /*
+       TODO: 
+       Implement this via geometry batching rather than additional draw calls
+    */
+
+    switch (resizeMode) {
+    | Stretch => 
+        let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
+        Geometry.draw(quad, textureShader.compiledShader);
+    | Repeat =>
+        let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=float_of_int(imgInfo.width), ~maxY=float_of_int(imgInfo.height), ());
+        Geometry.draw(quad, textureShader.compiledShader);
+
+    }
   };
 };

--- a/src/Draw/Image.re
+++ b/src/Draw/Image.re
@@ -47,42 +47,50 @@ let drawImage =
     glBindTexture(GL_TEXTURE_2D, imgInfo.texture);
 
     switch (resizeMode) {
-    | Stretch => 
-        let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
-        Geometry.draw(quad, textureShader.compiledShader);
+    | Stretch =>
+      let quad =
+        Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
+      Geometry.draw(quad, textureShader.compiledShader);
     | Repeat =>
-        let x = ref (0);
-        let y = ref (0);
+      let x = ref(0);
+      let y = ref(0);
 
-        let xDiv = int_of_float(ceil(width /. float_of_int(imgInfo.width)));
-        let yDiv = int_of_float(ceil(height /. float_of_int(imgInfo.height)));
+      let xDiv = int_of_float(ceil(width /. float_of_int(imgInfo.width)));
+      let yDiv = int_of_float(ceil(height /. float_of_int(imgInfo.height)));
 
-        let localTransform = Mat4.create();
+      let localTransform = Mat4.create();
 
-        /*
-           TODO: 
-           Implement this via geometry batching rather than additional draw calls
-        */
-        while (y^ < yDiv) {
-            while (x^ < xDiv) {
+      /*
+          TODO:
+          Implement this via geometry batching rather than additional draw calls
+       */
+      while (y^ < yDiv) {
+        while (x^ < xDiv) {
+          let xPos = float_of_int(x^ * imgInfo.width);
+          let yPos = float_of_int(y^ * imgInfo.height);
+          let v = Vec3.create(xPos, yPos, 0.);
 
+          Mat4.fromTranslation(localTransform, v);
+          Mat4.multiply(localTransform, world, localTransform);
+          CompiledShader.setUniformMatrix4fv(
+            textureShader.uniformWorld,
+            localTransform,
+          );
 
-                let xPos = float_of_int(x^ * imgInfo.width);
-                let yPos = float_of_int(y^ * imgInfo.height);
-                let v = Vec3.create(xPos, yPos, 0.);
+          let quad =
+            Assets.quad(
+              ~minX=0.,
+              ~minY=0.,
+              ~maxX=float_of_int(imgInfo.width),
+              ~maxY=float_of_int(imgInfo.height),
+              (),
+            );
+          Geometry.draw(quad, textureShader.compiledShader);
 
-                Mat4.fromTranslation(localTransform, v);
-                Mat4.multiply(localTransform, world, localTransform);
-                CompiledShader.setUniformMatrix4fv(textureShader.uniformWorld, localTransform);
-                
-                    let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=float_of_int(imgInfo.width), ~maxY=float_of_int(imgInfo.height), ());
-                    Geometry.draw(quad, textureShader.compiledShader);
-
-                incr(x);
-            }
-            incr(y)
-        }
-
-    }
+          incr(x);
+        };
+        incr(y);
+      };
+    };
   };
 };

--- a/src/Draw/Image.re
+++ b/src/Draw/Image.re
@@ -46,11 +46,6 @@ let drawImage =
 
     glBindTexture(GL_TEXTURE_2D, imgInfo.texture);
 
-    /*
-       TODO: 
-       Implement this via geometry batching rather than additional draw calls
-    */
-
     switch (resizeMode) {
     | Stretch => 
         let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
@@ -65,6 +60,10 @@ let drawImage =
 
         let localTransform = Mat4.create();
 
+        /*
+           TODO: 
+           Implement this via geometry batching rather than additional draw calls
+        */
         while (y^ < yDiv) {
             while (x^ < xDiv) {
 

--- a/src/Draw/ImageRenderer.re
+++ b/src/Draw/ImageRenderer.re
@@ -1,6 +1,7 @@
-open Reglfw;
 open Reglfw.Glfw;
 open Revery_Core;
+
+module Image = Reglfw.Image;
 
 type t = {
   mutable hasLoaded: bool,
@@ -16,64 +17,61 @@ let _cache: cache = Hashtbl.create(100);
 let initialImage = Image.fromColor(255, 0, 0, 255);
 let initialPixels = Image.getPixels(initialImage);
 
-let getTexture = (imagePath: string) => {
+let getTexture: string => t = (imagePath: string) => {
   /* TODO: Support url paths? */
   let execDir = Environment.getExecutingDirectory();
   let relativeImagePath = execDir ++ imagePath;
 
   let cacheResult = Hashtbl.find_opt(_cache, relativeImagePath);
 
-  let ret =
-    switch (cacheResult) {
-    | Some(r) => r
-    | None =>
-      /* Create an initial texture container */
-      let texture = glCreateTexture();
-      glBindTexture(GL_TEXTURE_2D, texture);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-      glTexImage2D(
-        GL_TEXTURE_2D,
-        0,
-        GL_RGBA,
-        GL_RGBA,
-        GL_UNSIGNED_BYTE,
-        initialPixels,
-      );
+switch (cacheResult) {
+| Some(r) => r
+| None =>
+  /* Create an initial texture container */
+  let texture = glCreateTexture();
+  glBindTexture(GL_TEXTURE_2D, texture);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexImage2D(
+    GL_TEXTURE_2D,
+    0,
+    GL_RGBA,
+    GL_RGBA,
+    GL_UNSIGNED_BYTE,
+    initialPixels,
+  );
 
-      let imageLoadPromise = Image.load(relativeImagePath);
+  let imageLoadPromise = Image.load(relativeImagePath);
 
-      let ret: t = {
-        hasLoaded: false,
-        texture,
-        width: 1,
-        height: 1,
-      };
+  let ret: t = {
+    hasLoaded: false,
+    texture,
+    width: 1,
+    height: 1,
+  };
 
-      let success = img => {
-        let pixels = Image.getPixels(img);
-        let {width, height, _}: Image.dimensions = Image.getDimensions(img);
-        glBindTexture(GL_TEXTURE_2D, texture);
-        glTexImage2D(
-          GL_TEXTURE_2D,
-          0,
-          GL_RGBA,
-          GL_RGBA,
-          GL_UNSIGNED_BYTE,
-          pixels,
-        );
+  let success = img => {
+    let pixels = Image.getPixels(img);
+    let {width, height, _}: Image.dimensions = Image.getDimensions(img);
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glTexImage2D(
+      GL_TEXTURE_2D,
+      0,
+      GL_RGBA,
+      GL_RGBA,
+      GL_UNSIGNED_BYTE,
+      pixels,
+    );
+    ret.hasLoaded = true;
+    ret.width = width;
+    ret.height = height;
+    Lwt.return();
+  };
 
-        ret.width = width;
-        ret.height = height;
-        Lwt.return();
-      };
-
-      let _ = Lwt.bind(imageLoadPromise, success);
-      Hashtbl.replace(_cache, relativeImagePath, ret);
-      ret;
-    };
-
+  let _ = Lwt.bind(imageLoadPromise, success);
+  Hashtbl.replace(_cache, relativeImagePath, ret);
   ret;
+};
 };

--- a/src/Draw/ImageRenderer.re
+++ b/src/Draw/ImageRenderer.re
@@ -17,61 +17,57 @@ let _cache: cache = Hashtbl.create(100);
 let initialImage = Image.fromColor(255, 0, 0, 255);
 let initialPixels = Image.getPixels(initialImage);
 
-let getTexture: string => t = (imagePath: string) => {
-  /* TODO: Support url paths? */
-  let execDir = Environment.getExecutingDirectory();
-  let relativeImagePath = execDir ++ imagePath;
+let getTexture: string => t =
+  (imagePath: string) => {
+    /* TODO: Support url paths? */
+    let execDir = Environment.getExecutingDirectory();
+    let relativeImagePath = execDir ++ imagePath;
 
-  let cacheResult = Hashtbl.find_opt(_cache, relativeImagePath);
+    let cacheResult = Hashtbl.find_opt(_cache, relativeImagePath);
 
-switch (cacheResult) {
-| Some(r) => r
-| None =>
-  /* Create an initial texture container */
-  let texture = glCreateTexture();
-  glBindTexture(GL_TEXTURE_2D, texture);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glTexImage2D(
-    GL_TEXTURE_2D,
-    0,
-    GL_RGBA,
-    GL_RGBA,
-    GL_UNSIGNED_BYTE,
-    initialPixels,
-  );
+    switch (cacheResult) {
+    | Some(r) => r
+    | None =>
+      /* Create an initial texture container */
+      let texture = glCreateTexture();
+      glBindTexture(GL_TEXTURE_2D, texture);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+      glTexImage2D(
+        GL_TEXTURE_2D,
+        0,
+        GL_RGBA,
+        GL_RGBA,
+        GL_UNSIGNED_BYTE,
+        initialPixels,
+      );
 
-  let imageLoadPromise = Image.load(relativeImagePath);
+      let imageLoadPromise = Image.load(relativeImagePath);
 
-  let ret: t = {
-    hasLoaded: false,
-    texture,
-    width: 1,
-    height: 1,
+      let ret: t = {hasLoaded: false, texture, width: 1, height: 1};
+
+      let success = img => {
+        let pixels = Image.getPixels(img);
+        let {width, height, _}: Image.dimensions = Image.getDimensions(img);
+        glBindTexture(GL_TEXTURE_2D, texture);
+        glTexImage2D(
+          GL_TEXTURE_2D,
+          0,
+          GL_RGBA,
+          GL_RGBA,
+          GL_UNSIGNED_BYTE,
+          pixels,
+        );
+        ret.hasLoaded = true;
+        ret.width = width;
+        ret.height = height;
+        Lwt.return();
+      };
+
+      let _ = Lwt.bind(imageLoadPromise, success);
+      Hashtbl.replace(_cache, relativeImagePath, ret);
+      ret;
+    };
   };
-
-  let success = img => {
-    let pixels = Image.getPixels(img);
-    let {width, height, _}: Image.dimensions = Image.getDimensions(img);
-    glBindTexture(GL_TEXTURE_2D, texture);
-    glTexImage2D(
-      GL_TEXTURE_2D,
-      0,
-      GL_RGBA,
-      GL_RGBA,
-      GL_UNSIGNED_BYTE,
-      pixels,
-    );
-    ret.hasLoaded = true;
-    ret.width = width;
-    ret.height = height;
-    Lwt.return();
-  };
-
-  let _ = Lwt.bind(imageLoadPromise, success);
-  Hashtbl.replace(_cache, relativeImagePath, ret);
-  ret;
-};
-};

--- a/src/Draw/ImageResizeMode.re
+++ b/src/Draw/ImageResizeMode.re
@@ -1,0 +1,3 @@
+type t =
+  | Stretch
+  | Repeat;

--- a/src/Draw/Revery_Draw.re
+++ b/src/Draw/Revery_Draw.re
@@ -3,6 +3,7 @@ module RenderPass = RenderPass;
 module FontCache = FontCache;
 module FontRenderer = FontRenderer;
 module Image = Image;
+module ImageResizeMode = ImageResizeMode;
 module Shapes = Shapes;
 module Text = Text;
 

--- a/src/Draw/Revery_Draw.re
+++ b/src/Draw/Revery_Draw.re
@@ -2,7 +2,7 @@ module Assets = Assets;
 module RenderPass = RenderPass;
 module FontCache = FontCache;
 module FontRenderer = FontRenderer;
-module ImageRenderer = ImageRenderer;
+module Image = Image;
 module Shapes = Shapes;
 module Text = Text;
 

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -29,4 +29,8 @@ class imageNode (imagePath: string) = {
       (),
     );
   };
+
+  pub setResizeMode = (mode: ImageResizeMode.t) => {
+    _resizeMode := mode; 
+  };
 };

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -1,15 +1,9 @@
-open Reglm;
-open Reglfw.Glfw;
-
 open Revery_Draw;
 
-module Shaders = Revery_Shaders;
-module Geometry = Revery_Geometry;
 module Layout = Layout;
 module LayoutTypes = Layout.LayoutTypes;
 
 open Node;
-open ViewNode;
 
 class imageNode (imagePath: string) = {
   as _this;
@@ -17,40 +11,18 @@ class imageNode (imagePath: string) = {
   pub! draw = (parentContext: NodeDrawContext.t) => {
     /* Draw background first */
     _super#draw(parentContext);
-    let textureShader = Assets.textureShader();
-    let {hasLoaded, texture, _ } = ImageRenderer.getTexture(imagePath);
-
-    switch (hasLoaded) {
-     | false => ()
-    | true => let ctx = RenderPass.getContext();
-    Shaders.CompiledShader.use(textureShader.compiledShader);
-    let m = ctx.projection;
 
     let dimensions = _this#measurements();
-    let width = float_of_int(dimensions.width);
-    let height = float_of_int(dimensions.height);
-    let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
-
-    let opacity = _super#getStyle().opacity *. parentContext.opacity;
-
     let world = _this#getWorldTransform();
+    let style = _this#getStyle();
 
-    Shaders.CompiledShader.setUniformMatrix4fv(
-      textureShader.uniformWorld,
-      world,
+    Image.drawImage(
+        ~imagePath,
+        ~transform=world,
+        ~width=float_of_int(dimensions.width),
+        ~height=float_of_int(dimensions.height),
+        ~opacity=style.opacity,
+        (),
     );
-    Shaders.CompiledShader.setUniformMatrix4fv(
-      textureShader.uniformProjection,
-      m,
-    );
-
-    Shaders.CompiledShader.setUniform4fv(
-      textureShader.uniformColor,
-      Vec4.create(1.0, 1.0, 1.0, opacity),
-    );
-
-    glBindTexture(GL_TEXTURE_2D, texture);
-    Geometry.draw(quad, textureShader.compiledShader);
-    };
   };
 };

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -18,9 +18,11 @@ class imageNode (imagePath: string) = {
     /* Draw background first */
     _super#draw(parentContext);
     let textureShader = Assets.textureShader();
-    let texture = ImageRenderer.getTexture(imagePath);
+    let {hasLoaded, texture, _ } = ImageRenderer.getTexture(imagePath);
 
-    let ctx = RenderPass.getContext();
+    switch (hasLoaded) {
+     | false => ()
+    | true => let ctx = RenderPass.getContext();
     Shaders.CompiledShader.use(textureShader.compiledShader);
     let m = ctx.projection;
 
@@ -49,5 +51,6 @@ class imageNode (imagePath: string) = {
 
     glBindTexture(GL_TEXTURE_2D, texture);
     Geometry.draw(quad, textureShader.compiledShader);
+    };
   };
 };

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -1,3 +1,4 @@
+open Revery_Core;
 open Revery_Draw;
 
 module Layout = Layout;
@@ -8,6 +9,7 @@ open Node;
 class imageNode (imagePath: string) = {
   as _this;
   inherit (class node)() as _super;
+  val _resizeMode: ref(ImageResizeMode.t) = ref(ImageResizeMode.Stretch);
   pub! draw = (parentContext: NodeDrawContext.t) => {
     /* Draw background first */
     _super#draw(parentContext);
@@ -17,12 +19,14 @@ class imageNode (imagePath: string) = {
     let style = _this#getStyle();
 
     Image.drawImage(
-        ~imagePath,
-        ~transform=world,
-        ~width=float_of_int(dimensions.width),
-        ~height=float_of_int(dimensions.height),
-        ~opacity=style.opacity,
-        (),
+      ~imagePath,
+      ~transform=world,
+      ~width=float_of_int(dimensions.width),
+      ~height=float_of_int(dimensions.height),
+      ~resizeMode=_resizeMode^,
+      ~tint=Colors.white,
+      ~opacity=style.opacity,
+      (),
     );
   };
 };

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -29,8 +29,7 @@ class imageNode (imagePath: string) = {
       (),
     );
   };
-
   pub setResizeMode = (mode: ImageResizeMode.t) => {
-    _resizeMode := mode; 
+    _resizeMode := mode;
   };
 };

--- a/src/UI/Primitives.re
+++ b/src/UI/Primitives.re
@@ -227,6 +227,12 @@ module Text = {
     );
 };
 
+module ImageResizeMode = {
+  type t =
+    | Stretch
+    | Repeat;
+};
+
 module Image = {
   let component = React.nativeComponent("Image");
 
@@ -238,6 +244,7 @@ module Image = {
         ~onMouseUp=?,
         ~onMouseWheel=?,
         ~ref=?,
+        ~resizeMode,
         ~style=Style.emptyImageStyle,
         ~src="",
         children,
@@ -260,6 +267,7 @@ module Image = {
             let node = (new ImageNode.imageNode)(src);
             node#setEvents(events);
             node#setStyle(styles);
+            node#setResizeMode(resizeMode);
             Obj.magic(node);
           },
           configureInstance: (~isFirstRender as _, node) => {
@@ -273,6 +281,7 @@ module Image = {
                 ~onMouseWheel?,
                 (),
               );
+            node#setResizeMode(resizeMode);
             node#setEvents(events);
             node#setStyle(styles);
             node;
@@ -289,6 +298,7 @@ module Image = {
         ~onMouseUp=?,
         ~onMouseWheel=?,
         ~ref=?,
+        ~resizeMode=Draw.ImageResizeMode.Stretch,
         ~style=Style.emptyImageStyle,
         ~src="",
         ~children,
@@ -300,6 +310,7 @@ module Image = {
       ~onMouseUp?,
       ~onMouseWheel?,
       ~ref?,
+      ~resizeMode?,
       ~style,
       ~src,
       React.listToElement(children),

--- a/src/UI/Primitives.re
+++ b/src/UI/Primitives.re
@@ -227,12 +227,6 @@ module Text = {
     );
 };
 
-module ImageResizeMode = {
-  type t =
-    | Stretch
-    | Repeat;
-};
-
 module Image = {
   let component = React.nativeComponent("Image");
 
@@ -244,7 +238,7 @@ module Image = {
         ~onMouseUp=?,
         ~onMouseWheel=?,
         ~ref=?,
-        ~resizeMode,
+        ~resizeMode=Revery_Draw.ImageResizeMode.Stretch,
         ~style=Style.emptyImageStyle,
         ~src="",
         children,
@@ -281,7 +275,8 @@ module Image = {
                 ~onMouseWheel?,
                 (),
               );
-            node#setResizeMode(resizeMode);
+            let imgNode: ImageNode.imageNode = Obj.magic(node);
+            imgNode#setResizeMode(resizeMode);
             node#setEvents(events);
             node#setStyle(styles);
             node;
@@ -298,7 +293,7 @@ module Image = {
         ~onMouseUp=?,
         ~onMouseWheel=?,
         ~ref=?,
-        ~resizeMode=Draw.ImageResizeMode.Stretch,
+        ~resizeMode=?,
         ~style=Style.emptyImageStyle,
         ~src="",
         ~children,


### PR DESCRIPTION
This adds a `resizeMode` parameter to the `<Image />` primitive, with the following values:
- `Stretch` (default)
- `Repeat` (tile the image to take up the bounds of the component)

The current implementation is very naive and has a few shortcomings:
- Incurs extra draw calls for tiling (it should be only a single draw call)
- Can overlap the bounds of the component (should be trimmed to fit)