### PR TITLE
feat: add more mouse-events to Text-primitive

### DIFF
--- a/src/UI_Primitives/Text.re
+++ b/src/UI_Primitives/Text.re
@@ -8,6 +8,10 @@ let%nativeComponent make =
                       ~onMouseMove=?,
                       ~onMouseUp=?,
                       ~onMouseWheel=?,
+                      ~onMouseEnter=?,
+                      ~onMouseLeave=?,
+                      ~onMouseOver=?,
+                      ~onMouseOut=?,
                       ~ref=?,
                       ~style=emptyTextStyle,
                       ~text="",
@@ -26,6 +30,10 @@ let%nativeComponent make =
           ~onMouseMove?,
           ~onMouseUp?,
           ~onMouseWheel?,
+          ~onMouseEnter?,
+          ~onMouseLeave?,
+          ~onMouseOver?,
+          ~onMouseOut?,
           (),
         );
       let node = PrimitiveNodeFactory.get().createTextNode(text);
@@ -42,6 +50,10 @@ let%nativeComponent make =
           ~onMouseMove?,
           ~onMouseUp?,
           ~onMouseWheel?,
+          ~onMouseEnter?,
+          ~onMouseLeave?,
+          ~onMouseOver?,
+          ~onMouseOut?,
           (),
         );
 


### PR DESCRIPTION
I've begun using "Hover"-primitives in projects, but the `Text`-primitive is missing a few mouse-events. I think it makes sense since they're already in the `View`!

```ocaml
// Hover.re
module Text = {
  type state =
    | Idle
    | Hover
    | Active;

  type action =
    | Idle
    | Hover
    | Active;

  let%component make =
                (
                  ~text,
                  ~hoverStyles=[],
                  ~activeStyles=[],
                  ~style=[],
                  ~onClick=?,
                  (),
                ) => {
    let%hook (state, dispatch) =
      Hooks.reducer(~initialState=Idle, (action, _state) =>
        switch (action) {
        | Idle => Idle
        | Hover => Hover
        | Active => Active
        }
      );

    let currentStyle =
      switch (state) {
      | Idle => style
      | Hover => Style.merge(~source=style, ~target=hoverStyles)
      | Active => Style.merge(~source=style, ~target=activeStyles)
      };

    <Clickable ?onClick>
      <Text
        onMouseOut={_ => dispatch(Idle)}
        onMouseOver={_ => dispatch(Hover)}
        onMouseDown={_ => dispatch(Active)}
        style=currentStyle
        text
      />
    </Clickable>;
  };
};
```