### PR TITLE
refactor: Move type windowCreateOptions to module

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -269,13 +269,14 @@ let init = app => {
 
   let win =
     App.createWindow(
-      ~createOptions=WindowCreateOptions.create(
-        ~width=windowWidth,
-        ~height=windowHeight,
-        ~maximized,
-        ~icon=Some("revery-icon.png"),
-        (),
-      ),
+      ~createOptions=
+        WindowCreateOptions.create(
+          ~width=windowWidth,
+          ~height=windowHeight,
+          ~maximized,
+          ~icon=Some("revery-icon.png"),
+          (),
+        ),
       app,
       "Welcome to Revery!",
     );

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -269,15 +269,15 @@ let init = app => {
 
   let win =
     App.createWindow(
+      ~createOptions=WindowCreateOptions.create(
+        ~width=windowWidth,
+        ~height=windowHeight,
+        ~maximized,
+        ~icon=Some("revery-icon.png"),
+        (),
+      ),
       app,
       "Welcome to Revery!",
-      ~createOptions={
-        ...Window.defaultCreateOptions,
-        width: windowWidth,
-        height: windowHeight,
-        maximized,
-        icon: Some("revery-icon.png"),
-      },
     );
 
   let render = () => <ExampleHost win />;

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -21,7 +21,7 @@ let getWindows = (app: t('s, 'a)) => app.windows;
 let quit = (code: int) => exit(code);
 
 let createWindow =
-    (~createOptions=Window.defaultCreateOptions, app: t('s, 'a), windowName) => {
+    (~createOptions=WindowCreateOptions.default, app: t('s, 'a), windowName) => {
   let w = Window.create(windowName, createOptions);
   /* Window.render(w) */
   app.windows = [w, ...app.windows];

--- a/src/Core/Revery_Core.re
+++ b/src/Core/Revery_Core.re
@@ -20,6 +20,8 @@ module UniqueId = UniqueId;
 module TextWrapping = TextWrapping;
 module TextOverflow = TextOverflow;
 
+module WindowCreateOptions = WindowCreateOptions;
+
 /*
  * Internally exposed modules, just for testing.
  */

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -51,30 +51,6 @@ type t = {
   onMouseWheel: Event.t(mouseWheelEvent),
 };
 
-type windowCreateOptions = {
-  resizable: bool,
-  visible: bool,
-  maximized: bool,
-  decorated: bool,
-  width: int,
-  height: int,
-  backgroundColor: Color.t,
-  vsync: bool,
-  icon: option(string),
-};
-
-let defaultCreateOptions = {
-  resizable: true,
-  visible: true,
-  maximized: false,
-  decorated: true,
-  width: 800,
-  height: 600,
-  backgroundColor: Colors.cornflowerBlue,
-  vsync: true,
-  icon: None,
-};
-
 let isDirty = (w: t) =>
   if (w.shouldRender() || w.areMetricsDirty) {
     true;
@@ -171,7 +147,7 @@ let render = (w: t) => {
   w.isRendering = false;
 };
 
-let create = (name: string, options: windowCreateOptions) => {
+let create = (name: string, options: WindowCreateOptions.t) => {
   Glfw.glfwDefaultWindowHints();
   Glfw.glfwWindowHint(GLFW_RESIZABLE, options.resizable);
   Glfw.glfwWindowHint(GLFW_VISIBLE, options.visible);

--- a/src/Core/WindowCreateOptions.re
+++ b/src/Core/WindowCreateOptions.re
@@ -1,0 +1,45 @@
+module Color = Color_wrapper;
+
+/** [t] is the type representing creation options for a window */
+type t = {
+  resizable: bool,
+  /** 
+    If [visible] is true, the window will be visible immediately upon creation.
+
+    If [visible] is false, the window will be invisible, and will require a call
+    to Window.show to make it visible. Can be useful to hide transient UI states.
+  */
+  visible: bool,
+  maximized: bool,
+  decorated: bool,
+  width: int,
+  height: int,
+  backgroundColor: Color.t,
+  vsync: bool,
+  icon: option(string),
+};
+
+let create = (
+    ~resizable=true,
+    ~visible=true,
+    ~maximized=false,
+    ~decorated=true,
+    ~width=800,
+    ~height=600,
+    ~backgroundColor=Colors.cornflowerBlue,
+    ~vsync=true,
+    ~icon=None,
+    ()
+) => {
+    resizable,
+    visible,
+    maximized,
+    decorated,
+    width,
+    height,
+    backgroundColor,
+    vsync,
+    icon,
+};
+
+let default = create();

--- a/src/Core/WindowCreateOptions.re
+++ b/src/Core/WindowCreateOptions.re
@@ -3,7 +3,7 @@ module Color = Color_wrapper;
 /** [t] is the type representing creation options for a window */
 type t = {
   resizable: bool,
-  /** 
+  /**
     If [visible] is true, the window will be visible immediately upon creation.
 
     If [visible] is false, the window will be invisible, and will require a call
@@ -19,27 +19,28 @@ type t = {
   icon: option(string),
 };
 
-let create = (
-    ~resizable=true,
-    ~visible=true,
-    ~maximized=false,
-    ~decorated=true,
-    ~width=800,
-    ~height=600,
-    ~backgroundColor=Colors.cornflowerBlue,
-    ~vsync=true,
-    ~icon=None,
-    ()
-) => {
-    resizable,
-    visible,
-    maximized,
-    decorated,
-    width,
-    height,
-    backgroundColor,
-    vsync,
-    icon,
+let create =
+    (
+      ~resizable=true,
+      ~visible=true,
+      ~maximized=false,
+      ~decorated=true,
+      ~width=800,
+      ~height=600,
+      ~backgroundColor=Colors.cornflowerBlue,
+      ~vsync=true,
+      ~icon=None,
+      (),
+    ) => {
+  resizable,
+  visible,
+  maximized,
+  decorated,
+  width,
+  height,
+  backgroundColor,
+  vsync,
+  icon,
 };
 
 let default = create();


### PR DESCRIPTION
__Breaking API Change:__ - this moves the `windowCreateOptions` type to a module, so it's easier to document and more streamlined in picking.

__Before:__
```
  ~createOptions={	
        ...Window.defaultCreateOptions,	
        width: windowWidth,	
        height: windowHeight,	
        maximized,	
        icon: Some("revery-icon.png"),	
      },
```
The problem with this is that `Window.defaultCreateOptions` was not very discoverable...

__After:__
```
      ~createOptions=
        WindowCreateOptions.create(
          ~width=windowWidth,
          ~height=windowHeight,
          ~maximized,
          ~icon=Some("revery-icon.png"),
          (),
        ),
```
(The `WindowCreateOptions.create` is a bit awkward - perhaps there is a better name for either the module or function?)