### PR TITLE
API - App: Add flushPendingCallbacks API

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -58,6 +58,8 @@ let _doPendingMainThreadJobs = () => {
   jobs |> List.rev |> List.iter(f => f());
 };
 
+let flushPendingcallbacks = _doPendingMainThreadJobs();
+
 let createWindow =
     (~createOptions=WindowCreateOptions.default, app: t, windowName) => {
   let w = Window.create(windowName, createOptions);

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -58,7 +58,7 @@ let _doPendingMainThreadJobs = () => {
   jobs |> List.rev |> List.iter(f => f());
 };
 
-let flushPendingcallbacks = _doPendingMainThreadJobs();
+let flushPendingCallbacks = () => _doPendingMainThreadJobs();
 
 let createWindow =
     (~createOptions=WindowCreateOptions.default, app: t, windowName) => {

--- a/src/Core/App.rei
+++ b/src/Core/App.rei
@@ -23,9 +23,20 @@ type delegatedFunc = unit => unit;
 /** [runOnMainThread(f)] schedules the function [f] to run during the next
     render frame on the main thread.
 
-    If the main thread is idle, this will force the main thread to render
+    If the application is idle, this will cause it to become active, and trigger a re-render.
 */
 let runOnMainThread: delegatedFunc => unit;
+
+/** [flushPendingCallbacks(f)] will explicitly run all the callbacks
+    queued up via [runOnMainThread].
+
+    In general, this should not need to be called by user code,
+    as it happens as part of the application lifecycle.
+
+    However, it may be necessary to call this for tests that queue
+    up callbacks via [runOnMainThread].
+*/
+let flushPendingCallbacks: unit => unit;
 
 /** [setCanIdle(f, app)] registers a callback [f]. Each frame, [f] will be called
  to check if the application can idle. If [f()] returns [false], the app will not


### PR DESCRIPTION
Required by https://github.com/onivim/oni2/pull/715 so that we can fully exercise the code.

In that test case, there is some product code that queues up some code to run on the main thread via `Revery.App.runOnMainThread`. However, there is no app started in the test - so the callback never executes.

This adds a way to explicitly flush those queued up calls and enable the test.