### PR TITLE
JSOO: Remove Thread.yield

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -103,9 +103,8 @@ let startWithState =
       Environment.sleep(Milliseconds(1.));
     };
 
-    if (Environment.isNative) {
-      Thread.yield();
-    };
+    Environment.yield();
+
     List.length(getWindows(appInstance)) == 0;
   };
 

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -13,6 +13,8 @@ let sleep = (t: Time.t) =>
     Unix.sleepf(Time.to_float_seconds(t));
   };
 
+external yield: unit => unit = "caml_thread_yield";
+
 let getExecutingDirectory = () =>
   isNative ? Filename.dirname(Sys.argv[0]) ++ Filename.dir_sep : "";
 

--- a/src/Core/file.js
+++ b/src/Core/file.js
@@ -4,6 +4,9 @@ function caml_thread_create() { }
 // Provides: caml_thread_initialize
 function caml_thread_initialize() { }
 
+// Provides: caml_thread_yield
+function caml_thread_yield() { }
+
 // Provides: caml_mutex_new
 function caml_mutex_new() { }
 


### PR DESCRIPTION
The `Thread.yield` call isn't available in JSOO. This refactors to call the `yield` stub directly, and put a no-op implementation for the JS build.