### PR TITLE
Bugfix: Explicitly set precision for both vertex/fragment shaders

### DIFF
--- a/src/Shaders/Shader.re
+++ b/src/Shaders/Shader.re
@@ -131,8 +131,6 @@ let compile = (shader: t) => {
     };
   };
 
-  
-
   switch (vsResult, fsResult) {
   | (CompilationSuccess, CompilationSuccess) =>
     linkProgram(vertexShader, fragmentShader)
@@ -141,6 +139,16 @@ let compile = (shader: t) => {
   | (CompilationSuccess, CompilationFailure(v)) =>
     raise(ShaderCompilationException(v ++ " in fragment shader: " ++ fs))
   | (CompilationFailure(v1), CompilationFailure(v2)) =>
-    raise(ShaderCompilationException(v1 ++ " in vertex shader: " ++ vs ++ " and " ++ v2 ++ " in fragment shader: " ++ fs ))
+    raise(
+      ShaderCompilationException(
+        v1
+        ++ " in vertex shader: "
+        ++ vs
+        ++ " and "
+        ++ v2
+        ++ " in fragment shader: "
+        ++ fs,
+      ),
+    )
   };
 };


### PR DESCRIPTION
...and improve error messages when shader compilation fails. 


Related to:
https://github.com/onivim/oni2/issues/833