### PR TITLE
[WIP] Fix key-repeat.

### DIFF
--- a/src/Native/cocoa/ReveryAppDelegate.c
+++ b/src/Native/cocoa/ReveryAppDelegate.c
@@ -17,6 +17,11 @@
     if (self) {
         _notificationActions = [NSMutableDictionary new];
     }
+
+    NSString *valueToSave = @"true";
+    [[NSUserDefaults standardUserDefaults] setObject:valueToSave forKey:@"ApplePressAndHoldEnabled"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+
     return self;
 }
 


### PR DESCRIPTION
Fix https://github.com/revery-ui/revery/issues/703. (Well will once actually moved to a sensible place).

Where does it make sense to add this? I'd guess a new function that we let users call to disable it. The one potential complication is that it only needs setting one time. Once its set, you get it set permanently. So we'd probably need a disable option too.

(For anyone testing this, you can follow up with a `defaults delete com.revery.examples` in bash to remove the key it adds for now, to test before and after.)

I've confirmed the fix works over in Oni2 as well.