### PR TITLE
Fix #647, timer set on mount not being cleared 

### DIFF
--- a/src/UI_Hooks/Revery_UI_Hooks.re
+++ b/src/UI_Hooks/Revery_UI_Hooks.re
@@ -16,7 +16,7 @@ let time = (~tickRate=Time.zero, ()) => {
 // TODO: Workaround for https://github.com/briskml/brisk-reconciler/issues/27
 // Remove when fixed
 let mountIfEffect = (condition, handler) => {
-  let%hook (maybeDispose, _setDispose) = state(Pervasives.ref(None));
+  let%hook (maybeDispose, _setDispose) = state(Stdlib.ref(None));
   let mountCleanup = () =>
     switch (maybeDispose^) {
     | Some(dispose) =>

--- a/src/UI_Hooks/Revery_UI_Hooks.re
+++ b/src/UI_Hooks/Revery_UI_Hooks.re
@@ -16,12 +16,12 @@ let time = (~tickRate=Time.zero, ()) => {
 // TODO: Workaround for https://github.com/briskml/brisk-reconciler/issues/27
 // Remove when fixed
 let mountIfEffect = (condition, handler) => {
-  let%hook (maybeDispose, setDispose) = Ref.ref(None);
+  let%hook (maybeDispose, _setDispose) = state(Pervasives.ref(None));
   let mountCleanup = () =>
-    switch (maybeDispose) {
+    switch (maybeDispose^) {
     | Some(dispose) =>
       dispose();
-      setDispose(None);
+      maybeDispose := None;
     | None => ()
     };
 
@@ -29,7 +29,7 @@ let mountIfEffect = (condition, handler) => {
     effect(
       OnMount,
       () => {
-        setDispose(handler());
+        maybeDispose := handler();
         Some(mountCleanup);
       },
     );
@@ -42,6 +42,7 @@ let mountIfEffect = (condition, handler) => {
         handler();
       },
     );
+
   ();
 };
 


### PR DESCRIPTION
Fixes #647 

Ach, foiled by the naming of `Ref.ref` again!

So what happened was that the `mountCleanup` closure was returned as the dispose function on mount, but that closure would always refer to the initial value of `maybeDispose`, `None`, because it's not an actual `ref`.

Also, it still worked if the condition changes because that called `mountCleanup` directly instead of using a stored closure! So it seemed to work when you paused the logo animation, and it ALSO worked on unmount AFTER having paused and resumed, because that stored the `dispose` function directly, instead of a closure referring to a stale `maybeDispose`.

The solution is to put an ordinary `ref` in a `state` (or `ref`) hook, and to use ti as an ordinary `ref` instead of using the hook setter.