### PR TITLE
Bugfix: Move Window.forceScaleFactor to a window option

### DIFF
--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -49,6 +49,7 @@ type t = {
   mutable backgroundColor: Color.t,
   sdlWindow: Sdl2.Window.t,
   uniqueId: int,
+  forceScaleFactor: option(float),
   mutable render: windowRenderCallback,
   mutable shouldRender: windowShouldRenderCallback,
   mutable metrics: WindowMetrics.t,
@@ -58,9 +59,6 @@ type t = {
   mutable requestedHeight: option(int),
   // True if composition (IME) is active
   mutable isComposingText: bool,
-  // If a scale factor is forced (ie, by a CLI argument),
-  // keep track of it here
-  mutable forceScaleFactor: option(float),
   onKeyDown: Event.t(Key.KeyEvent.t),
   onKeyUp: Event.t(Key.KeyEvent.t),
   onMouseUp: Event.t(mouseButtonEvent),
@@ -326,10 +324,6 @@ let _handleEvent = (sdlEvent: Sdl2.Event.t, v: t) => {
   };
 };
 
-let forceScaleFactor = (scaleFactor: float, w: t) => {
-  w.forceScaleFactor = Some(scaleFactor);
-};
-
 let create = (name: string, options: WindowCreateOptions.t) => {
   log("Starting window creation...");
 
@@ -392,7 +386,8 @@ let create = (name: string, options: WindowCreateOptions.t) => {
   };
 
   log("Getting window metrics");
-  let metrics = _getMetricsFromGlfwWindow(w);
+  let metrics =
+    _getMetricsFromGlfwWindow(~forceScaleFactor=options.forceScaleFactor, w);
   log("Metrics: " ++ WindowMetrics.show(metrics));
   let ret: t = {
     backgroundColor: options.backgroundColor,
@@ -410,7 +405,7 @@ let create = (name: string, options: WindowCreateOptions.t) => {
 
     isComposingText: false,
 
-    forceScaleFactor: None,
+    forceScaleFactor: options.forceScaleFactor,
 
     onMouseMove: Event.create(),
     onMouseWheel: Event.create(),

--- a/src/Core/WindowCreateOptions.re
+++ b/src/Core/WindowCreateOptions.re
@@ -38,6 +38,11 @@ type t = {
       [icon] is an optional path to an icon to show in the window frame.
    */
   icon: option(string),
+  /*
+       [forceScaleFactor] is an optional value to force scaling factor. Scaling affects both the outer window dimensions,
+       as well as the scaling of UI elements.
+   */
+  forceScaleFactor: option(float),
 };
 
 let create =
@@ -51,6 +56,7 @@ let create =
       ~backgroundColor=Colors.cornflowerBlue,
       ~vsync=true,
       ~icon=None,
+      ~forceScaleFactor=None,
       (),
     ) => {
   resizable,
@@ -60,6 +66,7 @@ let create =
   width,
   height,
   backgroundColor,
+  forceScaleFactor,
   vsync,
   icon,
 };


### PR DESCRIPTION
The current strategy of setting `Window.forceScaleFactor` after window creation wasn't useful, and would've added additional complexity - we'd have to re-acquire metrics and resize the Window.

Instead, we should know if we're going to force scaling when we create the window - so this option was moved to `WindowCreateOptions` and then follows the current flow of getting metrics during window creation, which simplifies management of this setting.