### PR TITLE
Respect position in reconciler

### DIFF
--- a/bench/lib/LayoutBench.re
+++ b/bench/lib/LayoutBench.re
@@ -28,7 +28,7 @@ let rec setupNodeTree =
 
   while (i^ > 0 && depth > 0) {
     let newNode = setupNodeTree(~depth=depth - 1, ~breadth, ());
-    n#addChild(newNode);
+    n#addChild(newNode, 0);
 
     decr(i);
   };

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -119,8 +119,7 @@ class node (()) = {
   pub getStyle = () => _style;
   pub setEvents = events => _events = events;
   pub getEvents = () => _events;
-  pub getChildren = () =>
-    _children;
+  pub getChildren = () => _children;
   pub getWorldTransform = () => {
     let state = _cachedNodeState |> getOrThrow("getWorldTransform");
     state.worldTransform;
@@ -259,34 +258,31 @@ class node (()) = {
     let bboxClipped = _this#getBoundingBoxClipped();
     BoundingBox2d.isPointInside(bboxClipped, p);
   };
-
   pub addChild = (child: node, position: int) => {
     let rec insert = (i, node, before, after) =>
       if (i > 0) {
         switch (after) {
-          | [] => after
-          | [head, ...tail] => insert(i - 1, node, [head, ...before], tail)
-        }
+        | [] => after
+        | [head, ...tail] => insert(i - 1, node, [head, ...before], tail)
+        };
       } else if (i == 0) {
-        insert(i - 1, node, before, [node, ...after])
+        insert(i - 1, node, before, [node, ...after]);
       } else {
         switch (before) {
-          | [] => after
-          | [head, ...tail] => insert(i, node, tail, [head, ...after])
-        }
+        | [] => after
+        | [head, ...tail] => insert(i, node, tail, [head, ...after])
+        };
       };
     _children = insert(position, child, [], _children);
     child#_setParent(Some((_this :> node)));
     _this#markLayoutDirty();
   };
