### PR TITLE
Fix #501

### DIFF
--- a/src/Math/BoundingBox2d.re
+++ b/src/Math/BoundingBox2d.re
@@ -40,8 +40,8 @@ let intersects = (b0: t, b1: t) => {
   !noOverlap;
 };
 
-let intersect = (b0: t, b1: t) => {
-  if(intersects(b0, b1)) {
+let intersect = (b0: t, b1: t) =>
+  if (intersects(b0, b1)) {
     let box0_minX = Vec2.get_x(b0.min);
     let box1_minX = Vec2.get_x(b1.min);
     let minX = max(box0_minX, box1_minX);
@@ -61,14 +61,12 @@ let intersect = (b0: t, b1: t) => {
     let max = Vec2.create(maxX, maxY);
 
     create(min, max);
-  }
-  else {
+  } else {
     let min = Vec2.create(0., 0.);
     let max = Vec2.create(0., 0.);
 
     create(min, max);
-  }
-};
+  };
 
 let _getMin = (fn, v1: Vec3.t, v2: Vec3.t, v3: Vec3.t, v4: Vec3.t) => {
   let x1 = fn(v1);

--- a/src/Math/BoundingBox2d.re
+++ b/src/Math/BoundingBox2d.re
@@ -40,6 +40,36 @@ let intersects = (b0: t, b1: t) => {
   !noOverlap;
 };
 
+let intersect = (b0: t, b1: t) => {
+  if(intersects(b0, b1)) {
+    let box0_minX = Vec2.get_x(b0.min);
+    let box1_minX = Vec2.get_x(b1.min);
+    let minX = max(box0_minX, box1_minX);
+    let box0_minY = Vec2.get_y(b0.min);
+    let box1_minY = Vec2.get_y(b1.min);
+    let minY = max(box0_minY, box1_minY);
+
+    let box0_maxX = Vec2.get_x(b0.max);
+    let box1_maxX = Vec2.get_x(b1.max);
+    let maxX = min(box0_maxX, box1_maxX);
+
+    let box0_maxY = Vec2.get_y(b0.max);
+    let box1_maxY = Vec2.get_y(b1.max);
+    let maxY = min(box0_maxY, box1_maxY);
+
+    let min = Vec2.create(minX, minY);
+    let max = Vec2.create(maxX, maxY);
+
+    create(min, max);
+  }
+  else {
+    let min = Vec2.create(0., 0.);
+    let max = Vec2.create(0., 0.);
+
+    create(min, max);
+  }
+};
+
 let _getMin = (fn, v1: Vec3.t, v2: Vec3.t, v3: Vec3.t, v4: Vec3.t) => {
   let x1 = fn(v1);
   let x2 = fn(v2);

--- a/src/Math/BoundingBox2d.rei
+++ b/src/Math/BoundingBox2d.rei
@@ -9,6 +9,8 @@ let create: (Vec2.t, Vec2.t) => t;
 
 let intersects: (t, t) => bool;
 
+let intersect: (t, t) => t;
+
 let isPointInside: (t, Vec2.t) => bool;
 
 let transform: (t, Mat4.t) => t;

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -185,8 +185,8 @@ class node (()) = {
       );
     let b = BoundingBox2d.create(min, max);
     let bbox = BoundingBox2d.transform(b, worldTransform);
-    switch(_this#getParent()){
-    | Some(p) => BoundingBox2d.intersect(bbox, p#getBoundingBoxClipped());
+    switch (_this#getParent()) {
+    | Some(p) => BoundingBox2d.intersect(bbox, p#getBoundingBoxClipped())
     | None => bbox
     };
   };
@@ -203,7 +203,8 @@ class node (()) = {
     let bboxClipped = _this#_recalculateBoundingBoxClipped(worldTransform);
     let depth = _this#_recalculateDepth();
 
-    _cachedNodeState := Some({transform, worldTransform, bbox, bboxClipped, depth});
+    _cachedNodeState :=
+      Some({transform, worldTransform, bbox, bboxClipped, depth});
 
     List.iter(c => c#recalculate(), _children^);
 

--- a/src/UI_Components/Clickable.re
+++ b/src/UI_Components/Clickable.re
@@ -18,7 +18,7 @@ let noop = () => ();
 let noopEvt = _evt => ();
 
 let isMouseInsideRef = (ref: node, mouseX: float, mouseY: float) => {
-  let clickableDimensions: BoundingBox2d.t = ref#getBoundingBox();
+  let clickableDimensions: BoundingBox2d.t = ref#getBoundingBoxClipped();
   let pointVec = Vec2.create(mouseX, mouseY);
   BoundingBox2d.isPointInside(clickableDimensions, pointVec);
 };

--- a/test/Math/BoundingBox2dTests.re
+++ b/test/Math/BoundingBox2dTests.re
@@ -29,31 +29,82 @@ test("BoundingBox2d", () => {
   });
 
   test("intersection", () => {
-    let bbox1 =
-      BoundingBox2d.create(Vec2.create(5., 5.), Vec2.create(10., 10.));
-    let bbox2 =
-      BoundingBox2d.create(Vec2.create(0., 0.), Vec2.create(4., 4.));
+    test("intersects", () => {
+      let bbox1 =
+        BoundingBox2d.create(Vec2.create(5., 5.), Vec2.create(10., 10.));
+      let bbox2 =
+        BoundingBox2d.create(Vec2.create(0., 0.), Vec2.create(4., 4.));
 
-    expect(BoundingBox2d.intersects(bbox1, bbox2)).toBe(false);
+      expect(BoundingBox2d.intersects(bbox1, bbox2)).toBe(false);
 
-    let leftIntersect =
-      BoundingBox2d.create(Vec2.create(4., 4.), Vec2.create(6., 6.));
+      let leftIntersect =
+        BoundingBox2d.create(Vec2.create(4., 4.), Vec2.create(6., 6.));
 
-    expect(BoundingBox2d.intersects(bbox1, leftIntersect)).toBe(true);
+      expect(BoundingBox2d.intersects(bbox1, leftIntersect)).toBe(true);
 
-    let topIntersect =
-      BoundingBox2d.create(Vec2.create(6., 4.), Vec2.create(8., 6.));
+      let topIntersect =
+        BoundingBox2d.create(Vec2.create(6., 4.), Vec2.create(8., 6.));
 
-    expect(BoundingBox2d.intersects(bbox1, topIntersect)).toBe(true);
+      expect(BoundingBox2d.intersects(bbox1, topIntersect)).toBe(true);
 
-    let rightIntersect =
-      BoundingBox2d.create(Vec2.create(7., 6.), Vec2.create(11., 8.));
+      let rightIntersect =
+        BoundingBox2d.create(Vec2.create(7., 6.), Vec2.create(11., 8.));
 
-    expect(BoundingBox2d.intersects(bbox1, rightIntersect)).toBe(true);
+      expect(BoundingBox2d.intersects(bbox1, rightIntersect)).toBe(true);
 
-    let bottomIntersect =
-      BoundingBox2d.create(Vec2.create(6., 9.), Vec2.create(7., 11.));
-    expect(BoundingBox2d.intersects(bbox1, bottomIntersect)).toBe(true);
+      let bottomIntersect =
+        BoundingBox2d.create(Vec2.create(6., 9.), Vec2.create(7., 11.));
+      expect(BoundingBox2d.intersects(bbox1, bottomIntersect)).toBe(true);
+    });
+    test("intersect", () => {
+      let areBboxEqual = (b1, b2) => {
+        BoundingBox2d.(
+          Vec2.get_x(b1.min) == Vec2.get_x(b2.min)
+          && Vec2.get_y(b1.min) == Vec2.get_y(b2.min)
+          && Vec2.get_x(b1.max) == Vec2.get_x(b2.max)
+          && Vec2.get_y(b1.max) == Vec2.get_y(b2.max)
+        );
+      };
+      let bbox =
+        BoundingBox2d.create(Vec2.create(1., 1.), Vec2.create(5., 10.));
+
+      let bbox2 =
+        BoundingBox2d.create(Vec2.create(2., 2.), Vec2.create(7., 8.));
+      let intersectBbox =
+        BoundingBox2d.create(Vec2.create(2., 2.), Vec2.create(5., 8.));
+
+      expect(
+        areBboxEqual(BoundingBox2d.intersect(bbox, bbox2), intersectBbox),
+      ).
+        toBe(
+        true,
+      );
+
+      let insideBbox =
+        BoundingBox2d.create(Vec2.create(3., 4.), Vec2.create(4., 7.));
+
+      expect(
+        areBboxEqual(BoundingBox2d.intersect(bbox, insideBbox), insideBbox),
+      ).
+        toBe(
+        true,
+      );
+
+      let outsideBbox =
+        BoundingBox2d.create(Vec2.create(6., 11.), Vec2.create(7., 12.));
+      let intersectOutsideBbox =
+        BoundingBox2d.create(Vec2.create(0., 0.), Vec2.create(0., 0.));
+
+      expect(
+        areBboxEqual(
+          BoundingBox2d.intersect(bbox, outsideBbox),
+          intersectOutsideBbox,
+        ),
+      ).
+        toBe(
+        true,
+      );
+    });
   });
 
   test("transform", () => {


### PR DESCRIPTION
Fixes #501 

It introduces a clipped bounding box for nodes formed by the intersection of the node's bounding box and its parent's clipped bounding box. It then uses this clipped bounding box for the hitTest so that clipped parts of elements will not be interacted with.