### PR TITLE
Dependency: reason-sdl2 -> 2.10.3006

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "86e07112135e5271171d00ae833ef236",
+  "checksum": "ff1c776b8aeb4c9d6b2c2a97aefda009",
   "root": "revery@link-dev:./package.json",
   "node": {
     "revery@link-dev:./package.json": {
@@ -16,7 +16,7 @@
         "reperf@1.4.0@d41d8cd9",
         "rench@github:revery-ui/rench#4554280@d41d8cd9",
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
-        "reason-sdl2@2.10.3005@d41d8cd9",
+        "reason-sdl2@2.10.3006@d41d8cd9",
         "reason-gl-matrix@0.9.9305@d41d8cd9",
         "reason-fontkit@2.7.0@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
@@ -133,20 +133,20 @@
       ],
       "devDependencies": []
     },
-    "reason-sdl2@2.10.3005@d41d8cd9": {
-      "id": "reason-sdl2@2.10.3005@d41d8cd9",
+    "reason-sdl2@2.10.3006@d41d8cd9": {
+      "id": "reason-sdl2@2.10.3006@d41d8cd9",
       "name": "reason-sdl2",
-      "version": "2.10.3005",
+      "version": "2.10.3006",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3005.tgz#sha1:c7d0f5d34ef8858acddb56472860bc507e5d2b6d"
+          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3006.tgz#sha1:1ca853d8cca5c8ba8c075ad3ee20ea75fa5bc60d"
         ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "esy-sdl2@2.0.10003@d41d8cd9", "esy-cmake@0.3.5@d41d8cd9",
+        "esy-sdl2@2.0.10004@d41d8cd9", "esy-cmake@0.3.5@d41d8cd9",
         "@opam/lwt_ppx@opam:1.2.4@369f3faf", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
@@ -258,14 +258,14 @@
       ],
       "devDependencies": []
     },
-    "esy-sdl2@2.0.10003@d41d8cd9": {
-      "id": "esy-sdl2@2.0.10003@d41d8cd9",
+    "esy-sdl2@2.0.10004@d41d8cd9": {
+      "id": "esy-sdl2@2.0.10004@d41d8cd9",
       "name": "esy-sdl2",
-      "version": "2.0.10003",
+      "version": "2.0.10004",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/esy-sdl2/-/esy-sdl2-2.0.10003.tgz#sha1:613589d74a779f26b51b3cd29622f40976522cdd"
+          "archive:https://registry.npmjs.org/esy-sdl2/-/esy-sdl2-2.0.10004.tgz#sha1:099759847d2e33258d80bdeeb536cf1d4cc98fa5"
         ]
       },
       "overrides": [],

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "bf4e307e0a40cee312360d11725255d9",
+  "checksum": "404b5827c60e74809f3f16f011c65614",
   "root": "revery@link-dev:./package.json",
   "node": {
     "wordwrap@0.0.3@d41d8cd9": {
@@ -58,7 +58,7 @@
         "reperf@1.4.0@d41d8cd9",
         "rench@github:revery-ui/rench#4554280@d41d8cd9",
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
-        "reason-sdl2@2.10.3005@d41d8cd9",
+        "reason-sdl2@2.10.3006@d41d8cd9",
         "reason-gl-matrix@0.9.9305@d41d8cd9",
         "reason-fontkit@2.7.0@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "http-server@0.11.1@d41d8cd9",
@@ -190,20 +190,20 @@
       ],
       "devDependencies": []
     },
