### PR TITLE
Recognize all re files as Reason

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,5 @@
 # Hide lockfile updates
 *esy.lock/* linguist-generated
 
-
+# Recognize all re files as Reason
+*.re linguist-language=Reason


### PR DESCRIPTION
This change enables syntax highlighting correctly and may improve readability on the GitHub.