### PR TITLE
Bugfix: Redraw window on Exposed event

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -153,6 +153,7 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
         | Sdl2.Event.WindowResized({windowID, _}) => handleEvent(windowID)
         | Sdl2.Event.WindowSizeChanged({windowID, _}) =>
           handleEvent(windowID)
+        | Sdl2.Event.WindowExposed({windowID, _}) => handleEvent(windowID)
         | Sdl2.Event.WindowMoved({windowID, _}) => handleEvent(windowID)
         | Sdl2.Event.WindowEnter({windowID}) => handleEvent(windowID)
         | Sdl2.Event.WindowLeave({windowID}) => handleEvent(windowID)

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -61,6 +61,7 @@ type t = {
   mutable requestedHeight: option(int),
   // True if composition (IME) is active
   mutable isComposingText: bool,
+  onExposed: Event.t(unit),
   onKeyDown: Event.t(Key.KeyEvent.t),
   onKeyUp: Event.t(Key.KeyEvent.t),
   onMouseUp: Event.t(mouseButtonEvent),
@@ -325,6 +326,7 @@ let _handleEvent = (sdlEvent: Sdl2.Event.t, v: t) => {
   | Sdl2.Event.WindowMoved(_) => v.areMetricsDirty = true
   | Sdl2.Event.WindowEnter(_) => Event.dispatch(v.onMouseEnter, ())
   | Sdl2.Event.WindowLeave(_) => Event.dispatch(v.onMouseLeave, ())
+  | Sdl2.Event.WindowExposed(_) => Event.dispatch(v.onExposed, ())
   | Sdl2.Event.Quit => ()
   | _ => ()
   };
@@ -424,6 +426,8 @@ let create = (name: string, options: WindowCreateOptions.t) => {
     isComposingText: false,
 
     forceScaleFactor: options.forceScaleFactor,
+
+    onExposed: Event.create(),
 
     onMouseMove: Event.create(),
     onMouseWheel: Event.create(),

--- a/src/UI/Ui.re
+++ b/src/UI/Ui.re
@@ -39,6 +39,13 @@ let start = (window: Window.t, element: React.syntheticElement) => {
   let container = Container.create(rootNode);
   let ui = RenderContainer.create(window, rootNode, container, mouseCursor);
 
+  let _ignore = 
+    Revery_Core.Event.subscribe(
+    window.onExposed,
+    () => {
+      uiDirty := true
+    });
+
   let _ignore =
     Revery_Core.Event.subscribe(
       window.onMouseMove,

--- a/src/UI/Ui.re
+++ b/src/UI/Ui.re
@@ -39,12 +39,8 @@ let start = (window: Window.t, element: React.syntheticElement) => {
   let container = Container.create(rootNode);
   let ui = RenderContainer.create(window, rootNode, container, mouseCursor);
 
-  let _ignore = 
-    Revery_Core.Event.subscribe(
-    window.onExposed,
-    () => {
-      uiDirty := true
-    });
+  let _ignore =
+    Revery_Core.Event.subscribe(window.onExposed, () => {uiDirty := true});
 
   let _ignore =
     Revery_Core.Event.subscribe(


### PR DESCRIPTION
This is a fix for https://github.com/onivim/oni2/issues/587 - in i3 or some window managers, when the window is presented or switched to, it would be empty - we weren't triggering a re-render.

SDL2 gives an event for this - the `SDL_WINDOW_EXPOSED` (docs: https://wiki.libsdl.org/SDL_WindowEvent). 

The fix is simply to listen for this and re-draw the UI when we get it.