### PR TITLE
Enable DropDown and RadioButtons components to have generic value.

### DIFF
--- a/examples/DropdownExample.re
+++ b/examples/DropdownExample.re
@@ -18,12 +18,12 @@ let textStyle =
 module DropdownExample = {
   let component = React.component("DropDownExample");
 
-  let items: Dropdown.items = [
-    {value: "1", label: "First option"},
-    {value: "2", label: "Second option"},
-    {value: "3", label: "Third option"},
-    {value: "4", label: "Fourth option"},
-    {value: "5", label: "A really, really, really long option"},
+  let items: Dropdown.items(int) = [
+    {value: 1, label: "First option"},
+    {value: 2, label: "Second option"},
+    {value: 3, label: "Third option"},
+    {value: 4, label: "Fourth option"},
+    {value: 5, label: "A really, really, really long option"},
   ];
 
   let createElement = (~children as _, ()) =>

--- a/examples/RadioButtonExample.re
+++ b/examples/RadioButtonExample.re
@@ -27,14 +27,14 @@ module RadioExample = {
             ]
           />
           <RadioButtons
-            onChange={txt => setRadioVal("Radio Button Value: " ++ txt)}
+            onChange={txt => setRadioVal("Radio Button Value: " ++ string_of_int(txt))}
             defaultSelected=0
             buttons=[
-              {text: "Button 1", value: "1"},
-              {text: "Button 2", value: "2"},
-              {text: "Button 3", value: "3"},
-              {text: "Button 4", value: "4"},
-            ]
+              {text: "Button 1", value: 1},
+              {text: "Button 2", value: 2},
+              {text: "Button 3", value: 3},
+              {text: "Button 4", value: 4},
+            ]// it is of type list(RadioButtons.button(int))
           />
           <Text
             text=radioVal

--- a/examples/RadioButtonExample.re
+++ b/examples/RadioButtonExample.re
@@ -27,14 +27,16 @@ module RadioExample = {
             ]
           />
           <RadioButtons
-            onChange={txt => setRadioVal("Radio Button Value: " ++ string_of_int(txt))}
+            onChange={txt =>
+              setRadioVal("Radio Button Value: " ++ string_of_int(txt))
+            }
             defaultSelected=0
             buttons=[
               {text: "Button 1", value: 1},
               {text: "Button 2", value: 2},
               {text: "Button 3", value: 3},
               {text: "Button 4", value: 4},
-            ]// it is of type list(RadioButtons.button(int))
+            ] // it is of type list(RadioButtons.button(int))
           />
           <Text
             text=radioVal

--- a/src/UI_Components/Dropdown.re
+++ b/src/UI_Components/Dropdown.re
@@ -33,23 +33,8 @@ let textStyles =
 
 let noop = _item => ();
 
-//let component = React.component("Dropdown");
-/*
-File "src/UI_Components/Dropdown.re", line 36, characters 4-13:
-Error: The type of this expression,
-       ?key:Revery_UI.React.Key.t ->
-       (('_weak1 state Revery_UI.React.Hooks.Reducer.t -> unit, unit,
-         '_weak1 state Revery_UI.React.Hooks.Reducer.t -> unit,
-         '_weak1 state Revery_UI.React.Hooks.Reducer.t -> unit)
-        Brisk_reconciler__.Hooks.t ->
-        (unit, unit, '_weak1 state Revery_UI.React.Hooks.Reducer.t -> unit,
-         unit)
-        Brisk_reconciler__.Hooks.t * Revery_UI.React.syntheticElement) ->
-       Revery_UI.React.syntheticElement,
-       contains type variables that cannot be generalized
-TODO: modify Brisk ? to allow polymorphic state
-MAYBE use +'a somewhere in Brisk
-*/
+let component(a) = React.component("Dropdown", a);
+
 let createElement =
     (
       ~items,
@@ -59,7 +44,7 @@ let createElement =
       ~children as _,
       (),
     ) =>
