### PR TITLE
Escape path to allow copying into paths with spaces.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": [ "dune build -p Revery -j4" ],
     "install": [
       "esy-installer Revery.install",
-      "bash -c \"#{os == 'windows' ? 'cp /usr/x86_64-w64-mingw32/sys-root/mingw/bin/*.dll $cur__bin': 'echo Build complete'}\""
+      "bash -c \"#{os == 'windows' ? 'cp /usr/x86_64-w64-mingw32/sys-root/mingw/bin/*.dll \\'$cur__bin\\'': 'echo Build complete'}\""
     ]
   },
   "dependencies": {


### PR DESCRIPTION
This also needs the same fix applying over in `reason-font-manager`, so assuming this fix is correct should merge that first and update the deps here as well. There is also the same fix required in Oni2.

https://github.com/revery-ui/reason-font-manager/pull/4