-
   pub removeChild = (n: node) => {
     _children =
       List.filter(c => c#getInternalId() != n#getInternalId(), _children);
     n#_setParent(None);
     _this#markLayoutDirty();
   };
-
   pub firstChild = () => List.hd(_this#getChildren());
   pub getParent = () => _parent;
   pub getMeasureFunction = () => None;

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -262,7 +262,7 @@ class node (()) = {
     let rec insert = (i, node, before, after) =>
       if (i > 0) {
         switch (after) {
-        | [] => after
+        | [] => insert(0, node, before, after)
         | [head, ...tail] => insert(i - 1, node, [head, ...before], tail)
         };
       } else if (i == 0) {

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -6,6 +6,27 @@ module RenderPass = Revery_Draw.RenderPass;
 
 open Revery_Math;
 
+module ListEx = {
+  let insert = (i, node, list) => {
+    let rec loop = (i, before, after) =>
+      if (i > 0) {
+        switch (after) {
+        | [] => loop(0, before, after)
+        | [head, ...tail] => loop(i - 1, [head, ...before], tail)
+        };
+      } else if (i == 0) {
+        loop(i - 1, before, [node, ...after]);
+      } else {
+        switch (before) {
+        | [] => after
+        | [head, ...tail] => loop(i, tail, [head, ...after])
+        };
+      };
+
+    loop(i, [], list);
+  };
+};
+
 module UniqueId =
   Revery_Core.UniqueId.Make({});
 
@@ -259,21 +280,7 @@ class node (()) = {
     BoundingBox2d.isPointInside(bboxClipped, p);
   };
   pub addChild = (child: node, position: int) => {
-    let rec insert = (i, node, before, after) =>
-      if (i > 0) {
-        switch (after) {
-        | [] => insert(0, node, before, after)
-        | [head, ...tail] => insert(i - 1, node, [head, ...before], tail)
-        };
-      } else if (i == 0) {
-        insert(i - 1, node, before, [node, ...after]);
-      } else {
-        switch (before) {
-        | [] => after
-        | [head, ...tail] => insert(i, node, tail, [head, ...after])
-        };
-      };
-    _children = insert(position, child, [], _children);
+    _children = ListEx.insert(position, child, _children);
     child#_setParent(Some((_this :> node)));
     _this#markLayoutDirty();
   };

--- a/src/UI/Reconciler.re
+++ b/src/UI/Reconciler.re
@@ -15,8 +15,8 @@ type node = reveryNode;
 
 let onStale: Event.t(unit) = Event.create();
 
-let insertNode = (~parent: node, ~child: node, ~position as _) => {
-  parent#addChild(child);
+let insertNode = (~parent: node, ~child: node, ~position) => {
+  parent#addChild(child, position);
   parent;
 };
 

--- a/src/UI/UiEvents.re
+++ b/src/UI/UiEvents.re
@@ -101,7 +101,7 @@ let getTopMostNode = (node: node, pos) => {
 
       let ignored = mode == Ignore;
 
-      let revChildren = node#getRevChildren();
+      let revChildren = List.rev(node#getChildren());
       let ret =
         switch (revChildren) {
         | [] => ignored ? None : Some(node)

--- a/test/UI/MouseTest.re
+++ b/test/UI/MouseTest.re
@@ -72,10 +72,10 @@ describe("Mouse", ({describe, test, _}) => {
         ),
       );
 
-      node1#addChild(node2);
-      node3#addChild(node4);
-      rootNode#addChild(node1);
-      rootNode#addChild(node3);
+      node1#addChild(node2, 0);
+      node3#addChild(node4, 0);
+      rootNode#addChild(node1, 0);
+      rootNode#addChild(node3, 1);
 
       Layout.layout(rootNode);
       rootNode#recalculate();
@@ -152,10 +152,10 @@ describe("Mouse", ({describe, test, _}) => {
         ),
       );
 
-      node1#addChild(node2);
-      node3#addChild(node4);
-      rootNode#addChild(node1);
-      rootNode#addChild(node3);
+      node1#addChild(node2, 0);
+      node3#addChild(node4, 0);
+      rootNode#addChild(node1, 0);
+      rootNode#addChild(node3, 1);
 
       Layout.layout(rootNode);
       rootNode#recalculate();
@@ -221,9 +221,9 @@ describe("Mouse", ({describe, test, _}) => {
         let node2 = createChildNode();
         let node3 = createChildNode();
 
-        node1#addChild(node2);
-        rootNode#addChild(node1);
-        rootNode#addChild(node3);
+        node1#addChild(node2, 0);
+        rootNode#addChild(node1, 0);
+        rootNode#addChild(node3, 1);
 
         Layout.layout(rootNode);
         rootNode#recalculate();
@@ -481,7 +481,7 @@ describe("Mouse", ({describe, test, _}) => {
         NodeEvents.make(~onMouseOut=f, ~onMouseOver=f, ()),
       );
 
-      parentNode#addChild(childNode);
+      parentNode#addChild(childNode, 0);
 
       Mouse.dispatch(
         cursor,

--- a/test/UI/NodeTests.re
+++ b/test/UI/NodeTests.re
@@ -16,7 +16,7 @@ describe("NodeTests", ({test, _}) => {
 
     expect.option(childNode#getParent()).toBeNone();
 
-    parentNode#addChild(childNode);
+    parentNode#addChild(childNode, 0);
 
     expect.int(List.length(parentNode#getChildren())).toBe(1);
     expect.option(childNode#getParent()).toBe(
@@ -68,7 +68,7 @@ describe("NodeTests", ({test, _}) => {
 
       let childNode = (new node)();
       childNode#setStyle(Style.make(~width=25, ~height=25, ()));
-      parentNode#addChild(childNode);
+      parentNode#addChild(childNode, 0);
 
       Layout.layout(parentNode);
       parentNode#recalculate();


### PR DESCRIPTION
I'm surprised revery works as good as it does just ignoring this. But unfortunately I stumbled across a bug, as I do, which is likely caused by this. I've therefore changed `node#addChild` to insert by position, and removed `_revChildren` as it no longer serves much of a purpose other than to add complexity. I also believe the assumption that elements typically should be appended is wrong. But even if it isn't, an ordinary list is probably the wrong data structure to use here anyway. A double-ended linked list or skip list might be better.

We should probably implement `moveNode` properly as well, and `removeNode` might be made slightly more efficient by using position rather than `id`, but that's probably not all that significant.

There seems to be no significant difference in the benchmark despite significant alterations to the reconciliation code. But perhaps the benchmark doesn't really test this.

Before:
```
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|  BENCHMARK                                                     |  ITERATIONS |  TIME              |  MINOR GC  |  MAJOR GC  |  MINOR ALLOC  |  PROMOTED  |  MAJOR ALLOC  |
|----------------------------------------------------------------+-------------+--------------------+------------+------------+---------------+------------+---------------|
|  Node: create single node                                      |  10000      |  0.00162792205811  |  4         |  0         |  820302       |  307       |  307          |
|----------------------------------------------------------------+-------------+--------------------+------------+------------+---------------+------------+---------------|
|  Layout: layout single node (force re-layout)                  |  10000      |  0.00284290313721  |  3         |  0         |  540158       |  111       |  111          |
|----------------------------------------------------------------+-------------+--------------------+------------+------------+---------------+------------+---------------|
|  Layout: layout node tree (4 deep, 4 wide) (force re-layout))  |  10000      |  1.94358897209     |  821       |  273       |  179092661    |  22167906  |  22167906     |
|----------------------------------------------------------------+-------------+--------------------+------------+------------+---------------+------------+---------------|
|  Layout: layout single node                                    |  10000      |  0.00290989875793  |  3         |  0         |  540158       |  111       |  111          |
|----------------------------------------------------------------+-------------+--------------------+------------+------------+---------------+------------+---------------|
|  Layout: layout node tree (4 deep, 4 wide)                     |  10000      |  1.94690203667     |  852       |  273       |  179091066    |  21563312  |  21563312     |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

After:
```
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|  BENCHMARK                                                     |  ITERATIONS |  TIME              |  MINOR GC  |  MAJOR GC  |  MINOR ALLOC  |  PROMOTED  |  MAJOR ALLOC  |
|----------------------------------------------------------------+-------------+--------------------+------------+------------+---------------+------------+---------------|
|  Node: create single node                                      |  10000      |  0.00154399871826  |  4         |  0         |  800302       |  299       |  299          |
|----------------------------------------------------------------+-------------+--------------------+------------+------------+---------------+------------+---------------|
|  Layout: layout single node (force re-layout)                  |  10000      |  0.00318002700806  |  3         |  0         |  540158       |  111       |  111          |
|----------------------------------------------------------------+-------------+--------------------+------------+------------+---------------+------------+---------------|
|  Layout: layout node tree (4 deep, 4 wide) (force re-layout))  |  10000      |  1.94854593277     |  841       |  259       |  179089613    |  21305774  |  21305774     |
|----------------------------------------------------------------+-------------+--------------------+------------+------------+---------------+------------+---------------|
|  Layout: layout single node                                    |  10000      |  0.00287389755249  |  3         |  0         |  540201       |  111       |  111          |
|----------------------------------------------------------------+-------------+--------------------+------------+------------+---------------+------------+---------------|
|  Layout: layout node tree (4 deep, 4 wide)                     |  10000      |  1.98566317558     |  847       |  269       |  179091657    |  21534614  |  21534614     |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```