-    "reason-sdl2@2.10.3005@d41d8cd9": {
-      "id": "reason-sdl2@2.10.3005@d41d8cd9",
+    "reason-sdl2@2.10.3006@d41d8cd9": {
+      "id": "reason-sdl2@2.10.3006@d41d8cd9",
       "name": "reason-sdl2",
-      "version": "2.10.3005",
+      "version": "2.10.3006",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3005.tgz#sha1:c7d0f5d34ef8858acddb56472860bc507e5d2b6d"
+          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3006.tgz#sha1:1ca853d8cca5c8ba8c075ad3ee20ea75fa5bc60d"
         ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "esy-sdl2@2.0.10003@d41d8cd9", "esy-cmake@0.3.5@d41d8cd9",
+        "esy-sdl2@2.0.10004@d41d8cd9", "esy-cmake@0.3.5@d41d8cd9",
         "@opam/lwt_ppx@opam:1.2.4@369f3faf", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
@@ -552,14 +552,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-sdl2@2.0.10003@d41d8cd9": {
-      "id": "esy-sdl2@2.0.10003@d41d8cd9",
+    "esy-sdl2@2.0.10004@d41d8cd9": {
+      "id": "esy-sdl2@2.0.10004@d41d8cd9",
       "name": "esy-sdl2",
-      "version": "2.0.10003",
+      "version": "2.0.10004",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/esy-sdl2/-/esy-sdl2-2.0.10003.tgz#sha1:613589d74a779f26b51b3cd29622f40976522cdd"
+          "archive:https://registry.npmjs.org/esy-sdl2/-/esy-sdl2-2.0.10004.tgz#sha1:099759847d2e33258d80bdeeb536cf1d4cc98fa5"
         ]
       },
       "overrides": [],

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "86e07112135e5271171d00ae833ef236",
+  "checksum": "ff1c776b8aeb4c9d6b2c2a97aefda009",
   "root": "revery@link-dev:./package.json",
   "node": {
     "revery@link-dev:./package.json": {
@@ -16,7 +16,7 @@
         "reperf@1.4.0@d41d8cd9",
         "rench@github:revery-ui/rench#4554280@d41d8cd9",
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
-        "reason-sdl2@2.10.3005@d41d8cd9",
+        "reason-sdl2@2.10.3006@d41d8cd9",
         "reason-gl-matrix@0.9.9305@d41d8cd9",
         "reason-fontkit@2.7.0@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
@@ -133,20 +133,20 @@
       ],
       "devDependencies": []
     },
-    "reason-sdl2@2.10.3005@d41d8cd9": {
-      "id": "reason-sdl2@2.10.3005@d41d8cd9",
+    "reason-sdl2@2.10.3006@d41d8cd9": {
+      "id": "reason-sdl2@2.10.3006@d41d8cd9",
       "name": "reason-sdl2",
-      "version": "2.10.3005",
+      "version": "2.10.3006",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3005.tgz#sha1:c7d0f5d34ef8858acddb56472860bc507e5d2b6d"
+          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3006.tgz#sha1:1ca853d8cca5c8ba8c075ad3ee20ea75fa5bc60d"
         ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "esy-sdl2@2.0.10003@d41d8cd9", "esy-cmake@0.3.5@d41d8cd9",
+        "esy-sdl2@2.0.10004@d41d8cd9", "esy-cmake@0.3.5@d41d8cd9",
         "@opam/lwt_ppx@opam:1.2.4@369f3faf", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
@@ -258,14 +258,14 @@
       ],
       "devDependencies": []
     },
-    "esy-sdl2@2.0.10003@d41d8cd9": {
-      "id": "esy-sdl2@2.0.10003@d41d8cd9",
+    "esy-sdl2@2.0.10004@d41d8cd9": {
+      "id": "esy-sdl2@2.0.10004@d41d8cd9",
       "name": "esy-sdl2",
-      "version": "2.0.10003",
+      "version": "2.0.10004",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/esy-sdl2/-/esy-sdl2-2.0.10003.tgz#sha1:613589d74a779f26b51b3cd29622f40976522cdd"
+          "archive:https://registry.npmjs.org/esy-sdl2/-/esy-sdl2-2.0.10004.tgz#sha1:099759847d2e33258d80bdeeb536cf1d4cc98fa5"
         ]
       },
       "overrides": [],

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "94a6565014f660c7d4b9748233c63e36",
+  "checksum": "b1f6aefe65957f4434e2e449bf24b7f0",
   "root": "revery@link-dev:./package.json",
   "node": {
     "wordwrap@0.0.3@d41d8cd9": {
@@ -58,7 +58,7 @@
         "reperf@1.4.0@d41d8cd9",
         "rench@github:revery-ui/rench#4554280@d41d8cd9",
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
-        "reason-sdl2@2.10.3005@d41d8cd9",
+        "reason-sdl2@2.10.3006@d41d8cd9",
         "reason-gl-matrix@0.9.9305@d41d8cd9",
         "reason-fontkit@2.7.0@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "http-server@0.11.1@d41d8cd9",
@@ -190,20 +190,20 @@
       ],
       "devDependencies": []
     },
-    "reason-sdl2@2.10.3005@d41d8cd9": {
-      "id": "reason-sdl2@2.10.3005@d41d8cd9",
+    "reason-sdl2@2.10.3006@d41d8cd9": {
+      "id": "reason-sdl2@2.10.3006@d41d8cd9",
       "name": "reason-sdl2",
-      "version": "2.10.3005",
+      "version": "2.10.3006",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3005.tgz#sha1:c7d0f5d34ef8858acddb56472860bc507e5d2b6d"
+          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3006.tgz#sha1:1ca853d8cca5c8ba8c075ad3ee20ea75fa5bc60d"
         ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "esy-sdl2@2.0.10003@d41d8cd9", "esy-cmake@0.3.5@d41d8cd9",
+        "esy-sdl2@2.0.10004@d41d8cd9", "esy-cmake@0.3.5@d41d8cd9",
         "@opam/lwt_ppx@opam:1.2.4@369f3faf", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
@@ -552,14 +552,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-sdl2@2.0.10003@d41d8cd9": {
-      "id": "esy-sdl2@2.0.10003@d41d8cd9",
+    "esy-sdl2@2.0.10004@d41d8cd9": {
+      "id": "esy-sdl2@2.0.10004@d41d8cd9",
       "name": "esy-sdl2",
-      "version": "2.0.10003",
+      "version": "2.0.10004",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/esy-sdl2/-/esy-sdl2-2.0.10003.tgz#sha1:613589d74a779f26b51b3cd29622f40976522cdd"
+          "archive:https://registry.npmjs.org/esy-sdl2/-/esy-sdl2-2.0.10004.tgz#sha1:099759847d2e33258d80bdeeb536cf1d4cc98fa5"
         ]
       },
       "overrides": [],

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@reason-native/console": "^0.0.3",
     "rench": "^1.9.0",
     "reason-font-manager": "^2.0.0",
-    "reason-sdl2": "^2.10.3005"
+    "reason-sdl2": "^2.10.3006"
   },
   "resolutions": {
     "rebez": "github:jchavarri/rebez#46cbc183",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "86e07112135e5271171d00ae833ef236",
+  "checksum": "ff1c776b8aeb4c9d6b2c2a97aefda009",
   "root": "revery@link-dev:./package.json",
   "node": {
     "revery@link-dev:./package.json": {
@@ -16,7 +16,7 @@
         "reperf@1.4.0@d41d8cd9",
         "rench@github:revery-ui/rench#4554280@d41d8cd9",
         "rebez@github:jchavarri/rebez#46cbc183@d41d8cd9",
-        "reason-sdl2@2.10.3005@d41d8cd9",
+        "reason-sdl2@2.10.3006@d41d8cd9",
         "reason-gl-matrix@0.9.9305@d41d8cd9",
         "reason-fontkit@2.7.0@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
@@ -133,20 +133,20 @@
       ],
       "devDependencies": []
     },
-    "reason-sdl2@2.10.3005@d41d8cd9": {
-      "id": "reason-sdl2@2.10.3005@d41d8cd9",
+    "reason-sdl2@2.10.3006@d41d8cd9": {
+      "id": "reason-sdl2@2.10.3006@d41d8cd9",
       "name": "reason-sdl2",
-      "version": "2.10.3005",
+      "version": "2.10.3006",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3005.tgz#sha1:c7d0f5d34ef8858acddb56472860bc507e5d2b6d"
+          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3006.tgz#sha1:1ca853d8cca5c8ba8c075ad3ee20ea75fa5bc60d"
         ]
       },
       "overrides": [],
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "esy-sdl2@2.0.10003@d41d8cd9", "esy-cmake@0.3.5@d41d8cd9",
+        "esy-sdl2@2.0.10004@d41d8cd9", "esy-cmake@0.3.5@d41d8cd9",
         "@opam/lwt_ppx@opam:1.2.4@369f3faf", "@opam/lwt@opam:4.4.0@0357bb8b",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
@@ -258,14 +258,14 @@
       ],
       "devDependencies": []
     },
-    "esy-sdl2@2.0.10003@d41d8cd9": {
-      "id": "esy-sdl2@2.0.10003@d41d8cd9",
+    "esy-sdl2@2.0.10004@d41d8cd9": {
+      "id": "esy-sdl2@2.0.10004@d41d8cd9",
       "name": "esy-sdl2",
-      "version": "2.0.10003",
+      "version": "2.0.10004",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/esy-sdl2/-/esy-sdl2-2.0.10003.tgz#sha1:613589d74a779f26b51b3cd29622f40976522cdd"
+          "archive:https://registry.npmjs.org/esy-sdl2/-/esy-sdl2-2.0.10004.tgz#sha1:099759847d2e33258d80bdeeb536cf1d4cc98fa5"
         ]
       },
       "overrides": [],


### PR DESCRIPTION
This picks up the X11 build fix on Mac by @CrossR  : https://github.com/revery-ui/esy-sdl2