### PR TITLE
fix(bug fix): Bracket keys not picked up as expected

### DIFF
--- a/src/Core/Key.re
+++ b/src/Core/Key.re
@@ -169,9 +169,9 @@ let toString = key =>
   | KEY_X => "x"
   | KEY_Y => "y"
   | KEY_Z => "z"
-  | KEY_LEFT_BRACKET => "("
+  | KEY_LEFT_BRACKET => "["
   | KEY_BACKSLASH => "\\"
-  | KEY_RIGHT_BRACKET => ")"
+  | KEY_RIGHT_BRACKET => "]"
   | _ => ""
   };
 
@@ -221,9 +221,9 @@ let fromString = key =>
   | "x" => KEY_X
   | "y" => KEY_Y
   | "z" => KEY_Z
-  | "(" => KEY_LEFT_BRACKET
+  | "[" => KEY_LEFT_BRACKET
   | "\\" => KEY_BACKSLASH
-  | ")" => KEY_RIGHT_BRACKET
+  | "]" => KEY_RIGHT_BRACKET
   | _ => KEY_UNKNOWN
   };
 


### PR DESCRIPTION
This looks like the root cause for https://github.com/onivim/oni2/issues/461 - when pressing `Control+[`, we're sending `Control+(` to libvim instead.