### PR TITLE
Enable bytecode builds

### DIFF
--- a/examples/Hello.re
+++ b/examples/Hello.re
@@ -104,12 +104,15 @@ module AnimatedText = {
   };
 };
 
-let render = () =>
+let render = () => {
+  let mode = Dynlink.is_native ? "Native" : "Bytecode";
+  let revery = "Revery (" ++ mode ++ ")";
   <Center>
     <Row>
       <AnimatedText delay=Time.zero text="Welcome" />
       <AnimatedText delay={Time.ms(500)} text="to" />
-      <AnimatedText delay={Time.seconds(1)} text="Revery" />
+      <AnimatedText delay={Time.seconds(1)} text=revery />
     </Row>
     <Logo />
   </Center>;
+};

--- a/examples/dune
+++ b/examples/dune
@@ -3,13 +3,17 @@
     (preprocess (pps brisk-reconciler.ppx lwt_ppx))
     (package Revery)
     (public_names Examples)
+    (modes native byte)
+    (ocamlc_flags (:standard -custom))
     (libraries
+        dynlink
         js_of_ocaml
         ExampleStubs
         str
         Revery
         flex
             ))
+
 (install
     (section bin)
     (package Revery)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "test": "esy b dune runtest",
     "format": "esy dune build @fmt --auto-promote",
     "format:windows": "esy b .ci/format.sh",
-    "run": "esy x Examples"
+    "run": "esy x Examples",
+    "run-native": "esy b dune exec examples/Examples.exe",
+    "run-bytecode": "esy b dune exec examples/Examples.bc"
   },
   "homepage": "https://github.com/bryphe/revery#readme",
   "esy": {

--- a/src/Native/dialog.c
+++ b/src/Native/dialog.c
@@ -134,7 +134,7 @@ CAMLprim value revery_alertOpenFiles_native(
   }
 }
 
-CAMLprim value revery_alertOpenFiles_bytcode(value *argv, int argn) {
+CAMLprim value revery_alertOpenFiles_bytecode(value *argv, int argn) {
   (void)argn;
   return revery_alertOpenFiles_native(argv[0], argv[1], argv[2], argv[3],
                                       argv[4], argv[5], argv[6], argv[7],


### PR DESCRIPTION
This PR is a really simple fix to get bytecode builds working (updates `examples/dune` to provide the proper ocamlc flags & allow building bytecode) and then 2 simple `esy` scripts to get build bytecode/native executables work.