### PR TITLE
Add Box Shadow Inset Property

### DIFF
--- a/examples/Boxshadow.re
+++ b/examples/Boxshadow.re
@@ -26,6 +26,14 @@ let secondBoxStyle =
     height(100),
   ];
 
+let thirdBoxStyle =
+  Style.[
+    backgroundColor(Colors.gray),
+    position(`Relative),
+    width(100),
+    height(100),
+  ];
+
 let firstShadow =
   Style.BoxShadow.make(
     ~yOffset=-10.,
@@ -46,6 +54,17 @@ let secondShadow =
     (),
   );
 
+let thirdShadow =
+  Style.BoxShadow.make(
+    ~yOffset=10.,
+    ~xOffset=-20.,
+    ~blurRadius=20.,
+    ~color=Colors.blue,
+    ~spreadRadius=10.,
+    ~inset=true,
+    (),
+  );
+
 let render = () =>
   <View style=parentStyles>
     <Padding padding=30>
@@ -56,6 +75,11 @@ let render = () =>
     <Padding padding=30>
       <BoxShadow boxShadow=secondShadow>
         <View style=secondBoxStyle />
+      </BoxShadow>
+    </Padding>
+    <Padding padding=30>
+      <BoxShadow boxShadow=thirdShadow>
+        <View style=thirdBoxStyle />
       </BoxShadow>
     </Padding>
   </View>;

--- a/src/Draw/GradientShader.re
+++ b/src/Draw/GradientShader.re
@@ -35,6 +35,21 @@ let uniforms: list(ShaderUniform.t) =
       name: "uShadowAmount",
       usage: FragmentShader,
     },
+    {
+      dataType: ShaderDataType.Vector2,
+      name: "uShadowOffset",
+      usage: FragmentShader,
+    },
+    {
+      dataType: ShaderDataType.Vector2,
+      name: "uShadowSpread",
+      usage: FragmentShader,
+    },
+    {
+      dataType: ShaderDataType.Float,
+      name: "uShadowInset",
+      usage: FragmentShader,
+    },
   ];
 
 let varying =
@@ -53,16 +68,16 @@ let vertexShader =
 |};
 
 let fragmentShader = {|
-  float leftEdgeAmount = smoothstep(0.0, uShadowAmount.x, vTexCoord.x);
-  float rightEdgeAmount = smoothstep(0.0, uShadowAmount.x, 1.0 - vTexCoord.x);
+  float leftEdgeAmount = smoothstep(0.0, uShadowAmount.x, vTexCoord.x + uShadowOffset.x - uShadowSpread.x);
+  float rightEdgeAmount = smoothstep(0.0, uShadowAmount.x, 1.0 - vTexCoord.x - uShadowOffset.x - uShadowSpread.x);
 
-  float topEdgeAmount = smoothstep(0.0, uShadowAmount.y, vTexCoord.y);
-  float bottomEdgeAmount = smoothstep(0.0, uShadowAmount.y, 1.0 - vTexCoord.y);
+  float topEdgeAmount = smoothstep(0.0, uShadowAmount.y, vTexCoord.y + uShadowOffset.y - uShadowSpread.y);
+  float bottomEdgeAmount = smoothstep(0.0, uShadowAmount.y, 1.0 - vTexCoord.y - uShadowOffset.y - uShadowSpread.y);
   float horizontalBlur = min(leftEdgeAmount, rightEdgeAmount);
   float verticalBlur = min(topEdgeAmount, bottomEdgeAmount);
 
   float blur = horizontalBlur * verticalBlur;
-  gl_FragColor = vec4(uShadowColor.rgb, blur);
+  gl_FragColor = vec4(uShadowColor.rgb, abs(uShadowInset - blur));
 |};
 
 type t = {
@@ -70,6 +85,9 @@ type t = {
   uniformProjection: uniformLocation,
   uniformShadowColor: uniformLocation,
   uniformShadowAmount: uniformLocation,
+  uniformShadowOffset: uniformLocation,
+  uniformShadowSpread: uniformLocation,
+  uniformShadowInset: uniformLocation,
   uniformWorld: uniformLocation,
 };
 
@@ -91,6 +109,12 @@ let create = () => {
     CompiledShader.getUniformLocation(compiledShader, "uShadowColor");
   let uniformShadowAmount =
     CompiledShader.getUniformLocation(compiledShader, "uShadowAmount");
+  let uniformShadowOffset =
+    CompiledShader.getUniformLocation(compiledShader, "uShadowOffset");
+  let uniformShadowSpread =
+    CompiledShader.getUniformLocation(compiledShader, "uShadowSpread");
+  let uniformShadowInset =
+    CompiledShader.getUniformLocation(compiledShader, "uShadowInset");
 
   {
     compiledShader,
@@ -98,5 +122,8 @@ let create = () => {
     uniformProjection,
     uniformShadowColor,
     uniformShadowAmount,
+    uniformShadowOffset,
+    uniformShadowSpread,
+    uniformShadowInset,
   };
 };

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -23,6 +23,7 @@ module BoxShadow = {
     blurRadius: float,
     spreadRadius: float,
     color: Color.t,
+    inset: bool,
   };
 
   type t = properties;
@@ -34,6 +35,7 @@ module BoxShadow = {
         ~blurRadius=20.,
         ~spreadRadius=00.,
         ~color=Color.rgba(0., 0., 0., 1.0),
+        ~inset=false,
         (),
       ) => {
     xOffset,
@@ -41,6 +43,7 @@ module BoxShadow = {
     blurRadius,
     spreadRadius,
     color,
+    inset,
   };
 
   let default: t = {
@@ -49,6 +52,7 @@ module BoxShadow = {
     blurRadius: 0.,
     spreadRadius: 0.,
     color: Colors.black,
+    inset: false,
   };
 };
 

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -247,10 +247,7 @@ let renderShadow = (~boxShadow, ~width, ~height, ~world, ~m) => {
   let shadowTransform = Mat4.create();
 
   /* Widen the size of the shadow based on the spread or blur radius specified */
-  let sizeModifier = switch(inset) {
-    | true => 0.0;
-    | false => spreadRadius +. blurRadius;
-  }
+  let sizeModifier = inset ? 0.0 : spreadRadius +. blurRadius;
 
   let quad =
     Assets.quad(
@@ -261,24 +258,24 @@ let renderShadow = (~boxShadow, ~width, ~height, ~world, ~m) => {
       (),
     );
 
-  switch(boxShadow.inset) {
-    | true =>
-      Mat4.fromTranslation(shadowTransform, Vec3.create(0., 0., 0.));
-    | false =>
-      Mat4.fromTranslation(shadowTransform, Vec3.create(xOffset, yOffset, 0.));
-  }
+  boxShadow.inset
+    ? Mat4.fromTranslation(shadowTransform, Vec3.create(0., 0., 0.))
+    : Mat4.fromTranslation(
+        shadowTransform,
+        Vec3.create(xOffset, yOffset, 0.),
+      );
 
   let shadowWorldTransform = Mat4.create();
 
-  let shadowOffset = switch(boxShadow.inset) {
-    | true => Vec2.create(xOffset /. width, yOffset /. height)
-    | false => Vec2.create(0., 0.)
-  }
+  let shadowOffset =
+    boxShadow.inset
+      ? Vec2.create(xOffset /. width, yOffset /. height)
+      : Vec2.create(0., 0.);
 
-  let shadowSpread = switch(boxShadow.inset) {
-    | true => Vec2.create(spreadRadius /. width, spreadRadius /. height)
-    | false => Vec2.create(0., 0.)
-  }
+  let shadowSpread =
+    boxShadow.inset
+      ? Vec2.create(spreadRadius /. width, spreadRadius /. height)
+      : Vec2.create(0., 0.);
 
   Mat4.multiply(shadowWorldTransform, world, shadowTransform);
 
@@ -346,9 +343,23 @@ class viewNode (()) = {
     let color = Color.multiplyAlpha(opacity, style.backgroundColor);
 
     switch (style.boxShadow) {
-    | {xOffset: 0., yOffset: 0., blurRadius: 0., spreadRadius: 0., color: _, inset: _} =>
+    | {
+        xOffset: 0.,
+        yOffset: 0.,
+        blurRadius: 0.,
+        spreadRadius: 0.,
+        color: _,
+        inset: _,
+      } =>
       ()
-    | {xOffset: _, yOffset: _, blurRadius: _, spreadRadius: _, color: _, inset: true} =>
+    | {
+        xOffset: _,
+        yOffset: _,
+        blurRadius: _,
+        spreadRadius: _,
+        color: _,
+        inset: true,
+      } =>
       ()
     | boxShadow => renderShadow(~boxShadow, ~width, ~height, ~world, ~m)
     };
@@ -369,9 +380,23 @@ class viewNode (()) = {
     _super#draw(parentContext);
 
     switch (style.boxShadow) {
-    | {xOffset: 0., yOffset: 0., blurRadius: 0., spreadRadius: 0., color: _, inset: _} =>
+    | {
+        xOffset: 0.,
+        yOffset: 0.,
+        blurRadius: 0.,
+        spreadRadius: 0.,
+        color: _,
+        inset: _,
+      } =>
       ()
-    | {xOffset: _, yOffset: _, blurRadius: _, spreadRadius: _, color: _, inset: false} =>
+    | {
+        xOffset: _,
+        yOffset: _,
+        blurRadius: _,
+        spreadRadius: _,
+        color: _,
+        inset: false,
+      } =>
       ()
     | boxShadow => renderShadow(~boxShadow, ~width, ~height, ~world, ~m)
     };


### PR DESCRIPTION
Quick take on adding support for the inset property to box shadows.

It looks like box shadows in general may be getting reworked with the move to skia. Would be happy to direct efforts in that direction instead or as well if it'd help.

Screenshot from the updated Box Shadow example:

<img width="912" alt="image" src="https://user-images.githubusercontent.com/2533/66710750-798e6180-ed33-11e9-92c8-d1d72b5cc868.png">