### PR TITLE
Performance: Improve idle performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@esy-ocaml/reason": "3.4.0",
-    "reason-glfw": "^3.2.1024",
+    "reason-glfw": "^3.2.1025",
     "reason-fontkit": "^2.4.1",
     "reason-gl-matrix": "^0.9.9304",
     "rebez": "*",

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -30,10 +30,10 @@ let createWindow =
 
 let _anyWindowsDirty = (app: t) =>
   List.fold_left(
-    (prev, w) => { 
-        let dirty = Window.isDirty(w);
-        //print_endline ("dirty: " ++ string_of_bool(dirty));
-        prev || dirty;
+    (prev, w) => {
+      let dirty = Window.isDirty(w);
+      //print_endline ("dirty: " ++ string_of_bool(dirty));
+      prev || dirty;
     },
     false,
     getWindows(app),
@@ -62,25 +62,22 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
   let _ = initFunc(appInstance);
 
   let appLoop = (_t: float) => {
-
     if (appInstance.idleCount >= framesToIdle) {
       Glfw.glfwWaitEvents();
     } else {
       Glfw.glfwPollEvents();
-    }
+    };
     Tick.Default.pump();
 
     _checkAndCloseWindows(appInstance);
 
     if (appInstance.isFirstRender || _anyWindowsDirty(appInstance)) {
-      //print_endline ("NO IDLE render");
       Performance.bench("renderWindows", () => {
         List.iter(w => Window.render(w), getWindows(appInstance));
         appInstance.idleCount = 0;
         appInstance.isFirstRender = false;
       });
     } else {
-      //print_endline ("IDLE render");
       appInstance.idleCount = appInstance.idleCount + 1;
 
       if (appInstance.idleCount === framesToIdle) {


### PR DESCRIPTION
__Issue:__ Today, when a Revery app is 'idle' (ie, no user input or animations incoming), CPU usage is higher than it should be.

__Defect:__ Revery is constantly running the application loop and re-rendering (like a game). Howevever, for applications, we don't want to be running the application loop this frequently. When there is no user input, and no animations or processing, we should block on user input.

__Fix:__ When idling, use `glfwWaitInputEvent` to block until user input. Add a method on `App` to force a re-render (via `glfwPostEmptyEvent`).

Needed for https://github.com/onivim/oni2/issues/304