### PR TITLE
CI: Bump node version

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -1,9 +1,6 @@
 # Cross-platform set of build steps for building esy projects
 
 steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '8.9'
   - script: npm install -g esy@0.5.8
     displayName: 'npm install -g esy@0.5.8'
   - script: esy install

--- a/.ci/esy-check-hygiene.yml
+++ b/.ci/esy-check-hygiene.yml
@@ -1,9 +1,6 @@
 # Cross-platform set of build steps for building esy projects
 
 steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '8.9'
   - script: npm install -g esy@0.5.8
     displayName: 'npm install -g esy@0.5.8'
   - script: esy install

--- a/.ci/use-node.yml
+++ b/.ci/use-node.yml
@@ -1,5 +1,5 @@
 steps:
   - task: NodeTool@0
-    displayName: 'Use Node 8.x'
+    displayName: 'Use Node 12.x'
     inputs:
-      versionSpec: 8.x
+      versionSpec: 12.x

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ jobs:
   - script: brew update
   - script: brew install libpng ragel
   - script: node --version
-  - template: .ci/restore-build-cache.yml
+  # - template: .ci/restore-build-cache.yml
   - template: .ci/esy-check-hygiene.yml
   - template: .ci/publish-build-cache.yml
 
@@ -64,7 +64,7 @@ jobs:
   - script: brew update
   - script: brew install libpng ragel
   - script: node --version
-  - template: .ci/restore-build-cache.yml
+  # - template: .ci/restore-build-cache.yml
   - template: .ci/esy-build-steps.yml
   - template: .ci/esy-bench.yml
   - template: .ci/publish-build-cache.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,9 +41,9 @@ jobs:
     # ESY__NPM_ROOT: /usr/local/lib/node_modules/esy
 
   steps:
+  - template: .ci/use-node.yml
   - script: brew update
   - script: brew install libpng ragel
-  - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml
   - template: .ci/esy-check-hygiene.yml
   - template: .ci/publish-build-cache.yml
@@ -61,9 +61,9 @@ jobs:
     # ESY__NPM_ROOT: /usr/local/lib/node_modules/esy
 
   steps:
+  - template: .ci/use-node.yml
   - script: brew update
   - script: brew install libpng ragel
-  - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml
   - template: .ci/esy-build-steps.yml
   - template: .ci/esy-bench.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,9 +41,8 @@ jobs:
     # ESY__NPM_ROOT: /usr/local/lib/node_modules/esy
 
   steps:
-  - template: .ci/use-node.yml
   - script: brew update
-  - script: brew install libpng ragel
+  - script: brew install node libpng ragel
   - template: .ci/restore-build-cache.yml
   - template: .ci/esy-check-hygiene.yml
   - template: .ci/publish-build-cache.yml
@@ -61,9 +60,8 @@ jobs:
     # ESY__NPM_ROOT: /usr/local/lib/node_modules/esy
 
   steps:
-  - template: .ci/use-node.yml
   - script: brew update
-  - script: brew install libpng ragel
+  - script: brew install node libpng ragel
   - template: .ci/restore-build-cache.yml
   - template: .ci/esy-build-steps.yml
   - template: .ci/esy-bench.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,8 @@ jobs:
 
   steps:
   - script: brew update
-  - script: brew install node libpng ragel
+  - script: brew install libpng ragel
+  - script: node --version
   - template: .ci/restore-build-cache.yml
   - template: .ci/esy-check-hygiene.yml
   - template: .ci/publish-build-cache.yml
@@ -61,7 +62,8 @@ jobs:
 
   steps:
   - script: brew update
-  - script: brew install node libpng ragel
+  - script: brew install libpng ragel
+  - script: node --version
   - template: .ci/restore-build-cache.yml
   - template: .ci/esy-build-steps.yml
   - template: .ci/esy-bench.yml


### PR DESCRIPTION
CI started failing with: 
```
##[section]Starting: Use Node 8.x
==============================================================================
Task         : Node.js tool installer
Description  : Finds or downloads and caches the specified version spec of Node.js and adds it to the PATH
Version      : 0.159.0
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/tool/node-js
==============================================================================
Downloading: https://nodejs.org/dist/v8.16.2/node-v8.16.2-darwin-x64.tar.gz
Extracting archive
[command]/usr/bin/tar xzC /Users/runner/runners/2.158.0/work/_temp/fe28070c-703f-4e2e-a618-27b57f84255e -f /Users/runner/runners/2.158.0/work/_temp/9026c5fe-cc47-4dd3-9938-db10c2477341
node-v8.16.2-darwin-x64/bin/node: (Empty error message)
tar: Error exit delayed from previous errors.
##[error]/usr/bin/tar failed with return code: 1
##[section]Finishing: Use Node 8.x
```

I'm trying to bump the node version to see if that helps...