### PR TITLE
Bugfix: getExecutingDirectory returns '.' in some cases

### DIFF
--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -19,13 +19,17 @@ let getExecutingDirectory = () =>
   if (!isNative) {
     "";
   } else {
-        let dir = 
-        switch ((String.rindex_opt(Sys.executable_name, '/'), String.rindex_opt(Sys.executable_name, '\\'))) {
-        | (Some(v1), Some(v2)) => String.sub(Sys.executable_name, 0, max(v1, v2))
-        | (None, Some(v)) => String.sub(Sys.executable_name, 0, v);
-        | (Some(v), None) => String.sub(Sys.executable_name, 0, v);
-        | _ => Sys.executable_name
-        }
+    let dir =
+      switch (
+        String.rindex_opt(Sys.executable_name, '/'),
+        String.rindex_opt(Sys.executable_name, '\\'),
+      ) {
+      | (Some(v1), Some(v2)) =>
+        String.sub(Sys.executable_name, 0, max(v1, v2))
+      | (None, Some(v)) => String.sub(Sys.executable_name, 0, v)
+      | (Some(v), None) => String.sub(Sys.executable_name, 0, v)
+      | _ => Sys.executable_name
+      };
 
     /* Check if there is a trailing slash. If not, we need to add one. */
 

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -15,35 +15,35 @@ let sleep = (t: Time.t) =>
 
 external yield: unit => unit = "caml_thread_yield";
 
-let getExecutingDirectory = () =>
+let getExecutingDirectory = () => {
   if (!isNative) {
-    "";
+    ""
   } else {
-    let dir =
-      switch (Filename.dirname(Sys.argv[0])) {
-      /* In some cases, like launching an OSX app from a .App folder,
-       * we'll get a '.' as the Sys.argv[0] value. In that case - we'll
-       * fallback to checking Sys.executable_name. */
-      | "." =>
-        /* We want the parent directory of the Sys.executable_name */
-        switch (String.rindex_opt(Sys.executable_name, '.')) {
-        | Some(v) => String.sub(Sys.executable_name, 0, v)
-        | None => Sys.executable_name
-        }
-      };
+    let dir = switch (Filename.dirname(Sys.argv[0])) {
+    /* In some cases, like launching an OSX app from a .App folder,
+     * we'll get a '.' as the Sys.argv[0] value. In that case - we'll
+     * fallback to checking Sys.executable_name. */
+    | "." => 
+      /* We want the parent directory of the Sys.executable_name */
+      switch(String.rindex_opt(Sys.executable_name, '.')) {
+      | Some(v) => String.sub(Sys.executable_name, 0, v)
+      | None => Sys.executable_name
+      }
+    | v => v
+    };
 
     /* Check if there is a trailing slash. If not, we need to add one. */
 
     let len = String.length(dir);
-    let ret =
-      switch (dir.[len - 1]) {
-      | '/' => dir
-      | '\\' => dir
-      | _ => dir ++ Filename.dir_sep
-      };
+    let ret = switch (String.get(dir, len - 1)) {
+    | '/' => dir
+    | '\\' => dir
+    | _ => dir ++ Filename.dir_sep
+    }
 
     ret;
-  };
+  }
+};
 
 let executingDirectory = getExecutingDirectory();
 

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -20,11 +20,11 @@ let getExecutingDirectory = () =>
     "";
   } else {
         let dir = 
-        switch ((String.rindex_opt(Sys.executable_name, '/'), String.rindex_opt(Sys.executable_name, '\\')) {
+        switch ((String.rindex_opt(Sys.executable_name, '/'), String.rindex_opt(Sys.executable_name, '\\'))) {
         | (Some(v1), Some(v2)) => String.sub(Sys.executable_name, 0, max(v1, v2))
         | (None, Some(v)) => String.sub(Sys.executable_name, 0, v);
-        | (Some(v), None) => String.sub(Sys.executable_name, 0, v)
-        | None => Sys.executable_name
+        | (Some(v), None) => String.sub(Sys.executable_name, 0, v);
+        | _ => Sys.executable_name
         }
 
     /* Check if there is a trailing slash. If not, we need to add one. */

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -15,35 +15,36 @@ let sleep = (t: Time.t) =>
 
 external yield: unit => unit = "caml_thread_yield";
 
-let getExecutingDirectory = () => {
+let getExecutingDirectory = () =>
   if (!isNative) {
-    ""
+    "";
   } else {
-    let dir = switch (Filename.dirname(Sys.argv[0])) {
-    /* In some cases, like launching an OSX app from a .App folder,
-     * we'll get a '.' as the Sys.argv[0] value. In that case - we'll
-     * fallback to checking Sys.executable_name. */
-    | "." => 
-      /* We want the parent directory of the Sys.executable_name */
-      switch(String.rindex_opt(Sys.executable_name, '.')) {
-      | Some(v) => String.sub(Sys.executable_name, 0, v)
-      | None => Sys.executable_name
-      }
-    | v => v
-    };
+    let dir =
+      switch (Filename.dirname(Sys.argv[0])) {
+      /* In some cases, like launching an OSX app from a .App folder,
+       * we'll get a '.' as the Sys.argv[0] value. In that case - we'll
+       * fallback to checking Sys.executable_name. */
+      | "." =>
+        /* We want the parent directory of the Sys.executable_name */
+        switch (String.rindex_opt(Sys.executable_name, '.')) {
+        | Some(v) => String.sub(Sys.executable_name, 0, v)
+        | None => Sys.executable_name
+        }
+      | v => v
+      };
 
     /* Check if there is a trailing slash. If not, we need to add one. */
 
     let len = String.length(dir);
-    let ret = switch (String.get(dir, len - 1)) {
-    | '/' => dir
-    | '\\' => dir
-    | _ => dir ++ Filename.dir_sep
-    }
+    let ret =
+      switch (dir.[len - 1]) {
+      | '/' => dir
+      | '\\' => dir
+      | _ => dir ++ Filename.dir_sep
+      };
 
     ret;
-  }
-};
+  };
 
 let executingDirectory = getExecutingDirectory();
 

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -16,7 +16,36 @@ let sleep = (t: Time.t) =>
 external yield: unit => unit = "caml_thread_yield";
 
 let getExecutingDirectory = () =>
-  isNative ? Filename.dirname(Sys.argv[0]) ++ Filename.dir_sep : "";
+  if (!isNative) {
+    "";
+  } else {
+    let dir =
+      switch (Filename.dirname(Sys.argv[0])) {
+      /* In some cases, like launching an OSX app from a .App folder,
+       * we'll get a '.' as the Sys.argv[0] value. In that case - we'll
+       * fallback to checking Sys.executable_name. */
+      | "." =>
+        /* We want the parent directory of the Sys.executable_name */
+        switch (String.rindex_opt(Sys.executable_name, '.')) {
+        | Some(v) => String.sub(Sys.executable_name, 0, v)
+        | None => Sys.executable_name
+        }
+      };
+
+    /* Check if there is a trailing slash. If not, we need to add one. */
+
+    let len = String.length(dir);
+    let ret =
+      switch (dir.[len - 1]) {
+      | '/' => dir
+      | '\\' => dir
+      | _ => dir ++ Filename.dir_sep
+      };
+
+    ret;
+  };
+
+let executingDirectory = getExecutingDirectory();
 
 let getWorkingDirectory = () => Sys.getcwd();
 

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -19,19 +19,13 @@ let getExecutingDirectory = () =>
   if (!isNative) {
     "";
   } else {
-    let dir =
-      switch (Filename.dirname(Sys.argv[0])) {
-      /* In some cases, like launching an OSX app from a .App folder,
-       * we'll get a '.' as the Sys.argv[0] value. In that case - we'll
-       * fallback to checking Sys.executable_name. */
-      | "." =>
-        /* We want the parent directory of the Sys.executable_name */
-        switch (String.rindex_opt(Sys.executable_name, '.')) {
-        | Some(v) => String.sub(Sys.executable_name, 0, v)
+        let dir = 
+        switch ((String.rindex_opt(Sys.executable_name, '/'), String.rindex_opt(Sys.executable_name, '\\')) {
+        | (Some(v1), Some(v2)) => String.sub(Sys.executable_name, 0, max(v1, v2))
+        | (None, Some(v)) => String.sub(Sys.executable_name, 0, v);
+        | (Some(v), None) => String.sub(Sys.executable_name, 0, v)
         | None => Sys.executable_name
         }
-      | v => v
-      };
 
     /* Check if there is a trailing slash. If not, we need to add one. */
 

--- a/src/Core/Environment.rei
+++ b/src/Core/Environment.rei
@@ -19,7 +19,15 @@ let sleep: Time.t => unit;
 
 let yield: unit => unit;
 
+/**
+[@deprecated]
+*/
 let getExecutingDirectory: unit => string;
+
+/**
+[executingDirectory] gets the directory where the running executable lives.
+*/
+let executingDirectory: string;
 
 let getWorkingDirectory: unit => string;
 


### PR DESCRIPTION
__Issue:__ In some cases, notably on OSX when bundling as an `.App` folder, the `getExecutingDirectory` function would return `.`. This is problematic because we often use it to figure out where binary-relative resources are.

__Defect:__ In that case, `Sys.argv[0]` just returns `'.'`. 

__Fix:__ In that particular case, `Sys,executable_name` gives us the full path to the executable. We can get the executing directory from that path.