### PR TITLE
JS: Bugfixes blocking page load

### DIFF
--- a/src/Core/Color.re
+++ b/src/Core/Color.re
@@ -20,7 +20,8 @@ let singleHex =
   Re.Perl.re(
     //"#\\([a-f|A-F|0-9]\\)\\([a-f|A-F|0-9]\\)\\([a-f|A-F|0-9]\\)\\([a-f|A-F|0-9]?[a-f|A-F|0-9]?\\)",
     "#([a-f|A-F|0-9])([a-f|A-F|0-9])([a-f|A-F|0-9])([a-f|A-F|0-9]?[a-f|A-F|0-9]?)",
-  ) |> Re.Perl.compile;
+  )
+  |> Re.Perl.compile;
 
 // Matches:
 // #FFFFFF
@@ -30,7 +31,8 @@ let doubleHex =
   Re.Perl.re(
     //"#\\([a-f|A-F|0-9][a-f|A-F|0-9]\\)\\([a-f|A-F|0-9][a-f|A-F|0-9]\\)\\([a-f|A-F|0-9][a-f|A-F|0-9]\\)\\([a-f|A-F|0-9]?[a-f|A-F|0-9]?\\)",
     "#([a-f|A-F|0-9][a-f|A-F|0-9])([a-f|A-F|0-9][a-f|A-F|0-9])([a-f|A-F|0-9][a-f|A-F|0-9])([a-f|A-F|0-9]?[a-f|A-F|0-9]?)",
-  ) |> Re.Perl.compile;
+  )
+  |> Re.Perl.compile;
 
 exception ColorHexParseException(string);
 
@@ -59,28 +61,24 @@ let parseColor = c => {
 let hex = str =>
   // First, try and parse with the 'double hex' option
   switch (Re.exec_opt(doubleHex, str)) {
-  | Some(matches) => {
+  | Some(matches) =>
     let r = Re.Group.get(matches, 1) |> parseColor;
     let g = Re.Group.get(matches, 2) |> parseColor;
     let b = Re.Group.get(matches, 3) |> parseColor;
     let a = Re.Group.get(matches, 4) |> parseColor;
     rgba(r, g, b, a);
-    }
   | None =>
     // Now, try and parse with the 'single hex' option
     switch (Re.exec_opt(singleHex, str)) {
-    | Some(matches) => {
+    | Some(matches) =>
       let r = Re.Group.get(matches, 1) |> parseColor;
       let g = Re.Group.get(matches, 2) |> parseColor;
       let b = Re.Group.get(matches, 3) |> parseColor;
       let a = Re.Group.get(matches, 4) |> parseColor;
       rgba(r, g, b, a);
-    };
-    | None =>
-      raise(ColorHexParseException("Unable to parse color: " ++ str));
+    | None => raise(ColorHexParseException("Unable to parse color: " ++ str))
     }
-    };
-
+  };
 
 let multiplyAlpha = (opacity: float, color: t) => {
   let ret: t = {...color, a: opacity *. color.a};

--- a/src/Core/Color.re
+++ b/src/Core/Color.re
@@ -18,7 +18,6 @@ let rgb = (r, g, b) => {r, g, b, a: 1.0};
 //let singleHex = Str.regexp("#\\([a-f\\|A-F\\|0-9]\\)\\([a-f\\|A-F\\|0-9]\\)\\([a-f\\|A-F\\|0-9]\\)\\([a-f\\|A-F\\|0-9]\\)");
 let singleHex =
   Re.Perl.re(
-    //"#\\([a-f|A-F|0-9]\\)\\([a-f|A-F|0-9]\\)\\([a-f|A-F|0-9]\\)\\([a-f|A-F|0-9]?[a-f|A-F|0-9]?\\)",
     "#([a-f|A-F|0-9])([a-f|A-F|0-9])([a-f|A-F|0-9])([a-f|A-F|0-9]?[a-f|A-F|0-9]?)",
   )
   |> Re.Perl.compile;
@@ -29,7 +28,6 @@ let singleHex =
 // #FFFFFF00
 let doubleHex =
   Re.Perl.re(
-    //"#\\([a-f|A-F|0-9][a-f|A-F|0-9]\\)\\([a-f|A-F|0-9][a-f|A-F|0-9]\\)\\([a-f|A-F|0-9][a-f|A-F|0-9]\\)\\([a-f|A-F|0-9]?[a-f|A-F|0-9]?\\)",
     "#([a-f|A-F|0-9][a-f|A-F|0-9])([a-f|A-F|0-9][a-f|A-F|0-9])([a-f|A-F|0-9][a-f|A-F|0-9])([a-f|A-F|0-9]?[a-f|A-F|0-9]?)",
   )
   |> Re.Perl.compile;

--- a/src/Core/dune
+++ b/src/Core/dune
@@ -3,4 +3,4 @@
     (public_name Revery.Core)
     (js_of_ocaml (javascript_files file.js))
     (cxx_names file)
-    (libraries threads console.lib str lwt sdl2 flex fontkit Rench))
+    (libraries threads console.lib str lwt sdl2 flex fontkit Rench re))

--- a/src/Draw/FontRenderer.re
+++ b/src/Draw/FontRenderer.re
@@ -22,12 +22,14 @@ let _getTexture = ((font: Fontkit.fk_face, glyphId: int)) => {
 
   let textureFormat = Environment.webGL ? GL_RGBA : GL_ALPHA;
 
+  let textureFilter = Environment.webGL ? GL_LINEAR : GL_NEAREST;
+
   let texture = glCreateTexture();
   glBindTexture(GL_TEXTURE_2D, texture);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, textureFilter);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, textureFilter);
   glTexImage2D(
     GL_TEXTURE_2D,
     0,


### PR DESCRIPTION
There were two issues blocking the JS build:
- The `Str.regexp` module isn't implemented in JSOO - fixed by switching to `re`
- The `GL_NEAREST` option was crashing in shader compilation w/ our WebGL 1 environment - switching to use `GL_LINEAR` in WebGL builds