### PR TITLE
Bugfix: Ensure timer stops when the bounce is 'idle'

### DIFF
--- a/src/UI_Components/ScrollView.re
+++ b/src/UI_Components/ScrollView.re
@@ -59,7 +59,9 @@ let%component make =
 
   let%hook (actualScrollTop, _bounceAnimationState, resetBouncingAnimation) =
     switch (bouncingState) {
-    | Idle => Hooks.animation(Animation.const(actualScrollTop))
+    | Idle =>
+      // TODO: Why isn't Animation.const always sufficient to stop the timer?
+      Hooks.animation(~active=false, Animation.const(actualScrollTop))
 
     | Bouncing(force) =>
       Hooks.animation(


### PR DESCRIPTION
__Issue:__ This came about from investigating onivim/oni2#946 - Revery would never shift into an 'idle' state, even though nothing was happening with the editor.

I started 'bisecting' the UI - I eventually found if I removed the file explorer, the issue did not repro. I dug further and found that it was only the `<ScrollView />` that caused the issue - if I removed the `<ScrollView />`, the app would downshift into idle.

The `<ScrollView />` chooses an animation strategy based on the animation state (a really neat, functional implementation!):
```
  let%hook (actualScrollTop, _bounceAnimationState, resetBouncingAnimation) =
    switch (bouncingState) {
    | Idle => Hooks.animation(Animation.const(actualScrollTop))

    | Bouncing(force) =>
      Hooks.animation(
        bounceAnimation(~origin=actualScrollTop, ~force), ~onComplete=() =>
        setBouncingState(_ => Idle)
      )
    };
```

I found, though, in the `Idle` state - the timer would continually fire - even though it shouldn't, as the animation is over instantly.

I thought that, perhaps this was a bug with a constant-animation in general - but mysteriously, this doesn't reproduce in the Revery example app (the ScrollView example). I'm still not exactly sure what is different between the `<ScrollView />` used in the file explorer, and the `<ScrollView />` used in the example app that would trigger these differences. Perhaps the way we render the UI triggers a different disposal route

__Fix:__ A simple fix that seems to address this is to add `~active=false` to the ScrollView's animation in the idle state. This fixes onivim/oni2#946 - but not sure if it is the best fix.