### PR TITLE
Performance - Memory: Fix memory leak in animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@opam/dune": "1.7.3",
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
-    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#daa00be"
+    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#c33239d"
   },
   "peerDependencies": {
     "ocaml": "^4.7.0"

--- a/src/Core/Performance.re
+++ b/src/Core/Performance.re
@@ -33,10 +33,11 @@ let getMemoryAllocations = (startCounters, endCounters) => {
   ret;
 };
 
-let isBenchmarking = switch (Sys.getenv_opt("REVERY_DEBUG")) {
-| Some(_) => true
-| None => false
-};
+let isBenchmarking =
+  switch (Sys.getenv_opt("REVERY_DEBUG")) {
+  | Some(_) => true
+  | None => false
+  };
 
 let bench: (string, performanceFunction('a)) => 'a =
   (name, f) =>

--- a/src/Core/Performance.re
+++ b/src/Core/Performance.re
@@ -33,11 +33,16 @@ let getMemoryAllocations = (startCounters, endCounters) => {
   ret;
 };
 
+let isBenchmarking = switch (Sys.getenv_opt("REVERY_DEBUG")) {
+| Some(_) => true
+| None => false
+};
+
 let bench: (string, performanceFunction('a)) => 'a =
   (name, f) =>
-    switch (Sys.getenv_opt("REVERY_DEBUG")) {
-    | None => f()
-    | Some(_) =>
+    switch (isBenchmarking) {
+    | false => f()
+    | true =>
       nestingLevel := nestingLevel^ + 1;
       let startTime = glfwGetTime();
       let startCounters = GarbageCollector.counters();

--- a/src/UI/Animation.re
+++ b/src/UI/Animation.re
@@ -79,9 +79,8 @@ module Make = (AnimationTickerImpl: AnimationTicker) => {
   let easeOut = cubicBezier(0.0, 0.0, 0.58, 1.0);
   let easeInOut = cubicBezier(0.42, 0.0, 0.58, 1.0);
 
-  let floatValue = (v: float) => {
-    let ret = {current: v};
-    ret;
+  let floatValue: float => animationValue = (v: float) => {
+    {current: v};
   };
 
   let getLocalTime = (clock: float, anim: animation) => {

--- a/src/UI/Animation.re
+++ b/src/UI/Animation.re
@@ -79,9 +79,10 @@ module Make = (AnimationTickerImpl: AnimationTicker) => {
   let easeOut = cubicBezier(0.0, 0.0, 0.58, 1.0);
   let easeInOut = cubicBezier(0.42, 0.0, 0.58, 1.0);
 
-  let floatValue: float => animationValue = (v: float) => {
-    {current: v};
-  };
+  let floatValue: float => animationValue =
+    (v: float) => {
+      {current: v};
+    };
 
   let getLocalTime = (clock: float, anim: animation) => {
     let adjustedStart = anim.startTime +. anim.delay;

--- a/src/UI/Container.re
+++ b/src/UI/Container.re
@@ -22,27 +22,17 @@ let update: (t, React.syntheticElement) => t =
         updates |> React.RenderedElement.executePendingEffects;
       | Some(s) =>
         let nextElement =
-          Performance.bench("RenderedElement.update", () =>
             React.RenderedElement.update(
               ~previousElement=s.previousElement,
               ~renderedElement=s.rendered,
               element,
             )
-          );
         let nextElement =
-          Performance.bench("RenderedElement.flushPendingUpdates", () =>
             React.RenderedElement.flushPendingUpdates(nextElement)
-          );
 
-        Performance.bench("RenderedElement.executeHostViewEffects", () =>
           React.RenderedElement.executeHostViewUpdates(nextElement) |> ignore
-        );
 
-        let ret =
-          Performance.bench("RenderedElement.executePendingEffects", () =>
             React.RenderedElement.executePendingEffects(nextElement)
-          );
-        ret;
       };
 
     let ret: t = {

--- a/src/UI/Container.re
+++ b/src/UI/Container.re
@@ -22,17 +22,17 @@ let update: (t, React.syntheticElement) => t =
         updates |> React.RenderedElement.executePendingEffects;
       | Some(s) =>
         let nextElement =
-            React.RenderedElement.update(
-              ~previousElement=s.previousElement,
-              ~renderedElement=s.rendered,
-              element,
-            )
+          React.RenderedElement.update(
+            ~previousElement=s.previousElement,
+            ~renderedElement=s.rendered,
+            element,
+          );
         let nextElement =
-            React.RenderedElement.flushPendingUpdates(nextElement)
+          React.RenderedElement.flushPendingUpdates(nextElement);
 
-          React.RenderedElement.executeHostViewUpdates(nextElement) |> ignore
+        React.RenderedElement.executeHostViewUpdates(nextElement) |> ignore;
 
-            React.RenderedElement.executePendingEffects(nextElement)
+        React.RenderedElement.executePendingEffects(nextElement);
       };
 
     let ret: t = {

--- a/src/UI/Hooks.re
+++ b/src/UI/Hooks.re
@@ -4,16 +4,15 @@ open Animated;
 
 let reducer = (_a, s) => s + 1;
 
-let animationLoop = (dispatch, v, opts) => () => {
-        let complete = Tick.interval(_t => dispatch(), Seconds(0.));
-        let {stop, _} = tween(v, opts) |> start(~complete);
-        Some(
-          () => {
-            stop();
-            complete();
-          },
-        );
-    
+let animationLoop = (dispatch, v, opts, ()) => {
+  let complete = Tick.interval(_t => dispatch(), Seconds(0.));
+  let {stop, _} = tween(v, opts) |> start(~complete);
+  Some(
+    () => {
+      stop();
+      complete();
+    },
+  );
 };
 
 let animation = (v: animationValue, opts: animationOptions, slots) => {

--- a/src/UI/Hooks.re
+++ b/src/UI/Hooks.re
@@ -4,15 +4,7 @@ open Animated;
 
 let reducer = (_a, s) => s + 1;
 
-let animation = (v: animationValue, opts: animationOptions, slots) => {
-  let (currentV, _, slots) = React.Hooks.ref(v, slots);
-  let (_, dispatch, slots) =
-    React.Hooks.reducer(~initialState=0, reducer, slots);
-
-  let slots =
-    React.Hooks.effect(
-      OnMount,
-      () => {
+let animationLoop = (dispatch, v, opts) => () => {
         let complete = Tick.interval(_t => dispatch(), Seconds(0.));
         let {stop, _} = tween(v, opts) |> start(~complete);
         Some(
@@ -21,7 +13,18 @@ let animation = (v: animationValue, opts: animationOptions, slots) => {
             complete();
           },
         );
-      },
+    
+};
+
+let animation = (v: animationValue, opts: animationOptions, slots) => {
+  let (currentV, _, slots) = React.Hooks.ref(v, slots);
+  let (_, dispatch, slots) =
+    React.Hooks.reducer(~initialState=0, reducer, slots);
+
+  let slots =
+    React.Hooks.effect(
+      OnMount,
+      animationLoop(dispatch, currentV, opts),
       slots,
     );
 

--- a/src/UI/Reconciler.re
+++ b/src/UI/Reconciler.re
@@ -20,7 +20,7 @@ let insertNode = (~parent: node, ~child: node, ~position as _) => {
   parent;
 };
 
-let deleteNode = (~parent: node, ~child: node) => {
+let deleteNode = (~parent: node, ~child: node, ~position as _) => {
   parent#removeChild(child);
   parent;
 };


### PR DESCRIPTION
__Issue:__ Our animations were leaking memory - this was very apparent in the JS playground, but also impacted native.

__Fix:__
- Pick up a fix in brisk-reconciler to break a dependency chain between the dispatch closure and the `hooks` object
- Fix a few other issues found while debugging this.