### PR TITLE
Fix formatting bugs on Linux and Windows

### DIFF
--- a/.ci/format.sh
+++ b/.ci/format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 OS=$1
 
 dune build @fmt --auto-promote
@@ -7,9 +7,8 @@ caml_output=$?
 
 if [[ $OS == "windows" ]]
 then
-    # Prevents "Environment too big" error on Windows
-    files=$(/usr/bin/find ./ -type f \( -iname \*.c -o -iname \*.h \) -not -path "*_esy/*")
-    native_output=$(astyle -n -Q --style=java --s4 "$files")
+    files=$(/usr/bin/find $(pwd) -type f \( -iname \*.c -o -iname \*.h \) -not -path "*_esy/*")
+    native_output=$(astyle -n -Q --style=java --s4 $(cygpath -w $files))
 elif [[ $OS == "darwin" ]]
 then
     native_output=$(find -E . -regex '.*\.(c|h)' -type f -not -path "*_esy/*" -exec astyle -n -Q --style=java --s4 {} \;)

--- a/.ci/format.sh
+++ b/.ci/format.sh
@@ -1,23 +1,29 @@
 #!/bin/bash
-set -e
 OS=$1
 
 dune build @fmt --auto-promote
 
-if [ $OS == "windows" ]
+caml_output=$?
+
+if [[ $OS == "windows" ]]
 then
     # Prevents "Environment too big" error on Windows
     files=$(/usr/bin/find ./ -type f \( -iname \*.c -o -iname \*.h \) -not -path "*_esy/*")
-    native_output=$(astyle -n -Q --style=java --s4 $files)
-elif [ $OS == "darwin" ]
+    native_output=$(astyle -n -Q --style=java --s4 "$files")
+elif [[ $OS == "darwin" ]]
 then
     native_output=$(find -E . -regex '.*\.(c|h)' -type f -not -path "*_esy/*" -exec astyle -n -Q --style=java --s4 {} \;)
-elif [ $OS == "linux" ]
+elif [[ $OS == "linux" ]]
 then
     native_output=$(find ./ -type f \( -iname \*.c -o -iname \*.h \) -not -path "*_esy/*" -exec astyle -n -Q --style=java --s4 {} \;)
 fi
 
-if [ $native_output ];
+if [[ $native_output ]]
 then
-    printf "Formatted the following native stubs:\n$native_output"; exit 1
+    printf "\nFormatted the following native stubs:\n%s" "$native_output"
+fi
+
+if [[ $caml_output != 0 ]] || [[ $native_output != "" ]]
+then
+    exit 1
 fi

--- a/.ci/format.sh
+++ b/.ci/format.sh
@@ -1,18 +1,23 @@
+#!/bin/bash
 set -e
 OS=$1
 
 dune build @fmt --auto-promote
 
-if [[ $OS == "windows" ]];
+if [ $OS == "windows" ]
 then
     # Prevents "Environment too big" error on Windows
     files=$(/usr/bin/find ./ -type f \( -iname \*.c -o -iname \*.h \) -not -path "*_esy/*")
     native_output=$(astyle -n -Q --style=java --s4 $files)
-else
+elif [ $OS == "darwin" ]
+then
     native_output=$(find -E . -regex '.*\.(c|h)' -type f -not -path "*_esy/*" -exec astyle -n -Q --style=java --s4 {} \;)
+elif [ $OS == "linux" ]
+then
+    native_output=$(find ./ -type f \( -iname \*.c -o -iname \*.h \) -not -path "*_esy/*" -exec astyle -n -Q --style=java --s4 {} \;)
 fi
 
-if [[ $native_output ]];
+if [ $native_output ];
 then
     printf "Formatted the following native stubs:\n$native_output"; exit 1
 fi

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:js": "esy b dune build examples/Examples.bc.js",
     "build:js:release": "esy b dune build examples/Examples.bc.js",
     "test": "esy b dune runtest",
-    "format": "esy sh .ci/format.sh #{os}",
+    "format": "esy bash .ci/format.sh #{os}",
     "run": "esy x Examples"
   },
   "homepage": "https://github.com/bryphe/revery#readme",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:js": "esy b dune build examples/Examples.bc.js",
     "build:js:release": "esy b dune build examples/Examples.bc.js",
     "test": "esy b dune runtest",
-    "format": "esy bash .ci/format.sh #{os}",
+    "format": "esy b bash .ci/format.sh #{os}",
     "run": "esy x Examples"
   },
   "homepage": "https://github.com/bryphe/revery#readme",


### PR DESCRIPTION
@glennsl pointed out that `-E` is not a universal expression for GNU `find`.

Annoyingly macOS uses BSD `find` which has slightly different configuration flags than GNU's.

@glennsl, can you checkout this branch to see if it works for you? I have tested it on:
- macOS
- Windows
- Ubuntu 19.10
- Bodhi Linux

But I don't want to merge this unless it really does fix the issue, obviously