### PR TITLE
Build: Intermittent failure with (exited with 127)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     ],
     "install": [
       "esy-installer Revery.install",
-      "bash -c \"#{os == 'windows' ? 'cp /usr/x86_64-w64-mingw32/sys-root/mingw/bin/*.dll \\'$cur__bin\\'': 'echo Build complete'}\""
+      "bash -c \"#{os == 'windows' ? 'cp /usr/x86_64-w64-mingw32/sys-root/mingw/bin/*.dll \\'$cur__bin\\'': ':'}\""
     ]
   },
   "dependencies": {


### PR DESCRIPTION
For Onivim 2, we see intermittent build failures like:
```
    # esy-build-package: running: 'esy-installer' 'Revery.install'
    # esy-build-package: installing using built-in installer
    # esy-build-package: running: 'bash' '-c' 'echo Build complete'
    error: command failed: 'bash' '-c' 'echo Build complete' (exited with 127)
    esy-build-package: exiting with errors above...
```

When building Onivim / Revery on CI.

It seems that it is failing during our `install` step:
```
 "install": [	    "install": [
      "esy-installer Revery.install",	
      "bash -c \"#{os == 'windows' ? 'cp /usr/x86_64-w64-mingw32/sys-root/mingw/bin/*.dll \\'$cur__bin\\'': 'echo Build complete'}\""
    ]
```

...although it isn't clear why either `bash` or `echo` would give an exit code of 127 (not found). This switches to use bash's no-op operator `:` instead of using `echo` - it also removes some extraneous logging.