### PR TITLE
[WIP] API - Native: Shell.openItem

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -293,6 +293,8 @@ let init = app => {
       "Welcome to Revery!",
     );
 
+  Revery_Native.Shell.openItem("file://~");
+
   if (Environment.webGL) {
     Window.maximize(win);
     ();

--- a/src/Native/ReveryCocoa.h
+++ b/src/Native/ReveryCocoa.h
@@ -1,3 +1,4 @@
 extern "C" {	
    void revery_alert_cocoa(void* pWin, const char* szMessage);
+   void revery_openItem_cocoa(const char *szItem);
 }

--- a/src/Native/Revery_Native.re
+++ b/src/Native/Revery_Native.re
@@ -1,1 +1,2 @@
 module Dialog = Dialog;
+module Shell = Shell;

--- a/src/Native/Shell.re
+++ b/src/Native/Shell.re
@@ -1,0 +1,5 @@
+//open Reglfw.Glfw;
+
+[@noalloc] external openItem: string => unit = "revery_openItem";
+
+// [@noalloc] external alert: (NativeWindow.t, string) => unit = "revery_alert";

--- a/src/Native/Shell.rei
+++ b/src/Native/Shell.rei
@@ -1,0 +1,5 @@
+/*
+ [openItem(path)] opens an item as if the user opened from the platform's desktop environment
+*/
+let openItem: string => unit;
+

--- a/src/Native/dialog.cpp
+++ b/src/Native/dialog.cpp
@@ -38,8 +38,25 @@ CAMLprim value revery_alert(value vWindow, value vMessage) {
 #elif __linux__
   revery_alert_gtk(pWin, szMessage);
 #else
-  printf("WARNING - Not implemented: alert");
+  // No-op
 #endif
-  return Val_unit;
+  CAMLreturn(Val_unit);
 }
+
+CAMLprim value revery_openItem(value vItem) {
+  CAMLparam1(vItem);
+
+  const char *szItem = String_val(vItem);
+  #ifdef WIN32
+    // TODO
+  #elif __APPLE__
+    revery_openItem_cocoa(szItem);
+  #elif __linux__
+    // TODO
+  #else
+    // No-op
+  #endif
+  CAMLreturn(Val_unit);
+}
+
 }

--- a/src/Native/dialog_cocoa.c
+++ b/src/Native/dialog_cocoa.c
@@ -14,4 +14,12 @@ void revery_alert_cocoa(void *pWin, const char *szMessage) {
     [alert setInformativeText:message];
     [alert runModal];
 }
+
+void revery_openItem_cocoa(const char *szItem) {
+    CFURLRef url = CFURLCreateWithBytes (NULL, (UInt8 *)szItem, strlen
+    (szItem),
+    kCFStringEncodingASCII, NULL);
+    LSOpenCFURLRef (url, NULL);
+    CFRelease (url);
+}
 #endif

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -3,7 +3,7 @@
     (public_name Revery.Native)
     (preprocess (pps lwt_ppx))
     (library_flags (:include flags.sexp))
-    (js_of_ocaml (javascript_files dialog.js))
+    (js_of_ocaml (javascript_files dialog.js shell.js))
     (c_names dialog_cocoa dialog_win32 dialog_gtk)
     (cxx_names dialog)
     (c_flags (:include c_flags.sexp))

--- a/src/Native/shell.js
+++ b/src/Native/shell.js
@@ -1,0 +1,4 @@
+// Provides: revery_openItem
+function revery_openItem(url) {
+    window.open(url);
+}


### PR DESCRIPTION
This API is inspired by the Electron [`openItem`](https://electronjs.org/docs/api/shell#shellopenitemfullpath) API - it provides a way for us to pass a URL to the OS and have it open in the correct application.

Some use cases:
- On a _welcome screen_ for Onivim 2, we could have links to the user manual / tutorials
- For Onivim 2, we could add some helper items in the command palette that open the configuration folder and extensions folder for convenience (using a `file://` URL)
- We could add a 'github' icon to the statusbar for to go to our issues page, for quick bug logging