### PR TITLE
Bugfix: Tick.timeout not disposing as expected

### DIFF
--- a/src/Core/Tick.re
+++ b/src/Core/Tick.re
@@ -12,11 +12,11 @@ module Make = (ClockImpl: Clock) => {
     UniqueId.Make({});
 
   type tickType =
-  | Timeout
-  | Interval;
+    | Timeout
+    | Interval;
 
   type tickFunction = {
-    tickType: tickType,
+    tickType,
     id: int,
     lastExecutionTime: Time.t,
     frequency: Time.t,
@@ -27,11 +27,11 @@ module Make = (ClockImpl: Clock) => {
 
   let _filterMap = (v: list(option('a))): list('a) => {
     let rec f = v =>
-    switch (v) {
-    | [Some(hd), ...tail]  => [hd, ...f(tail)];
-    | [None, ...tail] => f(tail);
-    | [] => [];
-    };
+      switch (v) {
+      | [Some(hd), ...tail] => [hd, ...f(tail)]
+      | [None, ...tail] => f(tail)
+      | [] => []
+      };
 
     f(v);
   };
@@ -47,17 +47,19 @@ module Make = (ClockImpl: Clock) => {
       if (nextTime <= currentTime) {
         let elapsedTime = Time.of_float_seconds(currentTime -. lastTime);
         ignore(tf.f(elapsedTime));
-        switch(tf.tickType) {
+        switch (tf.tickType) {
         | Timeout => None
-        | Interval => Some({...tf, lastExecutionTime: Time.of_float_seconds(currentTime)});
-        }
+        | Interval =>
+          Some({
+            ...tf,
+            lastExecutionTime: Time.of_float_seconds(currentTime),
+          })
+        };
       } else {
         Some(tf);
       };
     };
-    _activeTickers := _activeTickers^
-    |> List.map(f)
-    |> _filterMap;
+    _activeTickers := _activeTickers^ |> List.map(f) |> _filterMap;
   };
 
   let _clear = (id: int, ()) => {

--- a/src/Core/Tick.re
+++ b/src/Core/Tick.re
@@ -13,7 +13,6 @@ module IntMap =
     let compare = compare;
   });
 
-
 module Make = (ClockImpl: Clock) => {
   module TickId =
     UniqueId.Make({});
@@ -49,8 +48,12 @@ module Make = (ClockImpl: Clock) => {
     f(v);
   };
 
-  let show = () => _activeTickers^
-  |> List.fold_left((prev, curr) => showTickFunction(curr) ++ ", " ++ prev, "");
+  let show = () =>
+    _activeTickers^
+    |> List.fold_left(
+         (prev, curr) => showTickFunction(curr) ++ ", " ++ prev,
+         "",
+       );
 
   let pump = () => {
     // Add any newly-scheduled tickers
@@ -59,12 +62,17 @@ module Make = (ClockImpl: Clock) => {
 
     // Clear any pending tickers
     let cancelled = _cancelledTickers^;
-    _activeTickers := List.fold_left((prev, curr) => {
-     switch (IntMap.find_opt(curr.id, cancelled)) {
-     | None => [curr, ...prev]
-     | Some(_) => prev;
-     }
-    }, [], _activeTickers^);
+    _activeTickers :=
+      List.fold_left(
+        (prev, curr) => {
+          switch (IntMap.find_opt(curr.id, cancelled)) {
+          | None => [curr, ...prev]
+          | Some(_) => prev
+          }
+        },
+        [],
+        _activeTickers^,
+      );
     _cancelledTickers := IntMap.empty;
 
     let currentTime = Time.to_float_seconds(ClockImpl.time());

--- a/test/Core/TickTest.re
+++ b/test/Core/TickTest.re
@@ -31,31 +31,38 @@ describe("Ticker", ({describe, _}) => {
 
       expect.int(callCount^).toBe(1);
     });
-    test("nested tick - tick gets scheduled when called from inside tick", ({expect, _}) => {
-      
+    test(
+      "nested tick - tick gets scheduled when called from inside tick",
+      ({expect, _}) => {
       let outerCallCount = ref(0);
       let innerCallCount = ref(0);
-      
-      let _ignore = Tick.timeout(() => {
-        incr(outerCallCount);
-        let _ignore = Tick.timeout(() => incr(innerCallCount), Seconds(0.11));
-        }, Seconds(0.));
+
+      let _ignore =
+        Tick.timeout(
+          () => {
+            incr(outerCallCount);
+            let _ignore =
+              Tick.timeout(() => incr(innerCallCount), Seconds(0.11));
+            ();
+          },
+          Seconds(0.),
+        );
       TestTicker.incrementTime(Seconds(0.11));
       Tick.pump();
 
       expect.int(outerCallCount^).toBe(1);
       expect.int(innerCallCount^).toBe(0);
-      
+
       TestTicker.incrementTime(Seconds(0.11));
       Tick.pump();
-      
+
       expect.int(outerCallCount^).toBe(1);
       expect.int(innerCallCount^).toBe(1);
 
       // Incrementing again, the timeout should've expired - so no additional increment
       TestTicker.incrementTime(Seconds(1.01));
       Tick.pump();
-      
+
       expect.int(outerCallCount^).toBe(1);
       expect.int(innerCallCount^).toBe(1);
     });

--- a/test/Core/TickTest.re
+++ b/test/Core/TickTest.re
@@ -16,75 +16,76 @@ module TestTicker = {
 module Tick = Revery_Core.Internal.Tick.Make(TestTicker);
 
 describe("Ticker", ({describe, _}) => {
-describe("timeout", ({test, _}) => {
-  test("calls once after tick time", ({expect, _}) => {
-    let callCount = ref(0);
-    let _ignore = Tick.timeout(() => incr(callCount), Seconds(1.));
-    TestTicker.incrementTime(Seconds(1.01));
-    Tick.pump();
+  describe("timeout", ({test, _}) => {
+    test("calls once after tick time", ({expect, _}) => {
+      let callCount = ref(0);
+      let _ignore = Tick.timeout(() => incr(callCount), Seconds(1.));
+      TestTicker.incrementTime(Seconds(1.01));
+      Tick.pump();
 
-    expect.int(callCount^).toBe(1);
+      expect.int(callCount^).toBe(1);
 
-    // Incrementing again, the timeout should've expired - so no additional increment
-    TestTicker.incrementTime(Seconds(1.01));
-    Tick.pump();
-    
-    expect.int(callCount^).toBe(1);
+      // Incrementing again, the timeout should've expired - so no additional increment
+      TestTicker.incrementTime(Seconds(1.01));
+      Tick.pump();
+
+      expect.int(callCount^).toBe(1);
+    });
+    test("doesn't call if canceled", ({expect, _}) => {
+      let callCount = ref(0);
+      let cancel = Tick.timeout(() => incr(callCount), Seconds(1.));
+      TestTicker.incrementTime(Seconds(0.5));
+      Tick.pump();
+
+      cancel();
+      TestTicker.incrementTime(Seconds(0.51));
+      Tick.pump();
+
+      expect.int(callCount^).toBe(0);
+    });
   });
-  test("doesn't call if canceled", ({expect, _}) => {
-    let callCount = ref(0);
-    let cancel = Tick.timeout(() => incr(callCount), Seconds(1.));
-    TestTicker.incrementTime(Seconds(0.5));
-    Tick.pump();
+  describe("interval", ({test, _}) => {
+    test("calls after tick time", ({expect, _}) => {
+      let callCount = ref(0);
 
-    cancel();
-    TestTicker.incrementTime(Seconds(0.51));
-    Tick.pump();
+      let _ignore =
+        Tick.interval(_ => callCount := callCount^ + 1, Seconds(1.));
 
-    expect.int(callCount^).toBe(0);
-  });
-});
-describe("interval", ({test, _}) => {
-  test("calls after tick time", ({expect, _}) => {
-    let callCount = ref(0);
+      TestTicker.incrementTime(Seconds(1.01));
 
-    let _ignore =
-      Tick.interval(_ => callCount := callCount^ + 1, Seconds(1.));
+      expect.int(callCount^).toBe(0);
+      Tick.pump();
+      expect.int(callCount^).toBe(1);
 
-    TestTicker.incrementTime(Seconds(1.01));
+      Tick.pump();
+      expect.int(callCount^).toBe(1);
 
-    expect.int(callCount^).toBe(0);
-    Tick.pump();
-    expect.int(callCount^).toBe(1);
+      TestTicker.incrementTime(Seconds(0.9));
+      Tick.pump();
+      expect.int(callCount^).toBe(1);
 
-    Tick.pump();
-    expect.int(callCount^).toBe(1);
+      TestTicker.incrementTime(Seconds(0.11));
+      Tick.pump();
+      expect.int(callCount^).toBe(2);
+    });
 
-    TestTicker.incrementTime(Seconds(0.9));
-    Tick.pump();
-    expect.int(callCount^).toBe(1);
+    test("disposing tick subscription stops the tick", ({expect, _}) => {
+      let callCount = ref(0);
 
-    TestTicker.incrementTime(Seconds(0.11));
-    Tick.pump();
-    expect.int(callCount^).toBe(2);
-  });
+      let stop =
+        Tick.interval(_ => callCount := callCount^ + 1, Seconds(1.));
 
-  test("disposing tick subscription stops the tick", ({expect, _}) => {
-    let callCount = ref(0);
+      TestTicker.incrementTime(Seconds(1.01));
 
-    let stop = Tick.interval(_ => callCount := callCount^ + 1, Seconds(1.));
+      expect.int(callCount^).toBe(0);
+      Tick.pump();
+      expect.int(callCount^).toBe(1);
 
-    TestTicker.incrementTime(Seconds(1.01));
+      stop();
 
-    expect.int(callCount^).toBe(0);
-    Tick.pump();
-    expect.int(callCount^).toBe(1);
-
-    stop();
-
-    TestTicker.incrementTime(Seconds(2.));
-    Tick.pump();
-    expect.int(callCount^).toBe(1);
-  });
+      TestTicker.incrementTime(Seconds(2.));
+      Tick.pump();
+      expect.int(callCount^).toBe(1);
+    });
   });
 });

--- a/test/Core/TickTest.re
+++ b/test/Core/TickTest.re
@@ -15,7 +15,36 @@ module TestTicker = {
 
 module Tick = Revery_Core.Internal.Tick.Make(TestTicker);
 
-describe("Ticker", ({test, _}) => {
+describe("Ticker", ({describe, _}) => {
+describe("timeout", ({test, _}) => {
+  test("calls once after tick time", ({expect, _}) => {
+    let callCount = ref(0);
+    let _ignore = Tick.timeout(() => incr(callCount), Seconds(1.));
+    TestTicker.incrementTime(Seconds(1.01));
+    Tick.pump();
+
+    expect.int(callCount^).toBe(1);
+
+    // Incrementing again, the timeout should've expired - so no additional increment
+    TestTicker.incrementTime(Seconds(1.01));
+    Tick.pump();
+    
+    expect.int(callCount^).toBe(1);
+  });
+  test("doesn't call if canceled", ({expect, _}) => {
+    let callCount = ref(0);
+    let cancel = Tick.timeout(() => incr(callCount), Seconds(1.));
+    TestTicker.incrementTime(Seconds(0.5));
+    Tick.pump();
+
+    cancel();
+    TestTicker.incrementTime(Seconds(0.51));
+    Tick.pump();
+
+    expect.int(callCount^).toBe(0);
+  });
+});
+describe("interval", ({test, _}) => {
   test("calls after tick time", ({expect, _}) => {
     let callCount = ref(0);
 
@@ -56,5 +85,6 @@ describe("Ticker", ({test, _}) => {
     TestTicker.incrementTime(Seconds(2.));
     Tick.pump();
     expect.int(callCount^).toBe(1);
+  });
   });
 });


### PR DESCRIPTION
`Tick.timeout` should schedule a function to be dispatched once; however, there was a bug in which it would never be cleaned up.