### PR TITLE
Bugfix - JS: Fix missed caml_mutex_lock and caml_mutex_unlock stubs

### DIFF
--- a/src/Core/file.js
+++ b/src/Core/file.js
@@ -10,6 +10,12 @@ function caml_thread_yield() { }
 // Provides: caml_mutex_new
 function caml_mutex_new() { }
 
+// Provides: caml_mutex_lock
+function caml_mutex_lock() { }
+
+// Provides: caml_mutex_unlock
+function caml_mutex_unlock() { }
+
 // Provides: lwt_unix_iov_max
 function lwt_unix_iov_max() { }
 


### PR DESCRIPTION
When compiling with JSOO, via `esy '@js' run`, the `caml_mutex_lock` and `caml_mutex_unlock` stubs are not implemented, which cause a runtime javascript exception when loading.

This adds some no-op stubs - there is no need to implement these in JS, since there are no threads.