### PR TITLE
Perf: Use waitTimeout when idle

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -215,15 +215,11 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
         appInstance.onIdle();
       };
 
-      let evt = Sdl2.Event.wait();
+      let evt = Sdl2.Event.waitTimeout(250);
       switch (evt) {
-      | Ok(evt) => _handleEvent(evt);
-      | Error(_) => ();
-      }
-      /*switch (evt) {
       | None => ()
       | Some(evt) => _handleEvent(evt);
-      }*/
+      }
     };
 
     Environment.yield();

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -125,53 +125,52 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
 
   let _ = Sdl2.ScreenSaver.enable();
 
-  let _handleEvent = (evt) => {
-        let handleEvent = windowID => {
-          let window = getWindowById(appInstance, windowID);
-          switch (window) {
-          | Some(win) => Window._handleEvent(evt, win)
-          | None =>
-            logError(
-              "Unable to find window with ID: "
-              ++ string_of_int(windowID)
-              ++ " - event: "
-              ++ Sdl2.Event.show(evt),
-            )
-          };
-        };
-        switch (evt) {
-        | Sdl2.Event.MouseButtonUp({windowID, _}) => handleEvent(windowID)
-        | Sdl2.Event.MouseButtonDown({windowID, _}) => handleEvent(windowID)
-        | Sdl2.Event.MouseMotion({windowID, _}) => handleEvent(windowID)
-        | Sdl2.Event.MouseWheel({windowID, _}) => handleEvent(windowID)
-        | Sdl2.Event.KeyDown({windowID, _}) => handleEvent(windowID)
-        | Sdl2.Event.KeyUp({windowID, _}) => handleEvent(windowID)
-        | Sdl2.Event.TextInput({windowID, _}) => handleEvent(windowID)
-        | Sdl2.Event.TextEditing({windowID, _}) => handleEvent(windowID)
-        | Sdl2.Event.WindowResized({windowID, _}) => handleEvent(windowID)
-        | Sdl2.Event.WindowSizeChanged({windowID, _}) =>
-          handleEvent(windowID)
-        | Sdl2.Event.WindowExposed({windowID, _}) => handleEvent(windowID)
-        | Sdl2.Event.WindowMoved({windowID, _}) => handleEvent(windowID)
-        | Sdl2.Event.WindowEnter({windowID}) => handleEvent(windowID)
-        | Sdl2.Event.WindowLeave({windowID}) => handleEvent(windowID)
-        | Sdl2.Event.WindowClosed({windowID, _}) =>
-          logInfo("Got window closed event: " ++ string_of_int(windowID));
-          handleEvent(windowID);
-          switch (getWindowById(appInstance, windowID)) {
-          | None => ()
-          | Some(win) => _tryToClose(appInstance, win)
-          };
-        | Sdl2.Event.Quit =>
-          // Sometimes, on Mac, we could get a 'quit' without a
-          // corresponding WindowClosed event - this can happen
-          // if Command+Q is pressed. In that case, we'll try
-          // closing all the windows - and if they all close,
-          // we'll exit the app.
-          quit(~code=0, appInstance)
-        | _ => ()
-        };
+  let _handleEvent = evt => {
+    let handleEvent = windowID => {
+      let window = getWindowById(appInstance, windowID);
+      switch (window) {
+      | Some(win) => Window._handleEvent(evt, win)
+      | None =>
+        logError(
+          "Unable to find window with ID: "
+          ++ string_of_int(windowID)
+          ++ " - event: "
+          ++ Sdl2.Event.show(evt),
+        )
       };
+    };
+    switch (evt) {
+    | Sdl2.Event.MouseButtonUp({windowID, _}) => handleEvent(windowID)
+    | Sdl2.Event.MouseButtonDown({windowID, _}) => handleEvent(windowID)
+    | Sdl2.Event.MouseMotion({windowID, _}) => handleEvent(windowID)
+    | Sdl2.Event.MouseWheel({windowID, _}) => handleEvent(windowID)
+    | Sdl2.Event.KeyDown({windowID, _}) => handleEvent(windowID)
+    | Sdl2.Event.KeyUp({windowID, _}) => handleEvent(windowID)
+    | Sdl2.Event.TextInput({windowID, _}) => handleEvent(windowID)
+    | Sdl2.Event.TextEditing({windowID, _}) => handleEvent(windowID)
+    | Sdl2.Event.WindowResized({windowID, _}) => handleEvent(windowID)
+    | Sdl2.Event.WindowSizeChanged({windowID, _}) => handleEvent(windowID)
+    | Sdl2.Event.WindowExposed({windowID, _}) => handleEvent(windowID)
+    | Sdl2.Event.WindowMoved({windowID, _}) => handleEvent(windowID)
+    | Sdl2.Event.WindowEnter({windowID}) => handleEvent(windowID)
+    | Sdl2.Event.WindowLeave({windowID}) => handleEvent(windowID)
+    | Sdl2.Event.WindowClosed({windowID, _}) =>
+      logInfo("Got window closed event: " ++ string_of_int(windowID));
+      handleEvent(windowID);
+      switch (getWindowById(appInstance, windowID)) {
+      | None => ()
+      | Some(win) => _tryToClose(appInstance, win)
+      };
+    | Sdl2.Event.Quit =>
+      // Sometimes, on Mac, we could get a 'quit' without a
+      // corresponding WindowClosed event - this can happen
+      // if Command+Q is pressed. In that case, we'll try
+      // closing all the windows - and if they all close,
+      // we'll exit the app.
+      quit(~code=0, appInstance)
+    | _ => ()
+    };
+  };
 
   let _flushEvents = () => {
     let processingEvents = ref(true);
@@ -180,7 +179,7 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
       let evt = Sdl2.Event.poll();
       switch (evt) {
       | None => processingEvents := false
-      | Some(v) => _handleEvent(v);
+      | Some(v) => _handleEvent(v)
       };
     };
   };
@@ -218,8 +217,8 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
       let evt = Sdl2.Event.waitTimeout(250);
       switch (evt) {
       | None => ()
-      | Some(evt) => _handleEvent(evt);
-      }
+      | Some(evt) => _handleEvent(evt)
+      };
     };
 
     Environment.yield();


### PR DESCRIPTION
This helps decrease CPU usage when idle by using the `waitTimeout` SDL2 method instead of just a random `sleep`. 

In addition, if we get something to run from another thread, we 'wake up' the application from the `waitTimeout`.