### PR TITLE
Native/dialog.c: Rename "revery_alertOpenFiles_bytcode" to "revery_alertOpenFiles_bytecode"

### DIFF
--- a/src/Native/dialog.c
+++ b/src/Native/dialog.c
@@ -134,7 +134,7 @@ CAMLprim value revery_alertOpenFiles_native(
   }
 }
 
-CAMLprim value revery_alertOpenFiles_bytcode(value *argv, int argn) {
+CAMLprim value revery_alertOpenFiles_bytecode(value *argv, int argn) {
   (void)argn;
   return revery_alertOpenFiles_native(argv[0], argv[1], argv[2], argv[3],
                                       argv[4], argv[5], argv[6], argv[7],


### PR DESCRIPTION
Previously this function was called "revery_alertOpenFiles_bytcode" which would result in a build failure using the bytecode backend