### PR TITLE
Bugfix: Revery doesn't allow application to sleep

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -120,6 +120,11 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
   let _ = Sdl2.init();
   let _dispose = initFunc(appInstance);
 
+  // By default, SDL2 suppresses the screen saver and sleep mode
+  // (this makes sense for games!). However, we should not be blocking
+  // sleep / screensavers for Revery applications.
+  let _ = Sdl2.ScreenSaver.enable();
+
   let _flushEvents = () => {
     let processingEvents = ref(true);
 


### PR DESCRIPTION
Thanks @mrkishi for catching this! It turns out SDL2 does not allow the screen saver / sleep to  turn on by default (this makes sense for games). We do not want to block screen saver / sleep with Revery, though.