### PR TITLE
API: Font resolution

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a5f42749fb240ba1a25ad6530c3906a6",
+  "checksum": "ad0bf6efce7e90e4c2f8831c5c20b7f5",
   "root": "revery@link-dev:./package.json",
   "node": {
     "revery@link-dev:./package.json": {
@@ -17,7 +17,8 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-glfw@3.2.1029@d41d8cd9",
         "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "reason-fontkit@2.6.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
+        "reason-fontkit@2.6.0@d41d8cd9",
+        "reason-font-manager@2.0.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "flex@1.2.2@d41d8cd9", "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@3f2cb6e0",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
@@ -190,6 +191,26 @@
         "reason-gl-matrix@0.9.9305@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
+        "@esy-ocaml/reason@3.5.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "reason-font-manager@2.0.0@d41d8cd9": {
+      "id": "reason-font-manager@2.0.0@d41d8cd9",
+      "name": "reason-font-manager",
+      "version": "2.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/reason-font-manager/-/reason-font-manager-2.0.0.tgz#sha1:eb59d070fa1f3e5f75864cd1f68ac832e4b4557a"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
+        "@reason-native/rely@3.1.0@d41d8cd9",
+        "@reason-native/pastel@0.1.0@d41d8cd9",
+        "@reason-native/console@0.0.3@d41d8cd9",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
       ],
       "devDependencies": []

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "eafc65e13595e037c479a0e941c12792",
+  "checksum": "4407b90b86a4d04315d3a090f85ef57e",
   "root": "revery@link-dev:./package.json",
   "node": {
     "wordwrap@0.0.3@d41d8cd9": {
@@ -59,7 +59,8 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-glfw@3.2.1029@d41d8cd9",
         "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "reason-fontkit@2.6.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
+        "reason-fontkit@2.6.0@d41d8cd9",
+        "reason-font-manager@2.0.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "http-server@0.11.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/odoc@opam:1.4.1@becd49d1",
@@ -248,6 +249,26 @@
         "reason-gl-matrix@0.9.9305@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
+        "@esy-ocaml/reason@3.5.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "reason-font-manager@2.0.0@d41d8cd9": {
+      "id": "reason-font-manager@2.0.0@d41d8cd9",
+      "name": "reason-font-manager",
+      "version": "2.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/reason-font-manager/-/reason-font-manager-2.0.0.tgz#sha1:eb59d070fa1f3e5f75864cd1f68ac832e4b4557a"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
+        "@reason-native/rely@3.1.0@d41d8cd9",
+        "@reason-native/pastel@0.1.0@d41d8cd9",
+        "@reason-native/console@0.0.3@d41d8cd9",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
       ],
       "devDependencies": []
@@ -470,7 +491,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "requires-port@1.0.0@d41d8cd9", "follow-redirects@1.7.0@d41d8cd9",
+        "requires-port@1.0.0@d41d8cd9", "follow-redirects@1.8.1@d41d8cd9",
         "eventemitter3@3.1.2@d41d8cd9"
       ],
       "devDependencies": []
@@ -489,14 +510,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "follow-redirects@1.7.0@d41d8cd9": {
-      "id": "follow-redirects@1.7.0@d41d8cd9",
+    "follow-redirects@1.8.1@d41d8cd9": {
+      "id": "follow-redirects@1.8.1@d41d8cd9",
       "name": "follow-redirects",
-      "version": "1.7.0",
+      "version": "1.8.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz#sha1:489ebc198dc0e7f64167bd23b03c4c19b5784c76"
+          "archive:https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.8.1.tgz#sha1:24804f9eaab67160b0e840c085885d606371a35b"
         ]
       },
       "overrides": [],

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a5f42749fb240ba1a25ad6530c3906a6",
+  "checksum": "ad0bf6efce7e90e4c2f8831c5c20b7f5",
   "root": "revery@link-dev:./package.json",
   "node": {
     "revery@link-dev:./package.json": {
@@ -17,7 +17,8 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-glfw@3.2.1029@d41d8cd9",
         "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "reason-fontkit@2.6.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
+        "reason-fontkit@2.6.0@d41d8cd9",
+        "reason-font-manager@2.0.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "flex@1.2.2@d41d8cd9", "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@3f2cb6e0",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
@@ -190,6 +191,26 @@
         "reason-gl-matrix@0.9.9305@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
+        "@esy-ocaml/reason@3.5.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "reason-font-manager@2.0.0@d41d8cd9": {
+      "id": "reason-font-manager@2.0.0@d41d8cd9",
+      "name": "reason-font-manager",
+      "version": "2.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/reason-font-manager/-/reason-font-manager-2.0.0.tgz#sha1:eb59d070fa1f3e5f75864cd1f68ac832e4b4557a"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
+        "@reason-native/rely@3.1.0@d41d8cd9",
+        "@reason-native/pastel@0.1.0@d41d8cd9",
+        "@reason-native/console@0.0.3@d41d8cd9",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
       ],
       "devDependencies": []

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -59,6 +59,7 @@ let state: state = {
       source: "Boxshadow.re",
     },
     {name: "Focus", render: _ => FocusExample.render(), source: "Focus.re"},
+    {name: "Fonts", render: _ => FontsExample.render(), source: "Fonts.re"},
     {
       name: "Stopwatch",
       render: _ => Stopwatch.render(),

--- a/examples/FontsExample.re
+++ b/examples/FontsExample.re
@@ -1,0 +1,154 @@
+open Revery;
+open Revery.UI;
+open Revery.UI.Components;
+
+module FontComponent = {
+  type state = {
+    family: string,
+    mono: bool,
+    bold: bool,
+    italic: bool,
+    resolvedFont: option(Font.t),
+  };
+
+  let initialState: state = {
+    family: "Arial",
+    mono: false,
+    bold: false,
+    italic: false,
+    resolvedFont: None,
+  };
+
+  type actions =
+    | SetBold(bool)
+    | SetMono(bool)
+    | SetItalic(bool)
+    | SetFamily(string);
+
+  let reducer = (action: actions, state: state) => {
+    let state =
+      switch (action) {
+      | SetBold(v) => {...state, bold: v}
+      | SetMono(v) => {...state, mono: v}
+      | SetItalic(v) => {...state, italic: v}
+      | SetFamily(v) => {...state, family: v}
+      };
+
+    let resolvedFont =
+      Some(
+        Font.find(
+          ~weight=state.bold ? Font.Weight.Bold : Font.Weight.Normal,
+          ~mono=state.mono,
+          ~italic=state.italic,
+          state.family,
+        ),
+      );
+
+    switch (resolvedFont) {
+    | Some(v) => print_endline("New font: " ++ Font.show(v))
+    | None => ()
+    };
+
+    {...state, resolvedFont};
+  };
+
+  let component = React.component("Font");
+
+  let createElement = (~children as _, ()) =>
+    component(hooks => {
+      let (state, dispatch, hooks) =
+        Hooks.reducer(initialState, reducer, hooks);
+
+      let fontExample =
+        switch (state.resolvedFont) {
+        | None => React.empty
+        | Some(v) =>
+          <Text
+            text="Lorem ipsum dolor sit amet"
+            style=Style.[fontFamily(v.path), fontSize(24)]
+          />
+        };
+
+      (
+        hooks,
+        <Container width=500 height=500>
+          <Center>
+            <Padding padding=10>
+              <Row>
+                <Input
+                  placeholder="Type font name"
+                  onChange={({value, _}) => dispatch(SetFamily(value))}
+                  value={state.family}
+                />
+              </Row>
+            </Padding>
+            <Padding padding=10>
+              <Row>
+                <Padding padding=16>
+                  <Checkbox
+                    checked={state.bold}
+                    onChange={() => dispatch(SetBold(!state.bold))}
+                  />
+                </Padding>
+                <Center>
+                  <Text
+                    text="Bold"
+                    style=Style.[
+                      fontFamily("Roboto-Regular.ttf"),
+                      fontSize(20),
+                      width(150),
+                    ]
+                  />
+                </Center>
+              </Row>
+            </Padding>
+            <Padding padding=10>
+              <Row>
+                <Padding padding=16>
+                  <Checkbox
+                    checked={state.italic}
+                    onChange={() => dispatch(SetItalic(!state.italic))}
+                  />
+                </Padding>
+                <Center>
+                  <Text
+                    text="Italic"
+                    style=Style.[
+                      fontFamily("Roboto-Regular.ttf"),
+                      fontSize(20),
+                      width(150),
+                    ]
+                  />
+                </Center>
+              </Row>
+            </Padding>
+            <Padding padding=10>
+              <Row>
+                <Padding padding=16>
+                  <Checkbox
+                    checked={state.mono}
+                    onChange={() => dispatch(SetMono(!state.mono))}
+                  />
+                </Padding>
+                <Center>
+                  <Text
+                    text="Mono"
+                    style=Style.[
+                      fontFamily("Roboto-Regular.ttf"),
+                      fontSize(20),
+                      width(150),
+                    ]
+                  />
+                </Center>
+              </Row>
+            </Padding>
+            <Padding padding=16> <Row> fontExample </Row> </Padding>
+          </Center>
+        </Container>,
+      );
+    });
+};
+
+let render = () => {
+  <FontComponent />;
+};

--- a/examples/FontsExample.re
+++ b/examples/FontsExample.re
@@ -57,7 +57,7 @@ module FontComponent = {
   let createElement = (~children as _, ()) =>
     component(hooks => {
       let (state, dispatch, hooks) =
-        Hooks.reducer(initialState, reducer, hooks);
+        Hooks.reducer(~initialState, reducer, hooks);
 
       let fontExample =
         switch (state.resolvedFont) {

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5c33a9261d7fa6ae9c0c38f46034d830",
+  "checksum": "513cabf20b3e715bb8d0cbcebbf79b60",
   "root": "revery@link-dev:./package.json",
   "node": {
     "wordwrap@0.0.3@d41d8cd9": {
@@ -59,7 +59,8 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-glfw@3.2.1029@d41d8cd9",
         "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "reason-fontkit@2.6.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
+        "reason-fontkit@2.6.0@d41d8cd9",
+        "reason-font-manager@2.0.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "http-server@0.11.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/merlin-extend@opam:0.4@64c45329",
@@ -248,6 +249,26 @@
         "reason-gl-matrix@0.9.9305@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
+        "@esy-ocaml/reason@3.5.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "reason-font-manager@2.0.0@d41d8cd9": {
+      "id": "reason-font-manager@2.0.0@d41d8cd9",
+      "name": "reason-font-manager",
+      "version": "2.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/reason-font-manager/-/reason-font-manager-2.0.0.tgz#sha1:eb59d070fa1f3e5f75864cd1f68ac832e4b4557a"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
+        "@reason-native/rely@3.1.0@d41d8cd9",
+        "@reason-native/pastel@0.1.0@d41d8cd9",
+        "@reason-native/console@0.0.3@d41d8cd9",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
       ],
       "devDependencies": []
@@ -470,7 +491,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "requires-port@1.0.0@d41d8cd9", "follow-redirects@1.7.0@d41d8cd9",
+        "requires-port@1.0.0@d41d8cd9", "follow-redirects@1.8.1@d41d8cd9",
         "eventemitter3@3.1.2@d41d8cd9"
       ],
       "devDependencies": []
@@ -489,14 +510,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "follow-redirects@1.7.0@d41d8cd9": {
-      "id": "follow-redirects@1.7.0@d41d8cd9",
+    "follow-redirects@1.8.1@d41d8cd9": {
+      "id": "follow-redirects@1.8.1@d41d8cd9",
       "name": "follow-redirects",
-      "version": "1.7.0",
+      "version": "1.8.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz#sha1:489ebc198dc0e7f64167bd23b03c4c19b5784c76"
+          "archive:https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.8.1.tgz#sha1:24804f9eaab67160b0e840c085885d606371a35b"
         ]
       },
       "overrides": [],

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "flex": "^1.2.2",
     "reperf": "^1.4.0",
     "@reason-native/console": "^0.0.3",
-    "rench": "^1.9.0"
+    "rench": "^1.9.0",
+    "reason-font-manager": "*",
   },
   "resolutions": {
     "rebez": "github:jchavarri/rebez#46cbc183",
@@ -46,7 +47,8 @@
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
     "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#dd933fc",
-    "pesy": "0.4.1"
+    "pesy": "0.4.1",
+    "reason-font-manager": "link:../reason-font-manager"
   },
   "peerDependencies": {
     "ocaml": ">=4.6.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "reperf": "^1.4.0",
     "@reason-native/console": "^0.0.3",
     "rench": "^1.9.0",
-    "reason-font-manager": "*",
+    "reason-font-manager": "^2.0.0"
   },
   "resolutions": {
     "rebez": "github:jchavarri/rebez#46cbc183",
@@ -47,8 +47,7 @@
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
     "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#dd933fc",
-    "pesy": "0.4.1",
-    "reason-font-manager": "link:../reason-font-manager"
+    "pesy": "0.4.1"
   },
   "peerDependencies": {
     "ocaml": ">=4.6.0"

--- a/src/Font/Discovery.re
+++ b/src/Font/Discovery.re
@@ -1,0 +1,17 @@
+/**
+    Discovery.re
+
+*/
+open FontManager;
+
+let find =
+    (
+      ~weight=FontWeight.Bold,
+      ~width=FontWidth.Undefined,
+      ~mono=false,
+      ~italic=false,
+      family,
+    ) =>
+  FontManager.findFont(~weight, ~width, ~mono, ~italic, ~family, ());
+
+let show = FontManager.FontDescriptor.show;

--- a/src/Font/Revery_Font.re
+++ b/src/Font/Revery_Font.re
@@ -6,4 +6,17 @@
     - Loading fonts
 */
 
-module Discovery = Discovery;
+module FontWeight = FontManager.FontWeight;
+module FontWidth = FontManager.FontWidth;
+
+type t = FontManager.FontDescriptor.t;
+
+let find = (
+    ~weight=FontWeight.Bold, 
+    ~width=FontWidth.Undefined,
+    ~mono=false,
+    ~italic=false,
+    family) => 
+        FontManager.findFont(~weight, ~width, ~mono, ~italic, ~family, ());
+        
+let show = FontManager.FontDescriptor.show;

--- a/src/Font/Revery_Font.re
+++ b/src/Font/Revery_Font.re
@@ -1,22 +1,15 @@
-/**
-    Revery_Font.re
-
-    Module exposing font-related functionality, like:
-    - Discovering fonts
-    - Loading fonts
-*/
-
-module FontWeight = FontManager.FontWeight;
-module FontWidth = FontManager.FontWidth;
-
-type t = FontManager.FontDescriptor.t;
-
-let find = (
-    ~weight=FontWeight.Bold, 
-    ~width=FontWidth.Undefined,
-    ~mono=false,
-    ~italic=false,
-    family) => 
-        FontManager.findFont(~weight, ~width, ~mono, ~italic, ~family, ());
-        
-let show = FontManager.FontDescriptor.show;
+/**
+    Revery_Font.re
+
+    Module exposing font-related functionality, like:
+    - Discovering fonts
+    - Loading fonts
+*/
+module Weight = FontManager.FontWeight;
+module Width = FontManager.FontWidth;
+module Discovery = Discovery;
+
+type t = FontManager.FontDescriptor.t;
+
+let find = Discovery.find;
+let show = Discovery.show;

--- a/src/Font/Revery_Font.re
+++ b/src/Font/Revery_Font.re
@@ -1,0 +1,9 @@
+/**
+    Revery_Font.re
+
+    Module exposing font-related functionality, like:
+    - Discovering fonts
+    - Loading fonts
+*/
+
+module Discovery = Discovery;

--- a/src/Font/dune
+++ b/src/Font/dune
@@ -2,4 +2,4 @@
     (name Revery_Font)
     (public_name Revery.Font)
     (preprocess (pps lwt_ppx))
-    (libraries brisk-reconciler lwt lwt.unix reglfw flex fontkit rebez.lib Revery_Core Revery_Shaders Revery_Geometry Revery_Math))
+    (libraries reason-font-manager lwt lwt.unix reglfw flex fontkit rebez.lib Revery_Core Revery_Shaders Revery_Geometry Revery_Math))

--- a/src/Font/dune
+++ b/src/Font/dune
@@ -1,0 +1,5 @@
+(library
+    (name Revery_Font)
+    (public_name Revery.Font)
+    (preprocess (pps lwt_ppx))
+    (libraries brisk-reconciler lwt lwt.unix reglfw flex fontkit rebez.lib Revery_Core Revery_Shaders Revery_Geometry Revery_Math))

--- a/src/Revery.re
+++ b/src/Revery.re
@@ -7,6 +7,7 @@ include Revery_Core;
 /* Courtesy of @reason-native/console - a console-like API for native! */
 module Console = Console;
 
+module Font = Revery_Font;
 module Draw = Revery_Draw;
 module Geometry = Revery_Geometry;
 module Math = Revery_Math;

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
     (name Revery)
     (public_name Revery)
-    (libraries console.lib lwt lwt.unix reglfw Revery_Core Revery_Draw Revery_Math Revery_Shaders Revery_Geometry Revery_UI Revery_UI_Components Revery_Native Revery_UI_Primitives Revery_UI_Hooks))
+    (libraries console.lib lwt lwt.unix reglfw Revery_Core Revery_Font Revery_Draw Revery_Math Revery_Shaders Revery_Geometry Revery_UI Revery_UI_Components Revery_Native Revery_UI_Primitives Revery_UI_Hooks))
 
 (documentation
    (package Revery)

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a5f42749fb240ba1a25ad6530c3906a6",
+  "checksum": "ad0bf6efce7e90e4c2f8831c5c20b7f5",
   "root": "revery@link-dev:./package.json",
   "node": {
     "revery@link-dev:./package.json": {
@@ -17,7 +17,8 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-glfw@3.2.1029@d41d8cd9",
         "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "reason-fontkit@2.6.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
+        "reason-fontkit@2.6.0@d41d8cd9",
+        "reason-font-manager@2.0.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "flex@1.2.2@d41d8cd9", "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@3f2cb6e0",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
@@ -190,6 +191,26 @@
         "reason-gl-matrix@0.9.9305@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
+        "@esy-ocaml/reason@3.5.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "reason-font-manager@2.0.0@d41d8cd9": {
+      "id": "reason-font-manager@2.0.0@d41d8cd9",
+      "name": "reason-font-manager",
+      "version": "2.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/reason-font-manager/-/reason-font-manager-2.0.0.tgz#sha1:eb59d070fa1f3e5f75864cd1f68ac832e4b4557a"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
+        "@reason-native/rely@3.1.0@d41d8cd9",
+        "@reason-native/pastel@0.1.0@d41d8cd9",
+        "@reason-native/console@0.0.3@d41d8cd9",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
       ],
       "devDependencies": []


### PR DESCRIPTION
A major limitation of Revery today is that fonts need to be specified via a direct path to a font file (ttf, otf, etc).

This integrates https://github.com/revery-ui/reason-font-manager so that we can now do font discovery - given a font name + some parameters (bold, italic, etc) - we can search and resolve the font.

There is still some work that should be done, like caching results, asynchronous API, and hooking up to the font rendering - but this sets up the foundation for it.