### PR TITLE
Dependency: reason-fontkit -> 2.7.0

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "2e9b903ca21f9858f0a4730a35f6bde0",
+  "checksum": "85570b7507d09b3a6ebbbe6c5773c3ab",
   "root": "revery@link-dev:./package.json",
   "node": {
     "revery@link-dev:./package.json": {
@@ -18,10 +18,10 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-glfw@3.2.1029@d41d8cd9",
         "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "reason-fontkit@2.6.0@d41d8cd9",
+        "reason-fontkit@2.7.0@d41d8cd9",
         "reason-font-manager@2.0.0@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
@@ -66,7 +66,7 @@
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "@reason-native/rely@3.1.0@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/lambda-term@opam:2.0.2@119fb081",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
@@ -88,7 +88,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/lambda-term@opam:2.0.2@119fb081",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
@@ -149,7 +149,7 @@
         "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
         "ocaml@4.8.1000@d41d8cd9", "esy-glfw@3.2.1010@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/lwt_ppx@opam:1.2.3@22f5b56c",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
@@ -176,20 +176,19 @@
       ],
       "devDependencies": []
     },
-    "reason-fontkit@2.6.0@d41d8cd9": {
-      "id": "reason-fontkit@2.6.0@d41d8cd9",
+    "reason-fontkit@2.7.0@d41d8cd9": {
+      "id": "reason-fontkit@2.7.0@d41d8cd9",
       "name": "reason-fontkit",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-fontkit/-/reason-fontkit-2.6.0.tgz#sha1:498d8599bcf171e26d925dde9b739ba647a80b86"
+          "archive:https://registry.npmjs.org/reason-fontkit/-/reason-fontkit-2.7.0.tgz#sha1:0ce9caa8347ffb28735199be195c692603dfb50d"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.2.2@d41d8cd9", "reason-glfw@3.2.1029@d41d8cd9",
-        "reason-gl-matrix@0.9.9305@d41d8cd9",
+        "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
@@ -1001,12 +1000,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/lwt_ppx@opam:1.2.3@22f5b56c": {
@@ -1030,14 +1029,14 @@
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
         "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
         "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/lwt_log@opam:1.1.1@2d7a797f": {
@@ -1058,15 +1057,15 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/lwt@opam:4.3.0@3f2cb6e0": {
-      "id": "@opam/lwt@opam:4.3.0@3f2cb6e0",
+    "@opam/lwt@opam:4.3.0@865b709c": {
+      "id": "@opam/lwt@opam:4.3.0@865b709c",
       "name": "@opam/lwt",
       "version": "opam:4.3.0",
       "source": {
@@ -1086,8 +1085,9 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
         "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@b85334ff", "@opam/dune@opam:1.11.3@9894df55",
-        "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/mmap@opam:1.1.0@b85334ff",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
+        "@opam/dune@opam:1.11.3@9894df55", "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/base-threads@opam:base@36803084",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1096,7 +1096,9 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
         "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@b85334ff", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/mmap@opam:1.1.0@b85334ff",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
+        "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/lambda-term@opam:2.0.2@119fb081": {
@@ -1120,7 +1122,7 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.3@62853a38",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/dune@opam:1.11.3@9894df55",
         "@opam/camomile@opam:1.0.2@51b42ad8",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1129,7 +1131,7 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.3@62853a38",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/dune@opam:1.11.3@9894df55",
         "@opam/camomile@opam:1.0.2@51b42ad8"
       ]
@@ -1211,13 +1213,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/lwt_log@opam:1.1.1@2d7a797f",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
         "@opam/dune@opam:1.11.3@9894df55"
@@ -1390,6 +1392,25 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
       ]
+    },
+    "@opam/dune-configurator@opam:1.0.0@4873acd8": {
+      "id": "@opam/dune-configurator@opam:1.0.0@4873acd8",
+      "name": "@opam/dune-configurator",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "dune-configurator",
+          "version": "1.0.0",
+          "path": "bench.esy.lock/opam/dune-configurator.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "@opam/dune@opam:1.11.3@9894df55" ]
     },
     "@opam/dune@opam:1.11.3@9894df55": {
       "id": "@opam/dune@opam:1.11.3@9894df55",

--- a/bench.esy.lock/opam/dune-configurator.1.0.0/opam
+++ b/bench.esy.lock/opam/dune-configurator.1.0.0/opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+maintainer: "Jérémie Dimino"
+description: """
+dune.configurator library distributed with Dune 1.x
+"""
+depends: ["dune" {<"2.0.0"}]

--- a/bench.esy.lock/opam/lwt.4.3.0/opam
+++ b/bench.esy.lock/opam/lwt.4.3.0/opam
@@ -20,6 +20,7 @@ dev-repo: "git+https://github.com/ocsigen/lwt.git"
 depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.7.0"}
+  "dune-configurator"
   "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
   "ocaml" {>= "4.02.0"}
   "ocplib-endian"

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b27bd06b64abd6cc4d64b90b2d04f7d9",
+  "checksum": "dd77cc33b71198b19f5468f23e1c79c0",
   "root": "revery@link-dev:./package.json",
   "node": {
     "wordwrap@0.0.3@d41d8cd9": {
@@ -60,11 +60,11 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-glfw@3.2.1029@d41d8cd9",
         "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "reason-fontkit@2.6.0@d41d8cd9",
+        "reason-fontkit@2.7.0@d41d8cd9",
         "reason-font-manager@2.0.0@d41d8cd9", "http-server@0.11.1@d41d8cd9",
         "flex@1.2.2@d41d8cd9", "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/odoc@opam:1.4.2@187ed639",
-        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
@@ -123,7 +123,7 @@
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "@reason-native/rely@3.1.0@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/lambda-term@opam:2.0.2@119fb081",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
@@ -145,7 +145,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/lambda-term@opam:2.0.2@119fb081",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
@@ -206,7 +206,7 @@
         "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
         "ocaml@4.8.1000@d41d8cd9", "esy-glfw@3.2.1010@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/lwt_ppx@opam:1.2.3@22f5b56c",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
@@ -233,20 +233,19 @@
       ],
       "devDependencies": []
     },
-    "reason-fontkit@2.6.0@d41d8cd9": {
-      "id": "reason-fontkit@2.6.0@d41d8cd9",
+    "reason-fontkit@2.7.0@d41d8cd9": {
+      "id": "reason-fontkit@2.7.0@d41d8cd9",
       "name": "reason-fontkit",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-fontkit/-/reason-fontkit-2.6.0.tgz#sha1:498d8599bcf171e26d925dde9b739ba647a80b86"
+          "archive:https://registry.npmjs.org/reason-fontkit/-/reason-fontkit-2.7.0.tgz#sha1:0ce9caa8347ffb28735199be195c692603dfb50d"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.2.2@d41d8cd9", "reason-glfw@3.2.1029@d41d8cd9",
-        "reason-gl-matrix@0.9.9305@d41d8cd9",
+        "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
@@ -1411,12 +1410,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/lwt_ppx@opam:1.2.3@22f5b56c": {
@@ -1440,14 +1439,14 @@
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
         "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
         "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/lwt_log@opam:1.1.1@2d7a797f": {
@@ -1468,15 +1467,15 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/lwt@opam:4.3.0@3f2cb6e0": {
-      "id": "@opam/lwt@opam:4.3.0@3f2cb6e0",
+    "@opam/lwt@opam:4.3.0@865b709c": {
+      "id": "@opam/lwt@opam:4.3.0@865b709c",
       "name": "@opam/lwt",
       "version": "opam:4.3.0",
       "source": {
@@ -1496,8 +1495,9 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
         "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@b85334ff", "@opam/dune@opam:1.11.3@9894df55",
-        "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/mmap@opam:1.1.0@b85334ff",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
+        "@opam/dune@opam:1.11.3@9894df55", "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/base-threads@opam:base@36803084",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1506,7 +1506,9 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
         "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@b85334ff", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/mmap@opam:1.1.0@b85334ff",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
+        "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/lambda-term@opam:2.0.2@119fb081": {
@@ -1530,7 +1532,7 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.3@62853a38",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/dune@opam:1.11.3@9894df55",
         "@opam/camomile@opam:1.0.2@51b42ad8",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1539,7 +1541,7 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.3@62853a38",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/dune@opam:1.11.3@9894df55",
         "@opam/camomile@opam:1.0.2@51b42ad8"
       ]
@@ -1621,13 +1623,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/lwt_log@opam:1.1.1@2d7a797f",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
         "@opam/dune@opam:1.11.3@9894df55"
@@ -1800,6 +1802,25 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
       ]
+    },
+    "@opam/dune-configurator@opam:1.0.0@4873acd8": {
+      "id": "@opam/dune-configurator@opam:1.0.0@4873acd8",
+      "name": "@opam/dune-configurator",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "dune-configurator",
+          "version": "1.0.0",
+          "path": "doc.esy.lock/opam/dune-configurator.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "@opam/dune@opam:1.11.3@9894df55" ]
     },
     "@opam/dune@opam:1.11.3@9894df55": {
       "id": "@opam/dune@opam:1.11.3@9894df55",

--- a/doc.esy.lock/opam/dune-configurator.1.0.0/opam
+++ b/doc.esy.lock/opam/dune-configurator.1.0.0/opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+maintainer: "Jérémie Dimino"
+description: """
+dune.configurator library distributed with Dune 1.x
+"""
+depends: ["dune" {<"2.0.0"}]

--- a/doc.esy.lock/opam/lwt.4.3.0/opam
+++ b/doc.esy.lock/opam/lwt.4.3.0/opam
@@ -20,6 +20,7 @@ dev-repo: "git+https://github.com/ocsigen/lwt.git"
 depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.7.0"}
+  "dune-configurator"
   "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
   "ocaml" {>= "4.02.0"}
   "ocplib-endian"

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "2e9b903ca21f9858f0a4730a35f6bde0",
+  "checksum": "85570b7507d09b3a6ebbbe6c5773c3ab",
   "root": "revery@link-dev:./package.json",
   "node": {
     "revery@link-dev:./package.json": {
@@ -18,10 +18,10 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-glfw@3.2.1029@d41d8cd9",
         "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "reason-fontkit@2.6.0@d41d8cd9",
+        "reason-fontkit@2.7.0@d41d8cd9",
         "reason-font-manager@2.0.0@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
@@ -66,7 +66,7 @@
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "@reason-native/rely@3.1.0@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/lambda-term@opam:2.0.2@119fb081",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
@@ -88,7 +88,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/lambda-term@opam:2.0.2@119fb081",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
@@ -149,7 +149,7 @@
         "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
         "ocaml@4.8.1000@d41d8cd9", "esy-glfw@3.2.1010@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/lwt_ppx@opam:1.2.3@22f5b56c",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
@@ -176,20 +176,19 @@
       ],
       "devDependencies": []
     },
-    "reason-fontkit@2.6.0@d41d8cd9": {
-      "id": "reason-fontkit@2.6.0@d41d8cd9",
+    "reason-fontkit@2.7.0@d41d8cd9": {
+      "id": "reason-fontkit@2.7.0@d41d8cd9",
       "name": "reason-fontkit",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-fontkit/-/reason-fontkit-2.6.0.tgz#sha1:498d8599bcf171e26d925dde9b739ba647a80b86"
+          "archive:https://registry.npmjs.org/reason-fontkit/-/reason-fontkit-2.7.0.tgz#sha1:0ce9caa8347ffb28735199be195c692603dfb50d"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.2.2@d41d8cd9", "reason-glfw@3.2.1029@d41d8cd9",
-        "reason-gl-matrix@0.9.9305@d41d8cd9",
+        "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
@@ -1001,12 +1000,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/lwt_ppx@opam:1.2.3@22f5b56c": {
@@ -1030,14 +1029,14 @@
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
         "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
         "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/lwt_log@opam:1.1.1@2d7a797f": {
@@ -1058,15 +1057,15 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/lwt@opam:4.3.0@3f2cb6e0": {
-      "id": "@opam/lwt@opam:4.3.0@3f2cb6e0",
+    "@opam/lwt@opam:4.3.0@865b709c": {
+      "id": "@opam/lwt@opam:4.3.0@865b709c",
       "name": "@opam/lwt",
       "version": "opam:4.3.0",
       "source": {
@@ -1086,8 +1085,9 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
         "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@b85334ff", "@opam/dune@opam:1.11.3@9894df55",
-        "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/mmap@opam:1.1.0@b85334ff",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
+        "@opam/dune@opam:1.11.3@9894df55", "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/base-threads@opam:base@36803084",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1096,7 +1096,9 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
         "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@b85334ff", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/mmap@opam:1.1.0@b85334ff",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
+        "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/lambda-term@opam:2.0.2@119fb081": {
@@ -1120,7 +1122,7 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.3@62853a38",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/dune@opam:1.11.3@9894df55",
         "@opam/camomile@opam:1.0.2@51b42ad8",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1129,7 +1131,7 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.3@62853a38",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/dune@opam:1.11.3@9894df55",
         "@opam/camomile@opam:1.0.2@51b42ad8"
       ]
@@ -1211,13 +1213,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/lwt_log@opam:1.1.1@2d7a797f",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
         "@opam/dune@opam:1.11.3@9894df55"
@@ -1390,6 +1392,25 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
       ]
+    },
+    "@opam/dune-configurator@opam:1.0.0@4873acd8": {
+      "id": "@opam/dune-configurator@opam:1.0.0@4873acd8",
+      "name": "@opam/dune-configurator",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "dune-configurator",
+          "version": "1.0.0",
+          "path": "esy.lock/opam/dune-configurator.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "@opam/dune@opam:1.11.3@9894df55" ]
     },
     "@opam/dune@opam:1.11.3@9894df55": {
       "id": "@opam/dune@opam:1.11.3@9894df55",

--- a/esy.lock/opam/dune-configurator.1.0.0/opam
+++ b/esy.lock/opam/dune-configurator.1.0.0/opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+maintainer: "Jérémie Dimino"
+description: """
+dune.configurator library distributed with Dune 1.x
+"""
+depends: ["dune" {<"2.0.0"}]

--- a/esy.lock/opam/lwt.4.3.0/opam
+++ b/esy.lock/opam/lwt.4.3.0/opam
@@ -20,6 +20,7 @@ dev-repo: "git+https://github.com/ocsigen/lwt.git"
 depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.7.0"}
+  "dune-configurator"
   "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
   "ocaml" {>= "4.02.0"}
   "ocplib-endian"

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "ee632accaa97f51a7ec8e598be8c8741",
+  "checksum": "7b0ad3a579489f38122a947f6cf2d617",
   "root": "revery@link-dev:./package.json",
   "node": {
     "wordwrap@0.0.3@d41d8cd9": {
@@ -60,11 +60,11 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-glfw@3.2.1029@d41d8cd9",
         "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "reason-fontkit@2.6.0@d41d8cd9",
+        "reason-fontkit@2.7.0@d41d8cd9",
         "reason-font-manager@2.0.0@d41d8cd9", "http-server@0.11.1@d41d8cd9",
         "flex@1.2.2@d41d8cd9", "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/merlin-extend@opam:0.4@64c45329",
-        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
@@ -123,7 +123,7 @@
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "@reason-native/rely@3.1.0@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/lambda-term@opam:2.0.2@119fb081",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
@@ -145,7 +145,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/lambda-term@opam:2.0.2@119fb081",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
@@ -206,7 +206,7 @@
         "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
         "ocaml@4.8.1000@d41d8cd9", "esy-glfw@3.2.1010@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/lwt_ppx@opam:1.2.3@22f5b56c",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
@@ -233,20 +233,19 @@
       ],
       "devDependencies": []
     },
-    "reason-fontkit@2.6.0@d41d8cd9": {
-      "id": "reason-fontkit@2.6.0@d41d8cd9",
+    "reason-fontkit@2.7.0@d41d8cd9": {
+      "id": "reason-fontkit@2.7.0@d41d8cd9",
       "name": "reason-fontkit",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-fontkit/-/reason-fontkit-2.6.0.tgz#sha1:498d8599bcf171e26d925dde9b739ba647a80b86"
+          "archive:https://registry.npmjs.org/reason-fontkit/-/reason-fontkit-2.7.0.tgz#sha1:0ce9caa8347ffb28735199be195c692603dfb50d"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.2.2@d41d8cd9", "reason-glfw@3.2.1029@d41d8cd9",
-        "reason-gl-matrix@0.9.9305@d41d8cd9",
+        "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
@@ -1382,12 +1381,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/lwt_ppx@opam:1.2.3@22f5b56c": {
@@ -1411,14 +1410,14 @@
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
         "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
         "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/lwt_log@opam:1.1.1@2d7a797f": {
@@ -1439,15 +1438,15 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/lwt@opam:4.3.0@3f2cb6e0": {
-      "id": "@opam/lwt@opam:4.3.0@3f2cb6e0",
+    "@opam/lwt@opam:4.3.0@865b709c": {
+      "id": "@opam/lwt@opam:4.3.0@865b709c",
       "name": "@opam/lwt",
       "version": "opam:4.3.0",
       "source": {
@@ -1467,8 +1466,9 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
         "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@b85334ff", "@opam/dune@opam:1.11.3@9894df55",
-        "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/mmap@opam:1.1.0@b85334ff",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
+        "@opam/dune@opam:1.11.3@9894df55", "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/base-threads@opam:base@36803084",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1477,7 +1477,9 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
         "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@b85334ff", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/mmap@opam:1.1.0@b85334ff",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
+        "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/lambda-term@opam:2.0.2@119fb081": {
@@ -1501,7 +1503,7 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.3@62853a38",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/dune@opam:1.11.3@9894df55",
         "@opam/camomile@opam:1.0.2@51b42ad8",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1510,7 +1512,7 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.3@62853a38",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/dune@opam:1.11.3@9894df55",
         "@opam/camomile@opam:1.0.2@51b42ad8"
       ]
@@ -1592,13 +1594,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/lwt_log@opam:1.1.1@2d7a797f",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
         "@opam/dune@opam:1.11.3@9894df55"
@@ -1771,6 +1773,25 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
       ]
+    },
+    "@opam/dune-configurator@opam:1.0.0@4873acd8": {
+      "id": "@opam/dune-configurator@opam:1.0.0@4873acd8",
+      "name": "@opam/dune-configurator",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "dune-configurator",
+          "version": "1.0.0",
+          "path": "js.esy.lock/opam/dune-configurator.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "@opam/dune@opam:1.11.3@9894df55" ]
     },
     "@opam/dune@opam:1.11.3@9894df55": {
       "id": "@opam/dune@opam:1.11.3@9894df55",

--- a/js.esy.lock/opam/dune-configurator.1.0.0/opam
+++ b/js.esy.lock/opam/dune-configurator.1.0.0/opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+maintainer: "Jérémie Dimino"
+description: """
+dune.configurator library distributed with Dune 1.x
+"""
+depends: ["dune" {<"2.0.0"}]

--- a/js.esy.lock/opam/lwt.4.3.0/opam
+++ b/js.esy.lock/opam/lwt.4.3.0/opam
@@ -20,6 +20,7 @@ dev-repo: "git+https://github.com/ocsigen/lwt.git"
 depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.7.0"}
+  "dune-configurator"
   "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
   "ocaml" {>= "4.02.0"}
   "ocplib-endian"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@esy-ocaml/reason": "^3.4.0",
     "reason-glfw": "^3.2.1029",
-    "reason-fontkit": "^2.6.0",
+    "reason-fontkit": "^2.7.0",
     "reason-gl-matrix": "^0.9.9305",
     "rebez": "*",
     "@opam/color": "^0.2.0",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "2e9b903ca21f9858f0a4730a35f6bde0",
+  "checksum": "85570b7507d09b3a6ebbbe6c5773c3ab",
   "root": "revery@link-dev:./package.json",
   "node": {
     "revery@link-dev:./package.json": {
@@ -18,10 +18,10 @@
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
         "reason-glfw@3.2.1029@d41d8cd9",
         "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "reason-fontkit@2.6.0@d41d8cd9",
+        "reason-fontkit@2.7.0@d41d8cd9",
         "reason-font-manager@2.0.0@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
@@ -66,7 +66,7 @@
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "@reason-native/rely@3.1.0@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/lambda-term@opam:2.0.2@119fb081",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
@@ -88,7 +88,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/lambda-term@opam:2.0.2@119fb081",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
@@ -149,7 +149,7 @@
         "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
         "ocaml@4.8.1000@d41d8cd9", "esy-glfw@3.2.1010@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/lwt_ppx@opam:1.2.3@22f5b56c",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
@@ -176,20 +176,19 @@
       ],
       "devDependencies": []
     },
-    "reason-fontkit@2.6.0@d41d8cd9": {
-      "id": "reason-fontkit@2.6.0@d41d8cd9",
+    "reason-fontkit@2.7.0@d41d8cd9": {
+      "id": "reason-fontkit@2.7.0@d41d8cd9",
       "name": "reason-fontkit",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-fontkit/-/reason-fontkit-2.6.0.tgz#sha1:498d8599bcf171e26d925dde9b739ba647a80b86"
+          "archive:https://registry.npmjs.org/reason-fontkit/-/reason-fontkit-2.7.0.tgz#sha1:0ce9caa8347ffb28735199be195c692603dfb50d"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.2.2@d41d8cd9", "reason-glfw@3.2.1029@d41d8cd9",
-        "reason-gl-matrix@0.9.9305@d41d8cd9",
+        "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
@@ -1001,12 +1000,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/lwt_ppx@opam:1.2.3@22f5b56c": {
@@ -1030,14 +1029,14 @@
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
         "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
         "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/lwt_log@opam:1.1.1@2d7a797f": {
@@ -1058,15 +1057,15 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/lwt@opam:4.3.0@865b709c", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/lwt@opam:4.3.0@3f2cb6e0": {
-      "id": "@opam/lwt@opam:4.3.0@3f2cb6e0",
+    "@opam/lwt@opam:4.3.0@865b709c": {
+      "id": "@opam/lwt@opam:4.3.0@865b709c",
       "name": "@opam/lwt",
       "version": "opam:4.3.0",
       "source": {
@@ -1086,8 +1085,9 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
         "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@b85334ff", "@opam/dune@opam:1.11.3@9894df55",
-        "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/mmap@opam:1.1.0@b85334ff",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
+        "@opam/dune@opam:1.11.3@9894df55", "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/base-threads@opam:base@36803084",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1096,7 +1096,9 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
         "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@b85334ff", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/mmap@opam:1.1.0@b85334ff",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
+        "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/lambda-term@opam:2.0.2@119fb081": {
@@ -1120,7 +1122,7 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.3@62853a38",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/dune@opam:1.11.3@9894df55",
         "@opam/camomile@opam:1.0.2@51b42ad8",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1129,7 +1131,7 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.3@62853a38",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/dune@opam:1.11.3@9894df55",
         "@opam/camomile@opam:1.0.2@51b42ad8"
       ]
@@ -1211,13 +1213,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/lwt_log@opam:1.1.1@2d7a797f",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/lwt@opam:4.3.0@865b709c",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
         "@opam/dune@opam:1.11.3@9894df55"
@@ -1390,6 +1392,25 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
       ]
+    },
+    "@opam/dune-configurator@opam:1.0.0@4873acd8": {
+      "id": "@opam/dune-configurator@opam:1.0.0@4873acd8",
+      "name": "@opam/dune-configurator",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "dune-configurator",
+          "version": "1.0.0",
+          "path": "test.esy.lock/opam/dune-configurator.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "@opam/dune@opam:1.11.3@9894df55" ]
     },
     "@opam/dune@opam:1.11.3@9894df55": {
       "id": "@opam/dune@opam:1.11.3@9894df55",

--- a/test.esy.lock/opam/dune-configurator.1.0.0/opam
+++ b/test.esy.lock/opam/dune-configurator.1.0.0/opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+maintainer: "Jérémie Dimino"
+description: """
+dune.configurator library distributed with Dune 1.x
+"""
+depends: ["dune" {<"2.0.0"}]

--- a/test.esy.lock/opam/lwt.4.3.0/opam
+++ b/test.esy.lock/opam/lwt.4.3.0/opam
@@ -20,6 +20,7 @@ dev-repo: "git+https://github.com/ocsigen/lwt.git"
 depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.7.0"}
+  "dune-configurator"
   "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
   "ocaml" {>= "4.02.0"}
   "ocplib-endian"


### PR DESCRIPTION
Update reason-fontkit to break dependency on GLFW, for #555 