### PR TITLE
Fix ScrollView freaking out when scrolling without overflow

### DIFF
--- a/src/UI_Components/ScrollView.re
+++ b/src/UI_Components/ScrollView.re
@@ -60,7 +60,7 @@ let make =
         let childMeasurements = inner#measurements();
         let outerMeasurements = outer#measurements();
 
-        let maxHeight = childMeasurements.height - outerMeasurements.height;
+        let maxHeight = max(0, childMeasurements.height - outerMeasurements.height);
         let maxWidth = childMeasurements.width - outerMeasurements.width;
 
         /*

--- a/src/UI_Components/ScrollView.re
+++ b/src/UI_Components/ScrollView.re
@@ -60,7 +60,8 @@ let make =
         let childMeasurements = inner#measurements();
         let outerMeasurements = outer#measurements();
 
-        let maxHeight = max(0, childMeasurements.height - outerMeasurements.height);
+        let maxHeight =
+          max(0, childMeasurements.height - outerMeasurements.height);
         let maxWidth = childMeasurements.width - outerMeasurements.width;
 
         /*


### PR DESCRIPTION
This fixes an issue with ScrollView where scrolling with the scroll wheel when not overflowing causes the viewport to rapidly "invert" or "jump" from top to bottom. This is because `maxHeight` is calculated to be negative when the content is smaller than the ScrollView. Fixed by clamping to 0.