### PR TITLE
API: App - add '~askNicely' argument to App.quit

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -48,12 +48,12 @@ let _tryToCloseAll = (app: t) => {
   Seq.iter(w => _tryToClose(app, w), windows);
 };
 
-let quit = (~force=true, ~code=0, app: t) => {
-  if (!force) {
+let quit = (~askNicely=false, ~code=0, app: t) => {
+  if (askNicely) {
     _tryToCloseAll(app);
   };
 
-  if (Hashtbl.length(app.windows) == 0 || force) {
+  if (Hashtbl.length(app.windows) == 0 || !askNicely) {
     logInfo("Quitting");
     exit(code);
   };

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -49,8 +49,11 @@ let _tryToCloseAll = (app: t) => {
 };
 
 let quit = (~force=true, ~code=0, app: t) => {
-  _tryToCloseAll(app);
-  if (Hashtbl.length(app.windows) == 0) {
+  if (!force) {
+    _tryToCloseAll(app);
+  };
+
+  if (Hashtbl.length(app.windows) == 0 || force) {
     logInfo("Quitting");
     exit(code);
   };

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -48,7 +48,7 @@ let _tryToCloseAll = (app: t) => {
   Seq.iter(w => _tryToClose(app, w), windows);
 };
 
-let quit = (~code=0, app: t) => {
+let quit = (~force=true, ~code=0, app: t) => {
   _tryToCloseAll(app);
   if (Hashtbl.length(app.windows) == 0) {
     logInfo("Quitting");
@@ -167,7 +167,7 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
       // if Command+Q is pressed. In that case, we'll try
       // closing all the windows - and if they all close,
       // we'll exit the app.
-      quit(~code=0, appInstance)
+      quit(~force=false, ~code=0, appInstance)
     | _ => ()
     };
   };

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -170,7 +170,7 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
       // if Command+Q is pressed. In that case, we'll try
       // closing all the windows - and if they all close,
       // we'll exit the app.
-      quit(~force=false, ~code=0, appInstance)
+      quit(~askNicely=true, ~code=0, appInstance)
     | _ => ()
     };
   };

--- a/src/Core/App.rei
+++ b/src/Core/App.rei
@@ -12,8 +12,16 @@ type canIdleFunc = unit => bool;
 /** [getWindows(app)] returns the list of all open [Window.t] instances */
 let getWindows: t => list(Window.t);
 
-/** [quit(c)] causes the App to quit with exit code [c] */
-let quit: (~code: int=?, t) => unit;
+/** 
+[quit(~force, ~code, c)] causes the App to quit with exit code [c] 
+
+[force] specifies whether quit should be forced (default [true]). If [false],
+the canQuit handlers will be run for each window. If [true], the canQuit handlers
+will be ignored.
+
+[code] specifies the exit code. Defaults to [0].
+*/
+let quit: (~force: bool=?, ~code: int=?, t) => unit;
 
 /** [isIdle(app)] returns true if the app is idling, false othwrise */
 let isIdle: t => bool;

--- a/src/Core/App.rei
+++ b/src/Core/App.rei
@@ -12,8 +12,8 @@ type canIdleFunc = unit => bool;
 /** [getWindows(app)] returns the list of all open [Window.t] instances */
 let getWindows: t => list(Window.t);
 
-/** 
-[quit(~force, ~code, c)] causes the App to quit with exit code [c] 
+/**
+[quit(~force, ~code, c)] causes the App to quit with exit code [c]
 
 [force] specifies whether quit should be forced (default [true]). If [false],
 the canQuit handlers will be run for each window. If [true], the canQuit handlers

--- a/src/Core/App.rei
+++ b/src/Core/App.rei
@@ -15,8 +15,8 @@ let getWindows: t => list(Window.t);
 /**
 [quit(~force, ~code, c)] causes the App to quit with exit code [c]
 
-[force] specifies whether quit should be forced (default [true]). If [false],
-the canQuit handlers will be run for each window. If [true], the canQuit handlers
+[askNicely] specifies whether quit should be forced (default [false]). If [true],
+the canQuit handlers will be run for each window. If [false], the canQuit handlers
 will be ignored.
 
 [code] specifies the exit code. Defaults to [0].

--- a/src/Core/App.rei
+++ b/src/Core/App.rei
@@ -13,7 +13,7 @@ type canIdleFunc = unit => bool;
 let getWindows: t => list(Window.t);
 
 /**
-[quit(~force, ~code, c)] causes the App to quit with exit code [c]
+[quit(~askNicely, ~code, c)] causes the App to quit with exit code [c]
 
 [askNicely] specifies whether quit should be forced (default [false]). If [true],
 the canQuit handlers will be run for each window. If [false], the canQuit handlers
@@ -21,7 +21,7 @@ will be ignored.
 
 [code] specifies the exit code. Defaults to [0].
 */
-let quit: (~force: bool=?, ~code: int=?, t) => unit;
+let quit: (~askNicely: bool=?, ~code: int=?, t) => unit;
 
 /** [isIdle(app)] returns true if the app is idling, false othwrise */
 let isIdle: t => bool;


### PR DESCRIPTION
From a conversation with @glennsl today - we should allow a `force` quit (which ignores any `canQuit` callbacks registered with the window).

We assume that, if a developer is calling `App.quit`, then they probably mean to force quit - so `force` defaults to true. However, if `force` is `false`, we'll still run the `canQuit` callbacks.