### PR TITLE
API: Window - Add `setCanQuitCallback` API

### DIFF
--- a/examples/CanQuitExample.re
+++ b/examples/CanQuitExample.re
@@ -3,9 +3,7 @@ open Revery.UI;
 open Revery.UI.Components;
 
 module CanQuit = {
-  type checkboxState = {
-    canQuit: bool,
-  };
+  type checkboxState = {canQuit: bool};
 
   let component = React.component("CanQuit");
 
@@ -26,21 +24,19 @@ module CanQuit = {
           ]>
           <Checkbox
             checkedColor=Colors.green
-            onChange={() =>  {
-                let win = getActiveWindow();
-                switch (win) {
-                | Some(win) => Window.setCanQuitCallback(win, () => !canQuit);
-                | None => ();
-                }
-                setCheckboxState({canQuit: !canQuit})}}
+            onChange={() => {
+              let win = getActiveWindow();
+              switch (win) {
+              | Some(win) => Window.setCanQuitCallback(win, () => !canQuit)
+              | None => ()
+              };
+              setCheckboxState({canQuit: !canQuit});
+            }}
             style=Style.[border(~width=2, ~color=Colors.green)]
             checked=canQuit
           />
           <Text
-            text={
-              "Can quit: "
-              ++ (canQuit ? "Yes": "No")
-            }
+            text={"Can quit: " ++ (canQuit ? "Yes" : "No")}
             style=Style.[
               marginTop(10),
               fontFamily("Roboto-Regular.ttf"),

--- a/examples/CanQuitExample.re
+++ b/examples/CanQuitExample.re
@@ -1,0 +1,57 @@
+open Revery;
+open Revery.UI;
+open Revery.UI.Components;
+
+module CanQuit = {
+  type checkboxState = {
+    canQuit: bool,
+  };
+
+  let component = React.component("CanQuit");
+
+  let createElement = (~children as _, ()) =>
+    component(hooks => {
+      let initialCheckboxState = {canQuit: true};
+      let ({canQuit}, setCheckboxState, hooks) =
+        Hooks.state(initialCheckboxState, hooks);
+
+      (
+        hooks,
+        <View
+          style=Style.[
+            width(500),
+            height(500),
+            justifyContent(`Center),
+            alignItems(`Center),
+          ]>
+          <Checkbox
+            checkedColor=Colors.green
+            onChange={() =>  {
+                let win = getActiveWindow();
+                switch (win) {
+                | Some(win) => Window.setCanQuitCallback(win, () => !canQuit);
+                | None => ();
+                }
+                setCheckboxState({canQuit: !canQuit})}}
+            style=Style.[border(~width=2, ~color=Colors.green)]
+            checked=canQuit
+          />
+          <Text
+            text={
+              "Can quit: "
+              ++ (canQuit ? "Yes": "No")
+            }
+            style=Style.[
+              marginTop(10),
+              fontFamily("Roboto-Regular.ttf"),
+              fontSize(20),
+            ]
+          />
+        </View>,
+      );
+    });
+};
+
+let render = () => {
+  <CanQuit />;
+};

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -27,6 +27,11 @@ let state: state = {
   examples: [
     {name: "Animation", render: _w => Hello.render(), source: "Hello.re"},
     {
+      name: "CanQuit",
+      render: _ => CanQuitExample.render(),
+      source: "CanQuit.re",
+    },
+    {
       name: "Button",
       render: _ => DefaultButton.render(),
       source: "DefaultButton.re",

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -29,16 +29,16 @@ let getWindowById = (app: t, id: int) => {
 };
 
 let _tryToClose = (app: t, window: Window.t) =>
-  if (Window.shouldClose(window)) {
+  if (Window.canQuit(window)) {
     logInfo(
-      "_tryToClose: Window shouldClose is true - closing window: "
+      "_tryToClose: Window canQuit is true - closing window: "
       ++ string_of_int(window.uniqueId),
     );
     Window.destroyWindow(window);
     Hashtbl.remove(app.windows, window.uniqueId);
   } else {
     logInfo(
-      "_tryToClose: Window shouldClose is false "
+      "_tryToClose: Window canQuit is false "
       ++ string_of_int(window.uniqueId),
     );
   };

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -2,6 +2,7 @@ open Events;
 
 type windowRenderCallback = unit => unit;
 type windowShouldRenderCallback = unit => bool;
+type windowCanQuitCallback = unit => bool;
 
 type size = {
   width: int,
@@ -52,6 +53,7 @@ type t = {
   forceScaleFactor: option(float),
   mutable render: windowRenderCallback,
   mutable shouldRender: windowShouldRenderCallback,
+  mutable canQuit: windowCanQuitCallback,
   mutable metrics: WindowMetrics.t,
   mutable areMetricsDirty: bool,
   mutable isRendering: bool,
@@ -396,6 +398,7 @@ let create = (name: string, options: WindowCreateOptions.t) => {
 
     render: () => (),
     shouldRender: () => false,
+    canQuit: () => true,
 
     metrics,
     areMetricsDirty: false,
@@ -556,8 +559,12 @@ let destroyWindow = (_w: t) => {
   ();
 };
 
-let shouldClose = (_w: t) => {
-  true;
+let canQuit = (w: t) => {
+  w.canQuit();
+};
+
+let setCanQuitCallback = (w: t, callback: windowCanQuitCallback) => {
+  w.canQuit = callback;
 };
 
 let setRenderCallback = (w: t, callback: windowRenderCallback) =>


### PR DESCRIPTION
This allows the application to set up a `canQuit` callback - this callback will be called when the user tries to exit the app (ie, via the `x` in the Window). If it returns `false` - the app will not close.

This is needed for Onivim 2 so that we can prevent closing in the case where there are unsaved files.