### PR TITLE
bugfix: Key.toString(KEY_TAB) does not return correct value

### DIFF
--- a/src/Core/Key.re
+++ b/src/Core/Key.re
@@ -126,6 +126,7 @@ type t =
 let toString = key =>
   switch (key) {
   | KEY_SPACE => " "
+  | KEY_TAB => "\t"
   | KEY_APOSTROPHE => "'"
   | KEY_COMMA => ","
   | KEY_MINUS => "-"


### PR DESCRIPTION
`Key.toString(KEY_TAB` should return `"\t"`, but it just returns an empty string. This was causing issues in resolving the tab key for bindings in Onivim 2.