### PR TITLE
UI - Primitives: Move boxshadow style to <BoxShadow /> component

### DIFF
--- a/examples/Boxshadow.re
+++ b/examples/Boxshadow.re
@@ -10,40 +10,50 @@ let parentStyles =
     flexDirection(`Column),
   ];
 
-let firstShadow =
+let firstBoxStyle =
   Style.[
     backgroundColor(Colors.blue),
     position(`Relative),
     width(100),
     height(100),
-    boxShadow(
-      ~yOffset=-10.,
-      ~xOffset=0.,
-      ~blurRadius=15.,
-      ~color=Colors.black,
-      ~spreadRadius=10.,
-    ),
-    marginVertical(30),
   ];
 
-let secondShadow =
+let secondBoxStyle =
   Style.[
     backgroundColor(Colors.red),
     position(`Relative),
     width(100),
     height(100),
-    boxShadow(
+  ];
+
+let firstShadow = Style.BoxShadow.make(
+      ~yOffset=-10.,
+      ~xOffset=0.,
+      ~blurRadius=15.,
+      ~color=Colors.black,
+      ~spreadRadius=10.,
+      (),
+    );
+
+let secondShadow = Style.BoxShadow.make(
       ~yOffset=10.,
       ~xOffset=-30.,
       ~blurRadius=20.,
       ~color=Colors.green,
       ~spreadRadius=0.,
-    ),
-    marginVertical(30),
-  ];
+      ()
+);
 
 let render = () =>
   <View style=parentStyles>
-    <View style=firstShadow />
-    <View style=secondShadow />
+    <Padding padding=30>
+      <BoxShadow boxShadow=firstShadow>
+        <View style=firstBoxStyle />
+      </BoxShadow>
+    </Padding>
+    <Padding padding=30>
+      <BoxShadow boxShadow=secondShadow>
+        <View style=secondBoxStyle />
+      </BoxShadow>
+    </Padding>
   </View>;

--- a/examples/Boxshadow.re
+++ b/examples/Boxshadow.re
@@ -26,23 +26,25 @@ let secondBoxStyle =
     height(100),
   ];
 
-let firstShadow = Style.BoxShadow.make(
-      ~yOffset=-10.,
-      ~xOffset=0.,
-      ~blurRadius=15.,
-      ~color=Colors.black,
-      ~spreadRadius=10.,
-      (),
-    );
+let firstShadow =
+  Style.BoxShadow.make(
+    ~yOffset=-10.,
+    ~xOffset=0.,
+    ~blurRadius=15.,
+    ~color=Colors.black,
+    ~spreadRadius=10.,
+    (),
+  );
 
-let secondShadow = Style.BoxShadow.make(
-      ~yOffset=10.,
-      ~xOffset=-30.,
-      ~blurRadius=20.,
-      ~color=Colors.green,
-      ~spreadRadius=0.,
-      ()
-);
+let secondShadow =
+  Style.BoxShadow.make(
+    ~yOffset=10.,
+    ~xOffset=-30.,
+    ~blurRadius=20.,
+    ~color=Colors.green,
+    ~spreadRadius=0.,
+    (),
+  );
 
 let render = () =>
   <View style=parentStyles>

--- a/examples/InputExample.re
+++ b/examples/InputExample.re
@@ -57,6 +57,7 @@ module Example = {
               onClick={() => setValue({first: "New value", second})}
             />
           </View>
+          <Padding padding=20>
           <BoxShadow
             boxShadow={Style.BoxShadow.make(
               ~xOffset=-5.,
@@ -76,11 +77,11 @@ module Example = {
               style=Style.[
                 backgroundColor(Colors.paleVioletRed),
                 color(Colors.white),
-                margin(20),
                 height(50),
               ]
             />
           </BoxShadow>
+          </Padding>
         </View>,
       );
     });

--- a/examples/InputExample.re
+++ b/examples/InputExample.re
@@ -57,28 +57,29 @@ module Example = {
               onClick={() => setValue({first: "New value", second})}
             />
           </View>
-          <BoxShadow boxShadow=Style.BoxShadow.make(
-                ~xOffset=-5.,
-                ~yOffset=2.,
-                ~color=Colors.black,
-                ~blurRadius=20.,
-                ~spreadRadius=0.,
-                (),
-          )>
-          <Input
-            placeholder="custom input"
-            placeholderColor=Colors.plum
-            cursorColor=Colors.white
-            autofocus=true
-            onChange={({value, _}) => setValue({first, second: value})}
-            onKeyDown={event => Console.log(event)}
-            style=Style.[
-              backgroundColor(Colors.paleVioletRed),
-              color(Colors.white),
-              margin(20),
-              height(50),
-            ]
-          />
+          <BoxShadow
+            boxShadow={Style.BoxShadow.make(
+              ~xOffset=-5.,
+              ~yOffset=2.,
+              ~color=Colors.black,
+              ~blurRadius=20.,
+              ~spreadRadius=0.,
+              (),
+            )}>
+            <Input
+              placeholder="custom input"
+              placeholderColor=Colors.plum
+              cursorColor=Colors.white
+              autofocus=true
+              onChange={({value, _}) => setValue({first, second: value})}
+              onKeyDown={event => Console.log(event)}
+              style=Style.[
+                backgroundColor(Colors.paleVioletRed),
+                color(Colors.white),
+                margin(20),
+                height(50),
+              ]
+            />
           </BoxShadow>
         </View>,
       );

--- a/examples/InputExample.re
+++ b/examples/InputExample.re
@@ -58,29 +58,29 @@ module Example = {
             />
           </View>
           <Padding padding=20>
-          <BoxShadow
-            boxShadow={Style.BoxShadow.make(
-              ~xOffset=-5.,
-              ~yOffset=2.,
-              ~color=Colors.black,
-              ~blurRadius=20.,
-              ~spreadRadius=0.,
-              (),
-            )}>
-            <Input
-              placeholder="custom input"
-              placeholderColor=Colors.plum
-              cursorColor=Colors.white
-              autofocus=true
-              onChange={({value, _}) => setValue({first, second: value})}
-              onKeyDown={event => Console.log(event)}
-              style=Style.[
-                backgroundColor(Colors.paleVioletRed),
-                color(Colors.white),
-                height(50),
-              ]
-            />
-          </BoxShadow>
+            <BoxShadow
+              boxShadow={Style.BoxShadow.make(
+                ~xOffset=-5.,
+                ~yOffset=2.,
+                ~color=Colors.black,
+                ~blurRadius=20.,
+                ~spreadRadius=0.,
+                (),
+              )}>
+              <Input
+                placeholder="custom input"
+                placeholderColor=Colors.plum
+                cursorColor=Colors.white
+                autofocus=true
+                onChange={({value, _}) => setValue({first, second: value})}
+                onKeyDown={event => Console.log(event)}
+                style=Style.[
+                  backgroundColor(Colors.paleVioletRed),
+                  color(Colors.white),
+                  height(50),
+                ]
+              />
+            </BoxShadow>
           </Padding>
         </View>,
       );

--- a/examples/InputExample.re
+++ b/examples/InputExample.re
@@ -57,6 +57,14 @@ module Example = {
               onClick={() => setValue({first: "New value", second})}
             />
           </View>
+          <BoxShadow boxShadow=Style.BoxShadow.make(
+                ~xOffset=-5.,
+                ~yOffset=2.,
+                ~color=Colors.black,
+                ~blurRadius=20.,
+                ~spreadRadius=0.,
+                (),
+          )>
           <Input
             placeholder="custom input"
             placeholderColor=Colors.plum
@@ -69,15 +77,9 @@ module Example = {
               color(Colors.white),
               margin(20),
               height(50),
-              boxShadow(
-                ~xOffset=-5.,
-                ~yOffset=2.,
-                ~color=Colors.black,
-                ~blurRadius=20.,
-                ~spreadRadius=0.,
-              ),
             ]
           />
+          </BoxShadow>
         </View>,
       );
     });

--- a/examples/TreeView.re
+++ b/examples/TreeView.re
@@ -190,18 +190,18 @@ module TreeView = {
         fontSize(10),
       ];
     <Padding padding=5>
-    <View
-      style=Style.[
-        justifyContent(`Center),
-        alignItems(`Center),
-        marginLeft(indent * 30),
-        backgroundColor(Colors.white),
-        width(80),
-        height(40)
-      ]>
+      <View
+        style=Style.[
+          justifyContent(`Center),
+          alignItems(`Center),
+          marginLeft(indent * 30),
+          backgroundColor(Colors.white),
+          width(80),
+          height(40),
+        ]>
         <Text text={data.name} style=textStyles />
         <Text text={data.level} style=textStyles />
-    </View>
+      </View>
     </Padding>;
   };
 };

--- a/examples/TreeView.re
+++ b/examples/TreeView.re
@@ -189,6 +189,7 @@ module TreeView = {
         fontFamily("Roboto-Regular.ttf"),
         fontSize(10),
       ];
+    <Padding padding=5>
     <View
       style=Style.[
         justifyContent(`Center),
@@ -196,19 +197,12 @@ module TreeView = {
         marginLeft(indent * 30),
         backgroundColor(Colors.white),
         width(80),
-        height(40),
-        marginVertical(5),
-        boxShadow(
-          ~xOffset=-6.,
-          ~yOffset=4.,
-          ~blurRadius=5.,
-          ~spreadRadius=2.,
-          ~color=Color.rgba(0., 0., 0., 0.5),
-        ),
+        height(40)
       ]>
-      <Text text={data.name} style=textStyles />
-      <Text text={data.level} style=textStyles />
-    </View>;
+        <Text text={data.name} style=textStyles />
+        <Text text={data.level} style=textStyles />
+    </View>
+    </Padding>;
   };
 };
 

