### PR TITLE
Bugfix: Command+Q doesn't quit the application

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -44,7 +44,7 @@ let _tryToClose = (app: t, window: Window.t) =>
   };
 
 let _tryToCloseAll = (app: t) => {
-  let windows = Hashtbl.to_seq_values(appInstance.windows);
+  let windows = Hashtbl.to_seq_values(app.windows);
   Seq.iter(w => _tryToClose(app, w), windows);
 };
 

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -167,7 +167,7 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
           if (Hashtbl.length(appInstance.windows) == 0) {
             logInfo("Quitting");
             exit(0);
-          }
+          };
         | _ => ()
         };
       };

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -43,6 +43,11 @@ let _tryToClose = (app: t, window: Window.t) =>
     );
   };
 
+let _tryToCloseAll = (app: t) => {
+  let windows = Hashtbl.to_seq_values(appInstance.windows);
+  Seq.iter(w => _tryToClose(app, w), windows);
+};
+
 let quit = (code: int) => exit(code);
 
 let isIdle = (app: t) => app.idleCount >= framesToIdle;
@@ -153,6 +158,12 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
           | Some(win) => _tryToClose(appInstance, win)
           };
         | Sdl2.Event.Quit =>
+          // Sometimes, on Mac, we could get a 'quit' without a
+          // corresponding WindowClosed event - this can happen
+          // if Command+Q is pressed. In that case, we'll try
+          // closing all the windows - and if they all close,
+          // we'll exit the app.
+          _tryToCloseAll(appInstance);
           if (Hashtbl.length(appInstance.windows) == 0) {
             logInfo("Quitting");
             exit(0);

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -48,7 +48,13 @@ let _tryToCloseAll = (app: t) => {
   Seq.iter(w => _tryToClose(app, w), windows);
 };
 
-let quit = (code: int) => exit(code);
+let quit = (~code=0, app: t) => {
+  _tryToCloseAll(app);
+  if (Hashtbl.length(app.windows) == 0) {
+    logInfo("Quitting");
+    exit(code);
+  };
+};
 
 let isIdle = (app: t) => app.idleCount >= framesToIdle;
 
@@ -163,11 +169,7 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
           // if Command+Q is pressed. In that case, we'll try
           // closing all the windows - and if they all close,
           // we'll exit the app.
-          _tryToCloseAll(appInstance);
-          if (Hashtbl.length(appInstance.windows) == 0) {
-            logInfo("Quitting");
-            exit(0);
-          };
+          quit(~code=0, appInstance)
         | _ => ()
         };
       };

--- a/src/Core/App.rei
+++ b/src/Core/App.rei
@@ -13,7 +13,7 @@ type canIdleFunc = unit => bool;
 let getWindows: t => list(Window.t);
 
 /** [quit(c)] causes the App to quit with exit code [c] */
-let quit: int => unit;
+let quit: (~code: int=?, t) => unit;
 
 /** [isIdle(app)] returns true if the app is idling, false othwrise */
 let isIdle: t => bool;


### PR DESCRIPTION
__Issue:__ This is a regression from the SDL2 upgrade. We were expecting that we get a 'WindowClosed' event prior to a 'Quit' event - this is true in the case of pressing the 'x' button in the window, but not the case when quitting the app external to a window - like via `Command+Q` in OSX.

__Fix:__ When we get a Quit event, try to close all the windows. In the 'WindowClosed' before, there won't be any windows around - so the logic will behave as before. However, in the `Command+Q` case, the logic will now attempt to close all open windows.

__BREAKING:__ This also hooks up the `App.quit` API to use the `canQuit` logic.