### PR TITLE
Font improvements

### DIFF
--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -150,12 +150,12 @@ let drawString =
 
     Geometry.draw(quad, shader);
 
-    x +. advance /. 64.0;
+    // This is wrong, see #457, but good enough for now.
+    ceil(x +. advance /. 64.0);
   };
 
   let shapedText = FontRenderer.shape(font, text);
   let startX = ref(x);
-  let lastCluster = ref(-1);
 
   Array.iter(
     s => {

--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -158,15 +158,10 @@ let drawString =
   let lastCluster = ref(-1);
 
   Array.iter(
-    s =>
-      // When multiple characters are part of the same cluster, they have the
-      // same cluster value. We only render the first appearance of a cluster
-      // value, which will be the whole glyph.
-      if (lastCluster^ != s.cluster || Environment.webGL) {
-        let nextX = render(s, startX^, y);
-        lastCluster := s.cluster;
-        startX := nextX;
-      },
+    s => {
+      let nextX = render(s, startX^, y);
+      startX := nextX;
+    },
     shapedText,
   );
 };


### PR DESCRIPTION
Cluster rendering now appears to be working properly. 8870f65 makes kerning a tiny bit off with certain font sizes on high DPI screens, but since Revery will be moving to Skia I'm thinking it's probably not worth spending more time working out details of font rendering.