### PR TITLE
API - Component: Bring back <Ticker />

### DIFF
--- a/src/UI_Components/Revery_UI_Components.re
+++ b/src/UI_Components/Revery_UI_Components.re
@@ -20,4 +20,5 @@ module ScrollView = ScrollView;
 module Slider = Slider;
 module Stack = Stack;
 module RadioButtons = RadioButtons;
+module Ticker = Ticker;
 module Tree = Tree;

--- a/src/UI_Components/Ticker.re
+++ b/src/UI_Components/Ticker.re
@@ -1,0 +1,26 @@
+open Revery_UI;
+open Revery_Core;
+open Revery_UI_Primitives;
+
+module Hooks = Revery_UI_Hooks;
+
+type tickFunction = Time.t => unit;
+let noop: tickFunction = _ => ();
+
+let component = React.component("Container");
+
+let createElement = (~children, ~onTick=noop, ~tickRate=Time.Seconds(1.), ()) =>
+  component(hooks => {
+    let hooks =
+      Hooks.effect(
+        OnMount,
+        () => {
+          let dispose = Revery_Core.Tick.interval(onTick, tickRate);
+
+          Some(dispose);
+        },
+        hooks,
+      );
+
+    (hooks, <View> ...children </View>);
+  });

--- a/src/UI_Components/Ticker.rei
+++ b/src/UI_Components/Ticker.rei
@@ -1,0 +1,29 @@
+open Revery_Core;
+open Revery_UI;
+
+type tickFunction = Time.t => unit;
+
+/**
+{2 Description:}
+
+The [Ticker] component is a helper that calls a specific function periodically as a side-effect.
+
+{2 Usage:}
+
+{[
+let tick tick = (t) => print_endline("Time: " ++ string_of_float(Time.toSeconds(t)));
+
+<Ticker onTick=tick tickRate=Seconds(1.0) />
+]}
+
+@param [onTick] Callback function, called for each tick.
+@param [tickRate] Frequency of calling the [onTick] function.
+*/
+let createElement:
+  (
+    ~children: list(React.syntheticElement),
+    ~onTick: tickFunction=?,
+    ~tickRate: Time.t=?,
+    unit
+  ) =>
+  React.syntheticElement;

--- a/src/index.mld
+++ b/src/index.mld
@@ -55,6 +55,7 @@ Framework for fast, native code, cross-platform GUI applications.
                 {li {{:../Revery/Revery_UI_Components/ScrollView/index.html} ScrollView}}
                 {li {{:../Revery/Revery_UI_Components/Slider/index.html} Slider}}
                 {li {{:../Revery/Revery_UI_Components/Stack/index.html} Stack}}
+                {li {{:../Revery/Revery_UI_Components/Ticker/index.html} Tickre}}
                 {li {{:../Revery/Revery_UI_Components/Tree/index.html} Tree}}
             }
     }


### PR DESCRIPTION
This brings back the `<Ticker />` component, which is often more convenient than setting up a hook.

Example usage: 
```
let tick tick = (t) => print_endline("Time: " ++ string_of_float(Time.toSeconds(t)));

<Ticker onTick=tick tickRate=Seconds(1.0) />
```

Since https://github.com/briskml/brisk-reconciler/pull/40 is now fixed / in, this component no longer leaks tickers when unmounted.

