### PR TITLE
Bugfix - Regression: PR #445 caused a blank screen on startup

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -8,8 +8,8 @@ let noop = () => ();
 type t('s, 'a) = {
   mutable windows: list(Window.t),
   mutable idleCount: int,
+  mutable isFirstRender: bool,
   onIdle: idleFunc,
-  isFirstRender: ref(bool),
 };
 
 let framesToIdle = 10;
@@ -50,8 +50,8 @@ let start = (~onIdle=noop, initFunc: appInitFunc('s, 'a)) => {
   let appInstance: t('s, 'a) = {
     windows: [],
     idleCount: 0,
+    isFirstRender: true,
     onIdle,
-    isFirstRender: ref(true),
   };
 
   let _ = Glfw.glfwInit();
@@ -63,11 +63,11 @@ let start = (~onIdle=noop, initFunc: appInitFunc('s, 'a)) => {
 
     _checkAndCloseWindows(appInstance);
 
-    if (appInstance.isFirstRender^ || _anyWindowsDirty(appInstance)) {
+    if (appInstance.isFirstRender || _anyWindowsDirty(appInstance)) {
       Performance.bench("renderWindows", () => {
         List.iter(w => Window.render(w), getWindows(appInstance));
         appInstance.idleCount = 0;
-        appInstance.isFirstRender := false;
+        appInstance.isFirstRender = false;
       });
     } else {
       appInstance.idleCount = appInstance.idleCount + 1;

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -47,7 +47,12 @@ let _checkAndCloseWindows = (app: t('s, 'a)) => {
 };
 
 let start = (~onIdle=noop, initFunc: appInitFunc('s, 'a)) => {
-  let appInstance: t('s, 'a) = {windows: [], idleCount: 0, onIdle, isFirstRender: ref(true)};
+  let appInstance: t('s, 'a) = {
+    windows: [],
+    idleCount: 0,
+    onIdle,
+    isFirstRender: ref(true),
+  };
 
   let _ = Glfw.glfwInit();
   let _ = initFunc(appInstance);


### PR DESCRIPTION
__Issue:__ For apps that don't have an animation or initial event to trigger a dirty window, the screen will be blank until something triggers a dirty state.

__Defect:__ Previously, before #445 , we had a `needsRender` value on the app instance that was set to `true` on startup, and anytime an action was dispatched against our ad-hoc state management. When that was removed, if nothing triggered a dirty event, a render would never be triggered.

__Fix:__ Always render the first frame. Bring back a limited version of  `needsRender` in the form of `isFirstRender`