### PR TITLE
UI - TreeView: Rendering order

### DIFF
--- a/src/UI_Components/Tree.re
+++ b/src/UI_Components/Tree.re
@@ -100,7 +100,7 @@ let rec renderTree = (~indent=0, ~nodeRenderer, ~emptyRenderer, t) => {
           List.concat([accum, grandChild]);
         },
         [],
-        v,
+        siblings,
       );
     [drawNode(current), ...renderedSiblings];
   };

--- a/src/UI_Components/Tree.re
+++ b/src/UI_Components/Tree.re
@@ -92,19 +92,17 @@ let rec renderTree = (~indent=0, ~nodeRenderer, ~emptyRenderer, t) => {
      only draw the parent do not render its children */
   | Node({status: Open, _} as x, [])
   | Node({status: Closed, _} as x, _) => [drawNode(x)]
-  | Node(current, [n, ...rest]) =>
-    let siblings =
+  | Node(current, siblings) =>
+    let renderedSiblings =
       List.fold_left(
         (accum, next) => {
           let grandChild = createSubtree(next);
           List.concat([accum, grandChild]);
         },
         [],
-        rest,
+        v,
       );
-    let firstChild = createSubtree(n);
-    let currentGeneration = [drawNode(current), ...siblings];
-    List.concat([currentGeneration, firstChild]);
+    [drawNode(current), ...renderedSiblings];
   };
 };
 


### PR DESCRIPTION
This tests out @r281GQ's idea in https://github.com/onivim/oni2#377 - it looks like there is a bug in the render order of the treeview. We happen to get the very first element rendering at the end of the list.