### PR TITLE
Fix nested clickables

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -156,7 +156,7 @@ let state: state = {
       source: "NestedClickable.re",
     },
   ],
-  selectedExample: "Nested Clickables",
+  selectedExample: "Animation",
 };
 
 let getExampleByName = (state: state, example: string) =>

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -150,8 +150,13 @@ let state: state = {
       render: _ => ZoomExample.render(),
       source: "ZoomExample.re",
     },
+    {
+      name: "Nested Clickables",
+      render: _ => NestedClickable.render(),
+      source: "NestedClickable.re",
+    },
   ],
-  selectedExample: "Animation",
+  selectedExample: "Nested Clickables",
 };
 
 let getExampleByName = (state: state, example: string) =>

--- a/examples/NestedClickable.re
+++ b/examples/NestedClickable.re
@@ -1,0 +1,29 @@
+open Revery;
+open Revery.UI;
+open Revery.UI.Components;
+
+module Styles = {
+  open Style;
+
+  let outer = [
+    position(`Absolute),
+    top(0),
+    bottom(0),
+    left(0),
+    right(0),
+    justifyContent(`Center),
+    alignItems(`Center),
+    backgroundColor(Colors.yellow),
+  ];
+};
+
+let%component clickies = () => {
+  let%hook (text, setText) = Hooks.state("Click something");
+
+  <Clickable
+    style=Styles.outer onClick={() => setText(_ => "Clicked outside")}>
+    <Button title=text onClick={() => setText(_ => "Clicked inside")} />
+  </Clickable>;
+};
+
+let render = () => <clickies />;

--- a/src/UI/Mouse.re
+++ b/src/UI/Mouse.re
@@ -450,10 +450,8 @@ let dispatch =
 
         switch (deepestNode) {
         | None =>
-          /*
-           * if no node found, call bubbled MouseOut on deepestStoredNode if there's some stored nodes
-           * And recursively send mouseLeave events to storedNodes if they exist
-           */
+          // if no node found, call bubbled MouseOut on deepestStoredNode if there's some stored nodes
+          // And recursively send mouseLeave events to storedNodes if they exist
           switch (storedNodesUnderCursor^) {
           | [] => ()
           | [node, ..._] => bubble(node, MouseOut(mouseMoveEventParams))
@@ -464,17 +462,13 @@ let dispatch =
         | Some(deepNode) =>
           switch (storedNodesUnderCursor^) {
           | [] =>
-            /*
-             * If some deepNode is found and there aer no storedNodes
-             * Traverse the tree and call MouseEnter on each  node -  https://developer.mozilla.org/en-US/docs/Web/Events/mouseenter
-             * And call bubbled MouseOver on deepNode
-             */
+            // If some deepNode is found and there are no storedNodes
+            // Traverse the tree and call MouseEnter on each  node -  https://developer.mozilla.org/en-US/docs/Web/Events/mouseenter
+            // And call bubbled MouseOver on deepNode
             sendMouseEnterEvents(deepNode, mouseMoveEventParams);
             bubble(deepNode, MouseOver(mouseMoveEventParams));
           | [node, ..._] =>
-            /*
-             * Only handle diff if the deepestStoredNode !==  the deepestFoundNode
-             */
+            // Only handle diff if the deepestStoredNode !==  the deepestFoundNode
             if (node#getInternalId() != deepNode#getInternalId()) {
               handleMouseEnterDiff(deepNode, mouseMoveEventParams, ());
             }

--- a/src/UI/Mouse.re
+++ b/src/UI/Mouse.re
@@ -428,80 +428,70 @@ let rec handleMouseEnterDiff = (deepestNode, evtParams, ~newNodes=[], ()) => {
 };
 
 let dispatch =
-    (cursor: Cursor.t, evt: Events.internalMouseEvents, node: Node.node) => {
-  node#hasRendered()
-    ? {
-      let pos = getPositionFromMouseEvent(cursor, evt);
+    (cursor: Cursor.t, evt: Events.internalMouseEvents, node: Node.node) =>
+  if (node#hasRendered()) {
+    let pos = getPositionFromMouseEvent(cursor, evt);
+    let eventToSend = internalToExternalEvent(cursor, evt);
 
-      let eventToSend = internalToExternalEvent(cursor, evt);
-
-      let mouseDown = isMouseDownEv(eventToSend);
-      if (mouseDown) {
-        switch (getFirstFocusable(node, pos)) {
-        | Some(node) => Focus.dispatch(node)
-        | None => Focus.loseFocus()
-        };
-      } else {
-        ();
+    if (isMouseDownEv(eventToSend)) {
+      switch (getFirstFocusable(node, pos)) {
+      | Some(node) => Focus.dispatch(node)
+      | None => Focus.loseFocus()
       };
+    };
 
-      handleListeners(eventToSend);
+    handleListeners(eventToSend);
 
-      if (!handleCapture(eventToSend)) {
-        let deepestNode = getTopMostNode(node, pos);
-        let mouseMove = isMouseMoveEv(eventToSend);
-        if (mouseMove) {
-          let mouseMoveEventParams = getMouseMoveEventParams(cursor, evt);
+    if (!handleCapture(eventToSend)) {
+      let deepestNode = getTopMostNode(node, pos);
 
-          switch (deepestNode) {
-          | None =>
-            /*
-             * if no node found, call bubbled MouseOut on deepestStoredNode if there's some stored nodes
-             * And recursively send mouseLeave events to storedNodes if they exist
-             */
-            switch (storedNodesUnderCursor^) {
-            | [] => ()
-            | [node, ..._] => bubble(node, MouseOut(mouseMoveEventParams))
-            };
-
-            sendMouseLeaveEvents(
-              storedNodesUnderCursor^,
-              mouseMoveEventParams,
-            );
-
-          | Some(deepNode) =>
-            switch (storedNodesUnderCursor^) {
-            | [] =>
-              /*
-               * If some deepNode is found and there aer no storedNodes
-               * Traverse the tree and call MouseEnter on each  node -  https://developer.mozilla.org/en-US/docs/Web/Events/mouseenter
-               * And call bubbled MouseOver on deepNode
-               */
-              sendMouseEnterEvents(deepNode, mouseMoveEventParams);
-              bubble(deepNode, MouseOver(mouseMoveEventParams));
-            | [node, ..._] =>
-              /*
-               * Only handle diff if the deepestStoredNode !==  the deepestFoundNode
-               */
-              if (node#getInternalId() != deepNode#getInternalId()) {
-                handleMouseEnterDiff(deepNode, mouseMoveEventParams, ());
-              }
-            }
-          };
-        };
+      if (isMouseMoveEv(eventToSend)) {
+        let mouseMoveEventParams = getMouseMoveEventParams(cursor, evt);
 
         switch (deepestNode) {
-        | None => ()
-        | Some(node) =>
-          let bbox = node#getBoundingBox();
-          DebugDraw.setActive(bbox);
-          bubble(node, eventToSend);
-          let cursor = node#getCursorStyle();
-          Event.dispatch(onCursorChanged, cursor);
+        | None =>
+          /*
+           * if no node found, call bubbled MouseOut on deepestStoredNode if there's some stored nodes
+           * And recursively send mouseLeave events to storedNodes if they exist
+           */
+          switch (storedNodesUnderCursor^) {
+          | [] => ()
+          | [node, ..._] => bubble(node, MouseOut(mouseMoveEventParams))
+          };
+
+          sendMouseLeaveEvents(storedNodesUnderCursor^, mouseMoveEventParams);
+
+        | Some(deepNode) =>
+          switch (storedNodesUnderCursor^) {
+          | [] =>
+            /*
+             * If some deepNode is found and there aer no storedNodes
+             * Traverse the tree and call MouseEnter on each  node -  https://developer.mozilla.org/en-US/docs/Web/Events/mouseenter
+             * And call bubbled MouseOver on deepNode
+             */
+            sendMouseEnterEvents(deepNode, mouseMoveEventParams);
+            bubble(deepNode, MouseOver(mouseMoveEventParams));
+          | [node, ..._] =>
+            /*
+             * Only handle diff if the deepestStoredNode !==  the deepestFoundNode
+             */
+            if (node#getInternalId() != deepNode#getInternalId()) {
+              handleMouseEnterDiff(deepNode, mouseMoveEventParams, ());
+            }
+          }
         };
       };
 
-      Cursor.set(cursor, pos);
-    }
-    : ();
-};
+      switch (deepestNode) {
+      | None => ()
+      | Some(node) =>
+        let bbox = node#getBoundingBox();
+        DebugDraw.setActive(bbox);
+        bubble(node, eventToSend);
+        let cursor = node#getCursorStyle();
+        Event.dispatch(onCursorChanged, cursor);
+      };
+    };
+
+    Cursor.set(cursor, pos);
+  };

--- a/src/UI/UiEvents.re
+++ b/src/UI/UiEvents.re
@@ -1,60 +1,29 @@
 open Node;
 open NodeEvents;
 
-module BubbledEvent = {
-  type bubbledEvent = {
-    id: int,
+module BubbleEvent: {
+  type t =
+    pri {
     event,
-    shouldPropagate: bool,
-    defaultPrevented: bool,
-    stopPropagation: unit => unit,
-    preventDefault: unit => unit,
+    mutable shouldPropagate: bool,
+    mutable defaultPrevented: bool,
   };
 
-  let generateId = () => {
-    let id = ref(1);
-    () => {
-      id := id^ + 1;
-      id^;
-    };
+  let stopPropagation: t => unit;
+  let preventDefault: t => unit;
+  let make: event => t;
+} = {
+  type t = {
+    event,
+    mutable shouldPropagate: bool,
+    mutable defaultPrevented: bool,
   };
 
-  let getId = generateId();
-  let activeEvent = ref(None);
+  let stopPropagation = event => event.shouldPropagate = false;
 
-  let stopPropagation = (id, ()) =>
-    switch (activeEvent^) {
-    | Some(evt) =>
-      if (id == evt.id) {
-        activeEvent := Some({...evt, shouldPropagate: false});
-      }
-    | None => ()
-    };
+  let preventDefault = event => event.defaultPrevented = true;
 
-  let preventDefault = (id, ()) =>
-    switch (activeEvent^) {
-    | Some(evt) =>
-      if (id == evt.id) {
-        activeEvent := Some({...evt, defaultPrevented: true});
-      }
-    | None => ()
-    };
-
-  let make = event => {
-    let id = getId();
-    let wrappedEvent =
-      Some({
-        id,
-        event,
-        shouldPropagate: true,
-        defaultPrevented: false,
-        stopPropagation: stopPropagation(id),
-        preventDefault: preventDefault(id),
-      });
-
-    activeEvent := wrappedEvent;
-    wrappedEvent;
-  };
+  let make = event => {event, shouldPropagate: true, defaultPrevented: false};
 };
 
 let isNodeImpacted = (n, pos) => n#hitTest(pos);
@@ -129,7 +98,7 @@ let getTopMostNode = (node: node, pos) => {
 };
 
 let rec traverseHeirarchy = (node: node, bubbled) =>
-  BubbledEvent.(
+  BubbleEvent.(
     /*
      track if default prevent or propagation stopped per node
      stop traversing node hierarchy if stop propagation is called
@@ -146,9 +115,8 @@ let rec traverseHeirarchy = (node: node, bubbled) =>
 
 let bubble = (node, event: event) => {
   /* Wrap event with preventDefault and stopPropagation */
-  let evt = BubbledEvent.make(event);
-  switch (evt) {
-  | Some(e) => traverseHeirarchy(node, e)
-  | None => ()
-  };
+  traverseHeirarchy(
+    node,
+    BubbleEvent.make(event),
+  );
 };

--- a/src/UI/UiEvents.re
+++ b/src/UI/UiEvents.re
@@ -4,10 +4,10 @@ open NodeEvents;
 module BubbleEvent: {
   type t =
     pri {
-    event,
-    mutable shouldPropagate: bool,
-    mutable defaultPrevented: bool,
-  };
+      event,
+      mutable shouldPropagate: bool,
+      mutable defaultPrevented: bool,
+    };
 
   let stopPropagation: t => unit;
   let preventDefault: t => unit;
@@ -71,7 +71,7 @@ let getTopMostNode = (node: node, pos) => {
       let ignored = mode == Ignore;
 
       let revChildren = List.rev(node#getChildren());
-      let ret =
+      let maybeChildNode =
         switch (revChildren) {
         | [] => ignored ? None : Some(node)
         | children =>
@@ -86,15 +86,14 @@ let getTopMostNode = (node: node, pos) => {
           )
         };
 
-      switch (ret) {
+      switch (maybeChildNode) {
       | None => ignored ? None : Some(node)
-      | Some(v) => Some(v)
+      | Some(childNode) => Some(childNode)
       };
     };
   };
 
-  let ret: option(node) = f(node, Default);
-  ret;
+  f(node, Default);
 };
 
 let rec traverseHeirarchy = (node: node, bubbled) =>

--- a/src/UI_Components/Button.rei
+++ b/src/UI_Components/Button.rei
@@ -12,7 +12,7 @@ Simple out-of-box button component
 let make:
   (
     ~title: string,
-    ~onClick: Clickable.clickFunction=?,
+    ~onClick: unit => unit=?,
     ~color: Revery_Core.Color.t=?,
     ~fontSize: int=?,
     ~width: int=?,

--- a/src/UI_Components/Clickable.re
+++ b/src/UI_Components/Clickable.re
@@ -32,23 +32,19 @@ let%component make =
               ) => {
   let%hook (isMouseCapturedHere, _setIsMouseDown) = Hooks.ref(ref(false));
 
-  let capture = () => {
-    isMouseCapturedHere := true;
-    isMouseCaptured := true;
-  };
-  let releaseCapture = () => {
-    isMouseCapturedHere := false;
-    isMouseCaptured := false;
-  };
-
-  let onMouseDown = _event =>
+  let capture = () =>
     if (! isMouseCaptured^) {
-      capture();
+      isMouseCapturedHere := true;
+      isMouseCaptured := true;
     };
-  let onMouseLeave = _event =>
+  let releaseCapture = () =>
     if (isMouseCapturedHere^) {
-      releaseCapture();
+      isMouseCapturedHere := false;
+      isMouseCaptured := false;
     };
+
+  let onMouseDown = _event => capture();
+  let onMouseLeave = _event => releaseCapture();
   let onMouseUp = (mouseEvt: NodeEvents.mouseButtonEventParams) =>
     if (isMouseCapturedHere^) {
       releaseCapture();
@@ -61,6 +57,7 @@ let%component make =
 
       onAnyClick(mouseEvt);
     };
+  let%hook () = Hooks.effect(OnMount, () => Some(releaseCapture));
 
   let style = Style.[cursor(MouseCursors.pointer), ...style];
 

--- a/src/UI_Components/Clickable.rei
+++ b/src/UI_Components/Clickable.rei
@@ -1,8 +1,5 @@
 open Revery_UI;
 
-type clickFunction = unit => unit;
-type clickFunctionWithEvt = NodeEvents.mouseButtonEventParams => unit;
-
 /**
 {2 Description:}
 
@@ -22,9 +19,9 @@ let make:
   (
     ~key: Brisk_reconciler.Key.t=?,
     ~style: list(Revery_UI.Style.viewStyleProps)=?,
-    ~onClick: clickFunction=?,
-    ~onRightClick: clickFunction=?,
-    ~onAnyClick: clickFunctionWithEvt=?,
+    ~onClick: unit => unit=?,
+    ~onRightClick: unit => unit=?,
+    ~onAnyClick: NodeEvents.mouseButtonEventParams => unit=?,
     ~componentRef: Revery_UI.node => unit=?,
     ~onBlur: Revery_UI.NodeEvents.focusHandler=?,
     ~onFocus: Revery_UI.NodeEvents.focusHandler=?,

--- a/test/UI/MouseTest.re
+++ b/test/UI/MouseTest.re
@@ -506,33 +506,21 @@ describe("Mouse", ({describe, test, _}) => {
     test(
       "test that state is updated per event when stop propagation is called",
       ({expect, _}) => {
-      let evt = BubbledEvent.make(MouseMove({mouseX: 50., mouseY: 50.}));
-      switch (evt) {
-      | Some(e) =>
-        e.stopPropagation();
-        switch (BubbledEvent.activeEvent^) {
-        | Some(activeEvent) =>
-          expect.bool(activeEvent.shouldPropagate).toBeFalse()
-        | None => ()
-        };
-      | None => ()
-      };
+      let evt = BubbleEvent.make(MouseMove({mouseX: 50., mouseY: 50.}));
+
+      BubbleEvent.stopPropagation(evt);
+
+      expect.bool(evt.shouldPropagate).toBeFalse();
     });
 
     test(
       "test that state is updated per event when prevent default is called",
       ({expect, _}) => {
-      let evt = BubbledEvent.make(MouseMove({mouseX: 50., mouseY: 50.}));
-      switch (evt) {
-      | Some(e) =>
-        e.preventDefault();
-        switch (BubbledEvent.activeEvent^) {
-        | Some(activeEvent) =>
-          expect.bool(activeEvent.defaultPrevented).toBeTrue()
-        | None => ()
-        };
-      | None => ()
-      };
+      let evt = BubbleEvent.make(MouseMove({mouseX: 50., mouseY: 50.}));
+
+      BubbleEvent.preventDefault(evt);
+
+      expect.bool(evt.defaultPrevented).toBeTrue();
     });
   });
 
@@ -570,6 +558,7 @@ describe("Mouse", ({describe, test, _}) => {
       expect.int(captureCount^).toBe(1);
     })
   );
+
   test(
     "onCursorChangedEvent gets dispatched with proper cursor", ({expect, _}) => {
     module Cursors = Revery_Core.MouseCursors;


### PR DESCRIPTION
Addresses #709

This allows clickables to be nested without ancestors hijacking the clicks of its descendants. It does so by implementing a local capture mechanism instead of using the global one that can be hijacked by anything anywhere in the codebase. By combining a module-local and component-local flag we can at least ensure that nothing outside the module can interfere, and we prevent different instances of the component from stepping on each others toes. The first instance to capture, which will be the deepest node, keeps the "lock" until it releases it, on `mouseleave`, `mouseup` or unmount. Hopefully that covers all the bases, but if not it's at least easier to reason about the mutation when it's local and encapsulated.

This also simplifies and fixes the `BubbleEvent` implementation so it should now work if it's to be used for anything, although currently it's not. And it cleans up various bits around the place. This isn't strictly necessary but, you know, I was in the area and trying to grok these things...