### PR TITLE
Bugfix: Performance - Memory climb on startup

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -282,4 +282,5 @@ let init = app => {
   UI.start(win, render);
 };
 
-App.startWithState(state, reducer, init);
+let onIdle = () => print_endline ("Example: idle callback triggered");
+App.startWithState(~onIdle, state, reducer, init);

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -282,5 +282,5 @@ let init = app => {
   UI.start(win, render);
 };
 
-let onIdle = () => print_endline ("Example: idle callback triggered");
+let onIdle = () => print_endline("Example: idle callback triggered");
 App.startWithState(~onIdle, state, reducer, init);

--- a/src/Core/GarbageCollector.re
+++ b/src/Core/GarbageCollector.re
@@ -6,32 +6,6 @@
  * Revery app model.
  */
 
-/* Increase minor heap size: 256kb -> 8MB */
-/*
- * Some more info on why this is helpful:
- * https://md.ekstrandom.net/blog/2010/06/ocaml-memory-tuning
- */
-let minorHeapSize = 8 * 1024 * 1024;
-
-/*
- * Amortize major collections across frames
- */
-let defaultSliceSize = minorHeapSize / 60;
-
-let tune = () =>
-  /* Gc tuning is only applicable in the native space */
-  if (Environment.isNative) {
-    let settings = Gc.get();
-
-    Gc.set({...settings, minor_heap_size: minorHeapSize});
-  };
-
-let minor = () =>
-  if (Environment.isNative) {
-    let _ = Gc.major_slice(defaultSliceSize);
-    ();
-  };
-
 let full = () =>
   if (Environment.isNative) {
     Gc.full_major();


### PR DESCRIPTION
Thanks @jaredly for reporting this!

__Issue:__ Even for a very bare-bones Revery app, memory usage would climb to ~90-100 MB slowly. This isn't much better than Electron!

__Defect:__ We added in some opinionated garbage collector tuning that seemed to be the culprit - inspired by:  https://md.ekstrandom.net/blog/2010/06/ocaml-memory-tuning However, this had the side effect of letting the minor / major heap grow to that higher size (which isn't desirable in general).

__Fix:__ We'll leave this sort of GC tuning up to the application, instead of baking it into Revery. 

After this fix, the `Examples` app sticks to around ~35MB on Windows, and the example repro app is even less. It seems like we should still be able to do better, but this is progress.

We'll need to investigate a nice way to have automation to verify we don't regress this sort of behavior (ie, an integration test that runs the app and verifies the memory usage doesn't cross a certain threshold)