### PR TITLE
Add a titlebar style option

### DIFF
--- a/src/Core/Revery_Core.re
+++ b/src/Core/Revery_Core.re
@@ -23,6 +23,7 @@ module TextOverflow = TextOverflow;
 
 module Vsync = Vsync;
 module WindowCreateOptions = WindowCreateOptions;
+module WindowStyles = WindowStyles;
 
 /*
  * Internally exposed modules, just for testing.

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -92,6 +92,12 @@ let setTitle = (v: t, title: string) => {
   Sdl2.Window.setTitle(v.sdlWindow, title);
 };
 
+let setTitlebarTransparent = (w: Sdl2.Window.t) =>
+  switch (Environment.os) {
+  | Mac => Sdl2.Window.setMacTitlebarTransparent(w)
+  | _ => ()
+  };
+
 let _getScaleFactor = (~forceScaleFactor=None, sdlWindow) => {
   switch (forceScaleFactor) {
   // If a scale factor is forced... prefer that!
@@ -472,6 +478,11 @@ let create = (name: string, options: WindowCreateOptions.t) => {
 
   if (options.visible) {
     Sdl2.Window.show(w);
+  };
+
+  switch (options.titlebarStyle) {
+  | System => ()
+  | Transparent => setTitlebarTransparent(w)
   };
 
   // onivim/oni2#791

--- a/src/Core/WindowCreateOptions.re
+++ b/src/Core/WindowCreateOptions.re
@@ -17,6 +17,11 @@ type t = {
     */
   decorated: bool,
   /**
+   [titlebarStyle] sets the appearance of the titlebar. Eventually this will be platform
+   independent, but as of right now, Transparent only works on macOS.
+    */
+  titlebarStyle: WindowStyles.titlebar,
+  /**
     [width] is the initial horizontal size of the [Window]
     */
   width: int,
@@ -51,6 +56,7 @@ let create =
       ~visible=true,
       ~maximized=false,
       ~decorated=true,
+      ~titlebarStyle=WindowStyles.System,
       ~width=800,
       ~height=600,
       ~backgroundColor=Colors.cornflowerBlue,
@@ -63,6 +69,7 @@ let create =
   visible,
   maximized,
   decorated,
+  titlebarStyle,
   width,
   height,
   backgroundColor,

--- a/src/Core/WindowStyles.re
+++ b/src/Core/WindowStyles.re
@@ -1,0 +1,4 @@
+type titlebar =
+  | System
+  // Only works on macOS as of right now
+  | Transparent;


### PR DESCRIPTION
This ties into the newly added `Sdl2.Window.setMacTitlebarTransparent`, which should eventually be expanded to other OSs.

I created a new file, `WindowStyles.re` to house all the styling of windows we may have in the future.