--- a/src/Draw/GradientShader.re
+++ b/src/Draw/GradientShader.re
@@ -62,7 +62,7 @@ let fragmentShader = {|
   float verticalBlur = min(topEdgeAmount, bottomEdgeAmount);
 
   float blur = horizontalBlur * verticalBlur;
-  gl_FragColor = vec4(uShadowColor, blur);
+  gl_FragColor = vec4(uShadowColor.rgb, blur);
 |};
 
 type t = {

--- a/src/UI/Selector.re
+++ b/src/UI/Selector.re
@@ -46,7 +46,6 @@ type selector('a) =
   | BorderVertical: selector(Border.t)
   | Transform: selector(list(Transform.t))
   | Opacity: selector(float)
-  | BoxShadow: selector(BoxShadow.properties)
   | Cursor: selector(option(MouseCursors.t));
 
 /**
@@ -127,8 +126,6 @@ let rec select:
       select(rest, selector, bv)
     | ([`Transform(tr), ...rest], Transform) => select(rest, selector, tr)
     | ([`Opacity(op), ...rest], Opacity) => select(rest, selector, op)
-    | ([`BoxShadow(bxsh), ...rest], BoxShadow) =>
-      select(rest, selector, bxsh)
     | ([`Cursor(cur), ...rest], Cursor) => select(rest, selector, cur)
     | ([_, ...rest], _) => select(rest, selector, default)
     };

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -40,10 +40,16 @@ module BoxShadow = {
     spreadRadius,
     color,
   };
+  
+  let default: t = {
+    xOffset: 0., yOffset: 0., blurRadius: 0., spreadRadius: 0., color: Colors.black,
+  };
+
 };
 
 type t = {
   backgroundColor: Color.t,
+  boxShadow: BoxShadow.t,
   color: Color.t,
   width: int,
   height: int,
@@ -94,7 +100,6 @@ type t = {
   borderRadius: float,
   transform: list(Transform.t),
   opacity: float,
-  boxShadow: BoxShadow.properties,
   cursor: option(MouseCursors.t),
 };
 
@@ -102,6 +107,7 @@ let make =
     (
       ~textOverflow=TextOverflow.Overflow,
       ~backgroundColor: Color.t=Colors.transparentBlack,
+      ~boxShadow=BoxShadow.default,
       ~color: Color.t=Colors.white,
       ~width=Encoding.cssUndefined,
       ~height=Encoding.cssUndefined,
@@ -151,19 +157,13 @@ let make =
       ~borderRadius=0.0,
       ~transform=[],
       ~opacity=1.0,
-      ~boxShadow=BoxShadow.{
-                   xOffset: 0.0,
-                   yOffset: 0.0,
-                   blurRadius: 0.0,
-                   spreadRadius: 0.0,
-                   color: Colors.black,
-                 },
       ~cursor=?,
       _unit: unit,
     ) => {
   let ret: t = {
     textOverflow,
     backgroundColor,
+    boxShadow,
     color,
     width,
     height,
@@ -213,7 +213,6 @@ let make =
     borderVertical,
     borderRadius,
     opacity,
-    boxShadow,
     cursor,
   };
 
@@ -334,7 +333,6 @@ type coreStyleProps = [
   | `BorderRadius(float)
   | `Transform(list(Transform.t))
   | `Opacity(float)
-  | `BoxShadow(BoxShadow.properties)
   | `Cursor(option(MouseCursors.t))
 ];
 
@@ -485,8 +483,6 @@ let cursor = c => `Cursor(Some(c));
 
 let opacity = o => `Opacity(o);
 let transform = t => `Transform(t);
-let boxShadow = (~xOffset, ~yOffset, ~spreadRadius, ~blurRadius, ~color) =>
-  `BoxShadow(BoxShadow.{xOffset, yOffset, spreadRadius, blurRadius, color});
 
 let overflow = o =>
   switch (o) {
@@ -575,7 +571,6 @@ let applyStyle = (style, styleRule) =>
   | `BorderHorizontal(borderHorizontal) => {...style, borderHorizontal}
   | `BorderRadius(borderRadius) => {...style, borderRadius}
   | `Opacity(opacity) => {...style, opacity}
-  | `BoxShadow(boxShadow) => {...style, boxShadow}
   | `Transform(transform) => {...style, transform}
   | `FontFamily(fontFamily) => {...style, fontFamily}
   | `FontSize(fontSize) => {...style, fontSize}
@@ -648,7 +643,6 @@ let merge = (~source, ~target) =>
               | (`BorderRadius(_), `BorderRadius(_)) => targetStyle
               | (`Transform(_), `Transform(_)) => targetStyle
               | (`Opacity(_), `Opacity(_)) => targetStyle
-              | (`BoxShadow(_), `BoxShadow(_)) => targetStyle
               | (newRule, _) => newRule
               }
             )

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -27,24 +27,29 @@ module BoxShadow = {
 
   type t = properties;
 
-  let make = (
-    ~xOffset=-5.,
-    ~yOffset=-5.,
-    ~blurRadius=20.,
-    ~spreadRadius=00.,
-    ~color=Color.rgba(0., 0., 0., 1.0),
-    ()) => {
+  let make =
+      (
+        ~xOffset=(-5.),
+        ~yOffset=(-5.),
+        ~blurRadius=20.,
+        ~spreadRadius=00.,
+        ~color=Color.rgba(0., 0., 0., 1.0),
+        (),
+      ) => {
     xOffset,
     yOffset,
     blurRadius,
     spreadRadius,
     color,
   };
-  
-  let default: t = {
-    xOffset: 0., yOffset: 0., blurRadius: 0., spreadRadius: 0., color: Colors.black,
-  };
 
+  let default: t = {
+    xOffset: 0.,
+    yOffset: 0.,
+    blurRadius: 0.,
+    spreadRadius: 0.,
+    color: Colors.black,
+  };
 };
 
 type t = {

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -24,6 +24,22 @@ module BoxShadow = {
     spreadRadius: float,
     color: Color.t,
   };
+
+  type t = properties;
+
+  let make = (
+    ~xOffset=-5.,
+    ~yOffset=-5.,
+    ~blurRadius=20.,
+    ~spreadRadius=00.,
+    ~color=Color.rgba(0., 0., 0., 1.0),
+    ()) => {
+    xOffset,
+    yOffset,
+    blurRadius,
+    spreadRadius,
+    color,
+  };
 };
 
 type t = {

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -278,12 +278,6 @@ let renderShadow = (~boxShadow, ~width, ~height, ~world, ~m) => {
     Color.toVec3(color),
   );
 
-  /* Shaders.CompiledShader.setUniform3fv( */
-  /*   gradientShader, */
-  /*   "uShadowColor", */
-  /*   Color.toVec3(color), */
-  /* ); */
-
   Shaders.CompiledShader.setUniform2fv(
     gradientShader.uniformShadowAmount,
     Vec2.create(blurRadius /. width, blurRadius /. height),

--- a/src/UI_Primitives/BoxShadow.re
+++ b/src/UI_Primitives/BoxShadow.re
@@ -3,12 +3,7 @@ let component = React.nativeComponent("BoxShadow");
 
 open Style;
 
-let make =
-    (
-      ~key=?,
-      ~boxShadow,
-      children,
-    ) =>
+let make = (~key=?, ~boxShadow, children) =>
   component(~key?, hooks =>
     (
       hooks,
@@ -29,13 +24,5 @@ let make =
     )
   );
 
-let createElement =
-    (
-      ~boxShadow=BoxShadow.make(),
-      ~children,
-      (),
-    ) =>
-  make(
-    ~boxShadow,
-    React.listToElement(children),
-  );
+let createElement = (~boxShadow=BoxShadow.make(), ~children, ()) =>
+  make(~boxShadow, React.listToElement(children));

--- a/src/UI_Primitives/BoxShadow.re
+++ b/src/UI_Primitives/BoxShadow.re
@@ -1,0 +1,41 @@
+open Revery_UI;
+let component = React.nativeComponent("BoxShadow");
+
+open Style;
+
+let make =
+    (
+      ~key=?,
+      ~boxShadow,
+      children,
+    ) =>
+  component(~key?, hooks =>
+    (
+      hooks,
+      {
+        make: () => {
+          let styles = Style.make(~boxShadow, ());
+          let node = PrimitiveNodeFactory.get().createViewNode();
+          node#setStyle(styles);
+          node;
+        },
+        configureInstance: (~isFirstRender as _, node) => {
+          let styles = Style.make(~boxShadow, ());
+          node#setStyle(styles);
+          node;
+        },
+        children,
+      },
+    )
+  );
+
+let createElement =
+    (
+      ~boxShadow=BoxShadow.make(),
+      ~children,
+      (),
+    ) =>
+  make(
+    ~boxShadow,
+    React.listToElement(children),
+  );

--- a/src/UI_Primitives/Padding.re
+++ b/src/UI_Primitives/Padding.re
@@ -1,0 +1,41 @@
+open Revery_UI;
+let component = React.nativeComponent("Padding");
+
+open Style;
+
+let make =
+    (
+      ~key=?,
+      ~padding,
+      children,
+    ) =>
+  component(~key?, hooks =>
+    (
+      hooks,
+      {
+        make: () => {
+          let styles = Style.make(~padding, ());
+          let node = PrimitiveNodeFactory.get().createViewNode();
+          node#setStyle(styles);
+          node;
+        },
+        configureInstance: (~isFirstRender as _, node) => {
+          let styles = Style.make(~padding, ());
+          node#setStyle(styles);
+          node;
+        },
+        children,
+      },
+    )
+  );
+
+let createElement =
+    (
+      ~padding,
+      ~children,
+      (),
+    ) =>
+  make(
+    ~padding,
+    React.listToElement(children),
+  );

--- a/src/UI_Primitives/Padding.re
+++ b/src/UI_Primitives/Padding.re
@@ -1,8 +1,6 @@
 open Revery_UI;
 let component = React.nativeComponent("Padding");
 
-open Style;
-
 let make = (~key=?, ~padding, children) =>
   component(~key?, hooks =>
     (

--- a/src/UI_Primitives/Padding.re
+++ b/src/UI_Primitives/Padding.re
@@ -3,12 +3,7 @@ let component = React.nativeComponent("Padding");
 
 open Style;
 
-let make =
-    (
-      ~key=?,
-      ~padding,
-      children,
-    ) =>
+let make = (~key=?, ~padding, children) =>
   component(~key?, hooks =>
     (
       hooks,
@@ -29,13 +24,5 @@ let make =
     )
   );
 
-let createElement =
-    (
-      ~padding,
-      ~children,
-      (),
-    ) =>
-  make(
-    ~padding,
-    React.listToElement(children),
-  );
+let createElement = (~padding, ~children, ()) =>
+  make(~padding, React.listToElement(children));

--- a/src/UI_Primitives/Revery_UI_Primitives.re
+++ b/src/UI_Primitives/Revery_UI_Primitives.re
@@ -4,8 +4,10 @@
  * Top-level API exposed for Revery.UI Primitives
  */
 
+module BoxShadow = BoxShadow;
 module PrimitiveNodeFactory = PrimitiveNodeFactory;
 module Image = Image;
 module OpenGL = OpenGL;
+module Padding = Padding;
 module Text = Text;
 module View = View;


### PR DESCRIPTION
This is a small, incremental change towards #489 - moving the `boxshadow` style to a component.

This also splits out a basic `<Padding />` component - although padding needs some additional properties (`left`, `right`, `top`, `bottom`, `horizontal`, `vertical`...)