### PR TITLE
Bugfix: High-DPI text measurement issue

### DIFF
--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -37,7 +37,7 @@ let _getScaledFontSizeFromWindow = (window: option(Window.t), fontSize) => {
   _getScaledFontSize(~scaleFactor, ~pixelRatio, fontSize);
 };
 
-let getLineHeight = (~window=None, ~fontFamily, ~fontSize, ~lineHeight, ()) => {
+let getLineHeight = (~window, ~fontFamily, ~fontSize, ~lineHeight, ()) => {
   let scaledFontSize = _getScaledFontSizeFromWindow(window, fontSize);
   let font = FontCache.load(fontFamily, scaledFontSize);
   let metrics = FontRenderer.getNormalizedMetrics(font);
@@ -49,7 +49,7 @@ type dimensions = {
   height: int,
 };
 
-let measure = (~window=?, ~fontFamily, ~fontSize, text) => {
+let measure = (~window, ~fontFamily, ~fontSize, text) => {
   let scaledFontSize = _getScaledFontSizeFromWindow(window, fontSize);
   let font = FontCache.load(fontFamily, scaledFontSize);
   let multiplier =

--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -41,7 +41,12 @@ let getLineHeight = (~window, ~fontFamily, ~fontSize, ~lineHeight, ()) => {
   let scaledFontSize = _getScaledFontSizeFromWindow(window, fontSize);
   let font = FontCache.load(fontFamily, scaledFontSize);
   let metrics = FontRenderer.getNormalizedMetrics(font);
-  lineHeight *. metrics.height;
+  let multiplier =
+    switch (window) {
+    | None => 1.0
+    | Some(w) => Window.getScaleAndZoom(w) *. Window.getDevicePixelRatio(w)
+    };
+  lineHeight *. metrics.height /. multiplier;
 };
 
 type dimensions = {

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -26,15 +26,15 @@ class textNode (text: string) = {
     let {color, backgroundColor, fontFamily, fontSize, lineHeight, _} = style;
     let opacity = parentContext.opacity *. style.opacity;
 
+    let window = Ui.getActiveWindow();
+
     let lineHeightPx =
-      Text.getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ());
+      Text.getLineHeight(~window, ~fontFamily, ~fontSize, ~lineHeight, ());
 
     /* when style.width & style.height are defined, Layout doesn't call the measure function */
     if (!_isMeasured) {
       _this#measure(style.width, style.height) |> ignore;
     };
-
-    let window = Ui.getActiveWindow();
 
     List.iteri(
       (lineNum, line) =>
@@ -72,8 +72,10 @@ class textNode (text: string) = {
 
     let formattedText = TextOverflow.removeLineBreaks(text);
 
+    let window = Ui.getActiveWindow();
+
     let measure = str =>
-      Text.measure(~window=?Ui.getActiveWindow(), ~fontFamily, ~fontSize, str)
+      Text.measure(~window, ~fontFamily, ~fontSize, str)
       |> (value => value.width);
 
     let width = measure(formattedText);
@@ -94,7 +96,7 @@ class textNode (text: string) = {
     _lines = [truncated];
 
     let lineHeightPx =
-      Text.getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ());
+      Text.getLineHeight(~window, ~fontFamily, ~fontSize, ~lineHeight, ());
 
     {width, height: int_of_float(lineHeightPx)};
   };
@@ -123,8 +125,9 @@ class textNode (text: string) = {
   };
   pub handleTextWrapping = (width, style) => {
     let {textWrap, fontFamily, fontSize, lineHeight, _}: Style.t = style;
+    let window = Ui.getActiveWindow();
     let lineHeightPx =
-      Text.getLineHeight(~fontFamily, ~fontSize, ~lineHeight, ());
+      Text.getLineHeight(~window, ~fontFamily, ~fontSize, ~lineHeight, ());
 
     switch (textWrap) {
     | WhitespaceWrap =>
@@ -132,7 +135,7 @@ class textNode (text: string) = {
         TextWrapping.wrapText(
           ~text,
           ~measureWidth=
-            str => Text.measure(~fontFamily, ~fontSize, str).width,
+            str => Text.measure(~window, ~fontFamily, ~fontSize, str).width,
           ~maxWidth=width,
           ~wrapHere=TextWrapping.isWhitespaceWrapPoint,
         );
@@ -147,7 +150,7 @@ class textNode (text: string) = {
 
       dimensions;
     | NoWrap =>
-      let d = Text.measure(~fontFamily, ~fontSize, text);
+      let d = Text.measure(~window, ~fontFamily, ~fontSize, text);
       let dimensions: Layout.LayoutTypes.dimensions = {
         width: d.width,
         height: d.height,
@@ -160,7 +163,7 @@ class textNode (text: string) = {
       let (lines, maxWidthLine) =
         wrapFunc(
           text,
-          str => Text.measure(~fontFamily, ~fontSize, str).width,
+          str => Text.measure(~window, ~fontFamily, ~fontSize, str).width,
           width,
         );
 

--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -259,7 +259,7 @@ let%component make =
   let measureTextWidth = text => {
     let dimensions =
       Revery_Draw.Text.measure(
-        ~window=?Revery_UI.getActiveWindow(),
+        ~window=Revery_UI.getActiveWindow(),
         ~fontFamily=textAttrs.fontFamily,
         ~fontSize=textAttrs.fontSize,
         text,


### PR DESCRIPTION
Tracking fix for root cause of https://github.com/onivim/oni2/issues/1068

For some of the text measurement APIs, we were not taking into account the scaling done for retina displays. This corrects the measurements, so that the `Text.measure` and `Text.getLineHeight` receive accurate metrics when in high-DPI.