-  React.component("Dropdown")(slots => {
+  component(slots => {
     let initialState = {items, selected: List.nth(items, 0), _open: false};
 
     let (state, dispatch, slots) =

--- a/src/UI_Components/Dropdown.re
+++ b/src/UI_Components/Dropdown.re
@@ -9,7 +9,7 @@ type item('a) = {
 type items('a) = list(item('a));
 
 type state('a) = {
-  items : items('a),
+  items: items('a),
   selected: item('a),
   _open: bool,
 };
@@ -33,7 +33,7 @@ let textStyles =
 
 let noop = _item => ();
 
-let component(a) = React.component("Dropdown", a);
+let component = a => React.component("Dropdown", a);
 
 let createElement =
     (

--- a/src/UI_Components/Dropdown.re
+++ b/src/UI_Components/Dropdown.re
@@ -1,22 +1,22 @@
 open Revery_UI;
 open Revery_Core;
 
-type item = {
-  value: string,
+type item('a) = {
+  value: 'a,
   label: string,
 };
 
-type items = list(item);
+type items('a) = list(item('a));
 
-type state = {
-  items,
-  selected: item,
+type state('a) = {
+  items : items('a),
+  selected: item('a),
   _open: bool,
 };
 
-type action =
+type action('a) =
   | ShowDropdown
-  | SelectItem(item);
+  | SelectItem(item('a));
 
 let reducer = (action, state) =>
   switch (action) {
@@ -33,7 +33,23 @@ let textStyles =
 
 let noop = _item => ();
 
-let component = React.component("Dropdown");
+//let component = React.component("Dropdown");
+/*
+File "src/UI_Components/Dropdown.re", line 36, characters 4-13:
+Error: The type of this expression,
+       ?key:Revery_UI.React.Key.t ->
+       (('_weak1 state Revery_UI.React.Hooks.Reducer.t -> unit, unit,
+         '_weak1 state Revery_UI.React.Hooks.Reducer.t -> unit,
+         '_weak1 state Revery_UI.React.Hooks.Reducer.t -> unit)
+        Brisk_reconciler__.Hooks.t ->
+        (unit, unit, '_weak1 state Revery_UI.React.Hooks.Reducer.t -> unit,
+         unit)
+        Brisk_reconciler__.Hooks.t * Revery_UI.React.syntheticElement) ->
+       Revery_UI.React.syntheticElement,
+       contains type variables that cannot be generalized
+TODO: modify Brisk ? to allow polymorphic state
+MAYBE use +'a somewhere in Brisk
+*/
 let createElement =
     (
       ~items,
@@ -43,7 +59,7 @@ let createElement =
       ~children as _,
       (),
     ) =>
-  component(slots => {
+  React.component("Dropdown")(slots => {
     let initialState = {items, selected: List.nth(items, 0), _open: false};
 
     let (state, dispatch, slots) =

--- a/src/UI_Components/RadioButtons.re
+++ b/src/UI_Components/RadioButtons.re
@@ -1,9 +1,9 @@
 open Revery_UI;
 open Revery_Core;
 
-type button = {
+type button('a) = {
   text: string,
-  value: string,
+  value: 'a,
 };
 let defaultStyle =
   Style.[
@@ -14,17 +14,18 @@ let defaultStyle =
     fontFamily("Roboto-Regular.ttf"),
   ];
 
-let component = React.component("RadioButtons");
+//let component = React.component("RadioButtons");
+// same thing as DropDown
 let make =
     (
       ~defaultSelected,
-      ~buttons: list(button),
+      ~buttons: list(button('a)),
       ~iconSize,
       ~style,
       ~onChange,
       _children,
     ) =>
-  component(slots => {
+  React.component("RadioButtons")(slots => {
     let defaultVal = List.nth(buttons, defaultSelected).value;
     let (checkedVal, setCheckedVal, slots) =
       React.Hooks.state(defaultVal, slots);

--- a/src/UI_Components/RadioButtons.re
+++ b/src/UI_Components/RadioButtons.re
@@ -14,7 +14,7 @@ let defaultStyle =
     fontFamily("Roboto-Regular.ttf"),
   ];
 
-let component(a) = React.component("RadioButtons", a);
+let component = a => React.component("RadioButtons", a);
 
 let make =
     (

--- a/src/UI_Components/RadioButtons.re
+++ b/src/UI_Components/RadioButtons.re
@@ -14,8 +14,8 @@ let defaultStyle =
     fontFamily("Roboto-Regular.ttf"),
   ];
 
-//let component = React.component("RadioButtons");
-// same thing as DropDown
+let component(a) = React.component("RadioButtons", a);
+
 let make =
     (
       ~defaultSelected,
@@ -25,7 +25,7 @@ let make =
       ~onChange,
       _children,
     ) =>
-  React.component("RadioButtons")(slots => {
+  component(slots => {
     let defaultVal = List.nth(buttons, defaultSelected).value;
     let (checkedVal, setCheckedVal, slots) =
       React.Hooks.state(defaultVal, slots);


### PR DESCRIPTION
In a school project, I have a function that translate string to Variant because DropDown only accept string as value.
But value are not dispayed => we could put anything.
So I have made this small patch to allow everybody to put whatever their want in value field.