### PR TITLE
Component: ClipContainer

### DIFF
--- a/src/UI_Components/ClipContainer.re
+++ b/src/UI_Components/ClipContainer.re
@@ -8,7 +8,8 @@ let createElement =
     (~children, ~color=Colors.transparentWhite, ~width as w, ~height as h, ()) =>
   component(hooks => {
     let c = color;
-    let style = Style.[width(w), height(h), overflow(`Hidden), backgroundColor(c)];
+    let style =
+      Style.[width(w), height(h), overflow(`Hidden), backgroundColor(c)];
 
     (hooks, <View style> ...children </View>);
   });

--- a/src/UI_Components/ClipContainer.re
+++ b/src/UI_Components/ClipContainer.re
@@ -1,0 +1,14 @@
+open Revery_Core;
+open Revery_UI;
+open Revery_UI_Primitives;
+
+let component = React.component("ClipContainer");
+
+let createElement =
+    (~children, ~color=Colors.transparentWhite, ~width as w, ~height as h, ()) =>
+  component(hooks => {
+    let c = color;
+    let style = Style.[width(w), height(h), overflow(`Hidden), backgroundColor(c)];
+
+    (hooks, <View style> ...children </View>);
+  });

--- a/src/UI_Components/ClipContainer.rei
+++ b/src/UI_Components/ClipContainer.rei
@@ -1,0 +1,30 @@
+open Revery_Core;
+open Revery_UI;
+
+/**
+{2 Description:}
+
+[ClipContainer] is similar to a container, except that it clips
+any items outside.
+
+{2 Usage:}
+
+{[
+<ClipContainer width=50 height=50>
+  <Container width=100 height=100 color=Colors.green />
+</ClipContainer
+]}
+
+@param [width] The width of the container, in pixels.
+@param [height] The height of the container, in pixels.
+@param [color] The color of the container.
+*/
+let createElement:
+  (
+    ~children: list(React.syntheticElement),
+    ~color: Color.t=?,
+    ~width: int,
+    ~height: int,
+    unit
+  ) =>
+  React.syntheticElement;

--- a/src/UI_Components/Revery_UI_Components.re
+++ b/src/UI_Components/Revery_UI_Components.re
@@ -8,6 +8,7 @@ module Button = Button;
 module Center = Center;
 module Checkbox = Checkbox;
 module Clickable = Clickable;
+module ClipContainer = ClipContainer;
 module Column = Column;
 module Container = Container;
 module Dropdown = Dropdown;

--- a/src/index.mld
+++ b/src/index.mld
@@ -37,6 +37,7 @@ Framework for fast, native, cross-platform GUI applications.
     {ul
                 {li {{:../Revery/Revery_UI_Components/Button/index.html} Button}}
                 {li {{:../Revery/Revery_UI_Components/Clickable/index.html} Clickable}}
+                {li {{:../Revery/Revery_UI_Components/ClipContainer/index.html} ClipContainer}}
                 {li {{:../Revery/Revery_UI_Components/Container/index.html} Container}}
                 {li {{:../Revery/Revery_UI_Components/Dropdown/index.html} Dropdown}}
                 {li {{:../Revery/Revery_UI_Components/Input/index.html} Input}}


### PR DESCRIPTION
This adds a `<ClipContainer />` component, which is like a `<Container />`, except it clips the elements (ie, behaves like having `overflow: hidden`)