### PR TITLE
Move to timber for logging

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,7 +1,24 @@
 {
-  "checksum": "6f5134af9edfe5618670e21725f48ab0",
+  "checksum": "f0e84d320e078d361bece8b26bd90190",
   "root": "revery@link-dev:./package.json",
   "node": {
+    "timber@github:glennsl/timber#37ffa07@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+      "name": "timber",
+      "version": "github:glennsl/timber#37ffa07",
+      "source": {
+        "type": "install",
+        "source": [ "github:glennsl/timber#37ffa07" ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
+    },
     "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9": {
       "id":
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
@@ -26,6 +43,7 @@
       },
       "overrides": [ "bench.json" ],
       "dependencies": [
+        "timber@github:glennsl/timber#37ffa07@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
@@ -544,6 +562,31 @@
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
+      ]
+    },
+    "@opam/stdlib-shims@opam:0.1.0@d957c903": {
+      "id": "@opam/stdlib-shims@opam:0.1.0@d957c903",
+      "name": "@opam/stdlib-shims",
+      "version": "opam:0.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/12/12b5704eed70c6bff5ac39a16db1425d#md5:12b5704eed70c6bff5ac39a16db1425d",
+          "archive:https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz#md5:12b5704eed70c6bff5ac39a16db1425d"
+        ],
+        "opam": {
+          "name": "stdlib-shims",
+          "version": "0.1.0",
+          "path": "bench.esy.lock/opam/stdlib-shims.0.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
     "@opam/stdio@opam:v0.13.0@eb59d879": {
@@ -1203,6 +1246,36 @@
         "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
+    "@opam/logs@opam:0.7.0@1d03143e": {
+      "id": "@opam/logs@opam:0.7.0@1d03143e",
+      "name": "@opam/logs",
+      "version": "opam:0.7.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/2b/2bf021ca13331775e33cf34ab60246f7#md5:2bf021ca13331775e33cf34ab60246f7",
+          "archive:https://erratique.ch/software/logs/releases/logs-0.7.0.tbz#md5:2bf021ca13331775e33cf34ab60246f7"
+        ],
+        "opam": {
+          "name": "logs",
+          "version": "0.7.0",
+          "path": "bench.esy.lock/opam/logs.0.7.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-threads@opam:base@36803084",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
+    },
     "@opam/lambda-term@opam:2.0.3@9465cf1c": {
       "id": "@opam/lambda-term@opam:2.0.3@9465cf1c",
       "name": "@opam/lambda-term",
@@ -1441,6 +1514,38 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/astring@opam:0.8.3@4e5e17d5"
+      ]
+    },
+    "@opam/fmt@opam:0.8.8@01c3a23c": {
+      "id": "@opam/fmt@opam:0.8.8@01c3a23c",
+      "name": "@opam/fmt",
+      "version": "opam:0.8.8",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/47/473490fcfdf3ff0a8ccee226b873d4b2#md5:473490fcfdf3ff0a8ccee226b873d4b2",
+          "archive:https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz#md5:473490fcfdf3ff0a8ccee226b873d4b2"
+        ],
+        "opam": {
+          "name": "fmt",
+          "version": "0.8.8",
+          "path": "bench.esy.lock/opam/fmt.0.8.8"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {

--- a/bench.esy.lock/opam/fmt.0.8.8/opam
+++ b/bench.esy.lock/opam/fmt.0.8.8/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "The fmt programmers" ]
+homepage: "https://erratique.ch/software/fmt"
+doc: "https://erratique.ch/software/fmt"
+dev-repo: "git+https://erratique.ch/repos/fmt.git"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+tags: [ "string" "format" "pretty-print" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  # Can be removed once ocaml >= 4.07
+  "seq"
+  "stdlib-shims"
+]
+depopts: [ "base-unix" "cmdliner" ]
+conflicts: [ "cmdliner" {< "0.9.8"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%"
+          "--with-base-unix" "%{base-unix:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """OCaml Format pretty-printer combinators"""
+description: """\
+
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
+library that allows to setup formatters for terminal color output
+depends on the Unix library. The optional `Fmt_cli` library that
+provides command line support for Fmt depends on [`Cmdliner`][cmdliner].
+
+Fmt is distributed under the ISC license.
+
+[cmdliner]: http://erratique.ch/software/cmdliner
+"""
+url {
+archive: "https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz"
+checksum: "473490fcfdf3ff0a8ccee226b873d4b2"
+}

--- a/bench.esy.lock/opam/logs.0.7.0/opam
+++ b/bench.esy.lock/opam/logs.0.7.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The logs programmers"]
+homepage: "https://erratique.ch/software/logs"
+doc: "https://erratique.ch/software/logs/doc"
+dev-repo: "git+https://erratique.ch/repos/logs.git"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+tags: [ "log" "system" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mtime" {with-test} ]
+depopts: [
+  "js_of_ocaml"
+  "fmt"
+  "cmdliner"
+  "lwt"
+  "base-threads"
+]
+conflicts: [
+  "js_of_ocaml" { < "3.3.0" } ]
+
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-js_of_ocaml" "%{js_of_ocaml:installed}%"
+          "--with-fmt" "%{fmt:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"
+          "--with-lwt" "%{lwt:installed}%"
+          "--with-base-threads" "%{base-threads:installed}%"
+]]
+
+synopsis: """Logging infrastructure for OCaml"""
+description: """\
+
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
+formatters depends on [Fmt][fmt].  The optional `Logs_browser`
+reporter that reports to the web browser console depends on
+[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
+command line support for controlling Logs depends on
+[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
+Lwt logging functions depends on [`Lwt`][lwt]
+
+Logs and its reporters are distributed under the ISC license.
+
+[fmt]: http://erratique.ch/software/fmt
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+[cmdliner]: http://erratique.ch/software/cmdliner
+[lwt]: http://ocsigen.org/lwt/
+"""
+url {
+archive: "https://erratique.ch/software/logs/releases/logs-0.7.0.tbz"
+checksum: "2bf021ca13331775e33cf34ab60246f7"
+}

--- a/bench.esy.lock/opam/stdlib-shims.0.1.0/opam
+++ b/bench.esy.lock/opam/stdlib-shims.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "The stdlib-shims programmers"
+authors: "The stdlib-shims programmers"
+homepage: "https://github.com/ocaml/stdlib-shims"
+doc: "https://ocaml.github.io/stdlib-shims/"
+dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
+bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
+tags: ["stdlib" "compatibility" "org:ocaml"]
+license: ["typeof OCaml system"]
+depends: [
+  "dune"
+  "ocaml" {>= "4.02.3"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+synopsis: "Backport some of the new stdlib features to older compiler"
+description: """
+Backport some of the new stdlib features to older compiler,
+such as the Stdlib module.
+
+This allows projects that require compatibility with older compiler to
+use these new features in their code.
+"""
+url {
+  src:
+    "https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz"
+  checksum: "md5=12b5704eed70c6bff5ac39a16db1425d"
+}

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "c098c104ee53549d60641fcd9952513a",
+  "checksum": "238f482f0a58abc9602979f439c8bdc3",
   "root": "revery@link-dev:./package.json",
   "node": {
     "wordwrap@0.0.3@d41d8cd9": {
@@ -44,6 +44,23 @@
       "dependencies": [ "qs@6.9.1@d41d8cd9" ],
       "devDependencies": []
     },
+    "timber@github:glennsl/timber#37ffa07@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+      "name": "timber",
+      "version": "github:glennsl/timber#37ffa07",
+      "source": {
+        "type": "install",
+        "source": [ "github:glennsl/timber#37ffa07" ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
+    },
     "secure-compare@3.0.1@d41d8cd9": {
       "id": "secure-compare@3.0.1@d41d8cd9",
       "name": "secure-compare",
@@ -82,13 +99,14 @@
       },
       "overrides": [ "doc.json" ],
       "dependencies": [
+        "timber@github:glennsl/timber#37ffa07@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-sdl2@2.10.3012@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
         "reason-fontkit@2.8.3@d41d8cd9",
-        "reason-font-manager@2.0.1@d41d8cd9", "http-server@0.12.0@d41d8cd9",
+        "reason-font-manager@2.0.1@d41d8cd9", "http-server@0.12.1@d41d8cd9",
         "flex@1.2.2@d41d8cd9", "@reason-native/rely@3.1.0@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/odoc@opam:1.4.2@11b715bb",
@@ -445,14 +463,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "http-server@0.12.0@d41d8cd9": {
-      "id": "http-server@0.12.0@d41d8cd9",
+    "http-server@0.12.1@d41d8cd9": {
+      "id": "http-server@0.12.1@d41d8cd9",
       "name": "http-server",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/http-server/-/http-server-0.12.0.tgz#sha1:316b450603c0454d4a462d97a3132808a9858563"
+          "archive:https://registry.npmjs.org/http-server/-/http-server-0.12.1.tgz#sha1:629ae9a8c786587ee21b0ff087b670f69b809d8c"
         ]
       },
       "overrides": [],
@@ -940,6 +958,31 @@
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
+      ]
+    },
+    "@opam/stdlib-shims@opam:0.1.0@d957c903": {
+      "id": "@opam/stdlib-shims@opam:0.1.0@d957c903",
+      "name": "@opam/stdlib-shims",
+      "version": "opam:0.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/12/12b5704eed70c6bff5ac39a16db1425d#md5:12b5704eed70c6bff5ac39a16db1425d",
+          "archive:https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz#md5:12b5704eed70c6bff5ac39a16db1425d"
+        ],
+        "opam": {
+          "name": "stdlib-shims",
+          "version": "0.1.0",
+          "path": "doc.esy.lock/opam/stdlib-shims.0.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
     "@opam/stdio@opam:v0.13.0@eb59d879": {
@@ -1628,6 +1671,36 @@
         "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
+    "@opam/logs@opam:0.7.0@1d03143e": {
+      "id": "@opam/logs@opam:0.7.0@1d03143e",
+      "name": "@opam/logs",
+      "version": "opam:0.7.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/2b/2bf021ca13331775e33cf34ab60246f7#md5:2bf021ca13331775e33cf34ab60246f7",
+          "archive:https://erratique.ch/software/logs/releases/logs-0.7.0.tbz#md5:2bf021ca13331775e33cf34ab60246f7"
+        ],
+        "opam": {
+          "name": "logs",
+          "version": "0.7.0",
+          "path": "doc.esy.lock/opam/logs.0.7.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-threads@opam:base@36803084",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
+    },
     "@opam/lambda-term@opam:2.0.3@9465cf1c": {
       "id": "@opam/lambda-term@opam:2.0.3@9465cf1c",
       "name": "@opam/lambda-term",
@@ -1866,6 +1939,38 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/astring@opam:0.8.3@4e5e17d5"
+      ]
+    },
+    "@opam/fmt@opam:0.8.8@01c3a23c": {
+      "id": "@opam/fmt@opam:0.8.8@01c3a23c",
+      "name": "@opam/fmt",
+      "version": "opam:0.8.8",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/47/473490fcfdf3ff0a8ccee226b873d4b2#md5:473490fcfdf3ff0a8ccee226b873d4b2",
+          "archive:https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz#md5:473490fcfdf3ff0a8ccee226b873d4b2"
+        ],
+        "opam": {
+          "name": "fmt",
+          "version": "0.8.8",
+          "path": "doc.esy.lock/opam/fmt.0.8.8"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {

--- a/doc.esy.lock/opam/fmt.0.8.8/opam
+++ b/doc.esy.lock/opam/fmt.0.8.8/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "The fmt programmers" ]
+homepage: "https://erratique.ch/software/fmt"
+doc: "https://erratique.ch/software/fmt"
+dev-repo: "git+https://erratique.ch/repos/fmt.git"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+tags: [ "string" "format" "pretty-print" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  # Can be removed once ocaml >= 4.07
+  "seq"
+  "stdlib-shims"
+]
+depopts: [ "base-unix" "cmdliner" ]
+conflicts: [ "cmdliner" {< "0.9.8"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%"
+          "--with-base-unix" "%{base-unix:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """OCaml Format pretty-printer combinators"""
+description: """\
+
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
+library that allows to setup formatters for terminal color output
+depends on the Unix library. The optional `Fmt_cli` library that
+provides command line support for Fmt depends on [`Cmdliner`][cmdliner].
+
+Fmt is distributed under the ISC license.
+
+[cmdliner]: http://erratique.ch/software/cmdliner
+"""
+url {
+archive: "https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz"
+checksum: "473490fcfdf3ff0a8ccee226b873d4b2"
+}

--- a/doc.esy.lock/opam/logs.0.7.0/opam
+++ b/doc.esy.lock/opam/logs.0.7.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The logs programmers"]
+homepage: "https://erratique.ch/software/logs"
+doc: "https://erratique.ch/software/logs/doc"
+dev-repo: "git+https://erratique.ch/repos/logs.git"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+tags: [ "log" "system" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mtime" {with-test} ]
+depopts: [
+  "js_of_ocaml"
+  "fmt"
+  "cmdliner"
+  "lwt"
+  "base-threads"
+]
+conflicts: [
+  "js_of_ocaml" { < "3.3.0" } ]
+
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-js_of_ocaml" "%{js_of_ocaml:installed}%"
+          "--with-fmt" "%{fmt:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"
+          "--with-lwt" "%{lwt:installed}%"
+          "--with-base-threads" "%{base-threads:installed}%"
+]]
+
+synopsis: """Logging infrastructure for OCaml"""
+description: """\
+
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
+formatters depends on [Fmt][fmt].  The optional `Logs_browser`
+reporter that reports to the web browser console depends on
+[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
+command line support for controlling Logs depends on
+[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
+Lwt logging functions depends on [`Lwt`][lwt]
+
+Logs and its reporters are distributed under the ISC license.
+
+[fmt]: http://erratique.ch/software/fmt
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+[cmdliner]: http://erratique.ch/software/cmdliner
+[lwt]: http://ocsigen.org/lwt/
+"""
+url {
+archive: "https://erratique.ch/software/logs/releases/logs-0.7.0.tbz"
+checksum: "2bf021ca13331775e33cf34ab60246f7"
+}

--- a/doc.esy.lock/opam/stdlib-shims.0.1.0/opam
+++ b/doc.esy.lock/opam/stdlib-shims.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "The stdlib-shims programmers"
+authors: "The stdlib-shims programmers"
+homepage: "https://github.com/ocaml/stdlib-shims"
+doc: "https://ocaml.github.io/stdlib-shims/"
+dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
+bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
+tags: ["stdlib" "compatibility" "org:ocaml"]
+license: ["typeof OCaml system"]
+depends: [
+  "dune"
+  "ocaml" {>= "4.02.3"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+synopsis: "Backport some of the new stdlib features to older compiler"
+description: """
+Backport some of the new stdlib features to older compiler,
+such as the Stdlib module.
+
+This allows projects that require compatibility with older compiler to
+use these new features in their code.
+"""
+url {
+  src:
+    "https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz"
+  checksum: "md5=12b5704eed70c6bff5ac39a16db1425d"
+}

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,14 +1,14 @@
 {
-  "checksum": "7d67a8a807d3f0607d5053e490a3ea05",
+  "checksum": "41f8d7fde0605c68491815a9f049de61",
   "root": "revery@link-dev:./package.json",
   "node": {
-    "timber@github:glennsl/timber#739b490@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#739b490@d41d8cd9",
+    "timber@github:glennsl/timber#37ffa07@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#37ffa07@d41d8cd9",
       "name": "timber",
-      "version": "github:glennsl/timber#739b490",
+      "version": "github:glennsl/timber#37ffa07",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/timber#739b490" ]
+        "source": [ "github:glennsl/timber#37ffa07" ]
       },
       "overrides": [],
       "dependencies": [
@@ -43,7 +43,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "timber@github:glennsl/timber#739b490@d41d8cd9",
+        "timber@github:glennsl/timber#37ffa07@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,7 +1,24 @@
 {
-  "checksum": "7eb5e3744d4091fe09412b21da9db3bd",
+  "checksum": "7d67a8a807d3f0607d5053e490a3ea05",
   "root": "revery@link-dev:./package.json",
   "node": {
+    "timber@github:glennsl/timber#739b490@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#739b490@d41d8cd9",
+      "name": "timber",
+      "version": "github:glennsl/timber#739b490",
+      "source": {
+        "type": "install",
+        "source": [ "github:glennsl/timber#739b490" ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.3.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+    },
     "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9": {
       "id":
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
@@ -26,6 +43,7 @@
       },
       "overrides": [],
       "dependencies": [
+        "timber@github:glennsl/timber#739b490@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
@@ -544,6 +562,31 @@
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
+      ]
+    },
+    "@opam/stdlib-shims@opam:0.1.0@d957c903": {
+      "id": "@opam/stdlib-shims@opam:0.1.0@d957c903",
+      "name": "@opam/stdlib-shims",
+      "version": "opam:0.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/12/12b5704eed70c6bff5ac39a16db1425d#md5:12b5704eed70c6bff5ac39a16db1425d",
+          "archive:https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz#md5:12b5704eed70c6bff5ac39a16db1425d"
+        ],
+        "opam": {
+          "name": "stdlib-shims",
+          "version": "0.1.0",
+          "path": "esy.lock/opam/stdlib-shims.0.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
     "@opam/stdio@opam:v0.13.0@eb59d879": {
@@ -1203,6 +1246,36 @@
         "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
+    "@opam/logs@opam:0.7.0@1d03143e": {
+      "id": "@opam/logs@opam:0.7.0@1d03143e",
+      "name": "@opam/logs",
+      "version": "opam:0.7.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/2b/2bf021ca13331775e33cf34ab60246f7#md5:2bf021ca13331775e33cf34ab60246f7",
+          "archive:https://erratique.ch/software/logs/releases/logs-0.7.0.tbz#md5:2bf021ca13331775e33cf34ab60246f7"
+        ],
+        "opam": {
+          "name": "logs",
+          "version": "0.7.0",
+          "path": "esy.lock/opam/logs.0.7.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-threads@opam:base@36803084",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+    },
     "@opam/lambda-term@opam:2.0.3@9465cf1c": {
       "id": "@opam/lambda-term@opam:2.0.3@9465cf1c",
       "name": "@opam/lambda-term",
@@ -1441,6 +1514,38 @@
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/astring@opam:0.8.3@4e5e17d5"
+      ]
+    },
+    "@opam/fmt@opam:0.8.8@01c3a23c": {
+      "id": "@opam/fmt@opam:0.8.8@01c3a23c",
+      "name": "@opam/fmt",
+      "version": "opam:0.8.8",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/47/473490fcfdf3ff0a8ccee226b873d4b2#md5:473490fcfdf3ff0a8ccee226b873d4b2",
+          "archive:https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz#md5:473490fcfdf3ff0a8ccee226b873d4b2"
+        ],
+        "opam": {
+          "name": "fmt",
+          "version": "0.8.8",
+          "path": "esy.lock/opam/fmt.0.8.8"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {

--- a/esy.lock/opam/fmt.0.8.8/opam
+++ b/esy.lock/opam/fmt.0.8.8/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "The fmt programmers" ]
+homepage: "https://erratique.ch/software/fmt"
+doc: "https://erratique.ch/software/fmt"
+dev-repo: "git+https://erratique.ch/repos/fmt.git"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+tags: [ "string" "format" "pretty-print" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  # Can be removed once ocaml >= 4.07
+  "seq"
+  "stdlib-shims"
+]
+depopts: [ "base-unix" "cmdliner" ]
+conflicts: [ "cmdliner" {< "0.9.8"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%"
+          "--with-base-unix" "%{base-unix:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """OCaml Format pretty-printer combinators"""
+description: """\
+
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
+library that allows to setup formatters for terminal color output
+depends on the Unix library. The optional `Fmt_cli` library that
+provides command line support for Fmt depends on [`Cmdliner`][cmdliner].
+
+Fmt is distributed under the ISC license.
+
+[cmdliner]: http://erratique.ch/software/cmdliner
+"""
+url {
+archive: "https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz"
+checksum: "473490fcfdf3ff0a8ccee226b873d4b2"
+}

--- a/esy.lock/opam/logs.0.7.0/opam
+++ b/esy.lock/opam/logs.0.7.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The logs programmers"]
+homepage: "https://erratique.ch/software/logs"
+doc: "https://erratique.ch/software/logs/doc"
+dev-repo: "git+https://erratique.ch/repos/logs.git"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+tags: [ "log" "system" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mtime" {with-test} ]
+depopts: [
+  "js_of_ocaml"
+  "fmt"
+  "cmdliner"
+  "lwt"
+  "base-threads"
+]
+conflicts: [
+  "js_of_ocaml" { < "3.3.0" } ]
+
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-js_of_ocaml" "%{js_of_ocaml:installed}%"
+          "--with-fmt" "%{fmt:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"
+          "--with-lwt" "%{lwt:installed}%"
+          "--with-base-threads" "%{base-threads:installed}%"
+]]
+
+synopsis: """Logging infrastructure for OCaml"""
+description: """\
+
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
+formatters depends on [Fmt][fmt].  The optional `Logs_browser`
+reporter that reports to the web browser console depends on
+[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
+command line support for controlling Logs depends on
+[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
+Lwt logging functions depends on [`Lwt`][lwt]
+
+Logs and its reporters are distributed under the ISC license.
+
+[fmt]: http://erratique.ch/software/fmt
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+[cmdliner]: http://erratique.ch/software/cmdliner
+[lwt]: http://ocsigen.org/lwt/
+"""
+url {
+archive: "https://erratique.ch/software/logs/releases/logs-0.7.0.tbz"
+checksum: "2bf021ca13331775e33cf34ab60246f7"
+}

--- a/esy.lock/opam/stdlib-shims.0.1.0/opam
+++ b/esy.lock/opam/stdlib-shims.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "The stdlib-shims programmers"
+authors: "The stdlib-shims programmers"
+homepage: "https://github.com/ocaml/stdlib-shims"
+doc: "https://ocaml.github.io/stdlib-shims/"
+dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
+bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
+tags: ["stdlib" "compatibility" "org:ocaml"]
+license: ["typeof OCaml system"]
+depends: [
+  "dune"
+  "ocaml" {>= "4.02.3"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+synopsis: "Backport some of the new stdlib features to older compiler"
+description: """
+Backport some of the new stdlib features to older compiler,
+such as the Stdlib module.
+
+This allows projects that require compatibility with older compiler to
+use these new features in their code.
+"""
+url {
+  src:
+    "https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz"
+  checksum: "md5=12b5704eed70c6bff5ac39a16db1425d"
+}

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -275,7 +275,8 @@ module ExampleHost = {
 };
 
 let init = app => {
-  let _ignore = Log.listen((_, msg) => print_endline(msg));
+  Timber.App.enablePrinting();
+  Timber.App.enableDebugLogging();
 
   let maximized = Environment.webGL;
 

--- a/examples/dune
+++ b/examples/dune
@@ -9,6 +9,7 @@
         str
         Revery
         flex
+        timber
             ))
 (install
     (section bin)

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9a02ea2cbc94189a6658bb6c44216ed7",
+  "checksum": "fe1eaf555349284a565485b63602af68",
   "root": "revery@link-dev:./package.json",
   "node": {
     "wordwrap@0.0.3@d41d8cd9": {
@@ -44,6 +44,23 @@
       "dependencies": [ "qs@6.9.1@d41d8cd9" ],
       "devDependencies": []
     },
+    "timber@github:glennsl/timber#37ffa07@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+      "name": "timber",
+      "version": "github:glennsl/timber#37ffa07",
+      "source": {
+        "type": "install",
+        "source": [ "github:glennsl/timber#37ffa07" ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
+    },
     "secure-compare@3.0.1@d41d8cd9": {
       "id": "secure-compare@3.0.1@d41d8cd9",
       "name": "secure-compare",
@@ -82,13 +99,14 @@
       },
       "overrides": [ "js.json" ],
       "dependencies": [
+        "timber@github:glennsl/timber#37ffa07@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-sdl2@2.10.3012@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
         "reason-fontkit@2.8.3@d41d8cd9",
-        "reason-font-manager@2.0.1@d41d8cd9", "http-server@0.12.0@d41d8cd9",
+        "reason-font-manager@2.0.1@d41d8cd9", "http-server@0.12.1@d41d8cd9",
         "flex@1.2.2@d41d8cd9", "@reason-native/rely@3.1.0@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/merlin-extend@opam:0.4@64c45329",
@@ -445,14 +463,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "http-server@0.12.0@d41d8cd9": {
-      "id": "http-server@0.12.0@d41d8cd9",
+    "http-server@0.12.1@d41d8cd9": {
+      "id": "http-server@0.12.1@d41d8cd9",
       "name": "http-server",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/http-server/-/http-server-0.12.0.tgz#sha1:316b450603c0454d4a462d97a3132808a9858563"
+          "archive:https://registry.npmjs.org/http-server/-/http-server-0.12.1.tgz#sha1:629ae9a8c786587ee21b0ff087b670f69b809d8c"
         ]
       },
       "overrides": [],
@@ -940,6 +958,31 @@
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
+      ]
+    },
+    "@opam/stdlib-shims@opam:0.1.0@d957c903": {
+      "id": "@opam/stdlib-shims@opam:0.1.0@d957c903",
+      "name": "@opam/stdlib-shims",
+      "version": "opam:0.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/12/12b5704eed70c6bff5ac39a16db1425d#md5:12b5704eed70c6bff5ac39a16db1425d",
+          "archive:https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz#md5:12b5704eed70c6bff5ac39a16db1425d"
+        ],
+        "opam": {
+          "name": "stdlib-shims",
+          "version": "0.1.0",
+          "path": "js.esy.lock/opam/stdlib-shims.0.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
     "@opam/stdio@opam:v0.13.0@eb59d879": {
@@ -1599,6 +1642,36 @@
         "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
+    "@opam/logs@opam:0.7.0@1d03143e": {
+      "id": "@opam/logs@opam:0.7.0@1d03143e",
+      "name": "@opam/logs",
+      "version": "opam:0.7.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/2b/2bf021ca13331775e33cf34ab60246f7#md5:2bf021ca13331775e33cf34ab60246f7",
+          "archive:https://erratique.ch/software/logs/releases/logs-0.7.0.tbz#md5:2bf021ca13331775e33cf34ab60246f7"
+        ],
+        "opam": {
+          "name": "logs",
+          "version": "0.7.0",
+          "path": "js.esy.lock/opam/logs.0.7.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-threads@opam:base@36803084",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
+    },
     "@opam/lambda-term@opam:2.0.3@9465cf1c": {
       "id": "@opam/lambda-term@opam:2.0.3@9465cf1c",
       "name": "@opam/lambda-term",
@@ -1837,6 +1910,38 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/astring@opam:0.8.3@4e5e17d5"
+      ]
+    },
+    "@opam/fmt@opam:0.8.8@01c3a23c": {
+      "id": "@opam/fmt@opam:0.8.8@01c3a23c",
+      "name": "@opam/fmt",
+      "version": "opam:0.8.8",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/47/473490fcfdf3ff0a8ccee226b873d4b2#md5:473490fcfdf3ff0a8ccee226b873d4b2",
+          "archive:https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz#md5:473490fcfdf3ff0a8ccee226b873d4b2"
+        ],
+        "opam": {
+          "name": "fmt",
+          "version": "0.8.8",
+          "path": "js.esy.lock/opam/fmt.0.8.8"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {

--- a/js.esy.lock/opam/fmt.0.8.8/opam
+++ b/js.esy.lock/opam/fmt.0.8.8/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "The fmt programmers" ]
+homepage: "https://erratique.ch/software/fmt"
+doc: "https://erratique.ch/software/fmt"
+dev-repo: "git+https://erratique.ch/repos/fmt.git"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+tags: [ "string" "format" "pretty-print" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  # Can be removed once ocaml >= 4.07
+  "seq"
+  "stdlib-shims"
+]
+depopts: [ "base-unix" "cmdliner" ]
+conflicts: [ "cmdliner" {< "0.9.8"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%"
+          "--with-base-unix" "%{base-unix:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """OCaml Format pretty-printer combinators"""
+description: """\
+
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
+library that allows to setup formatters for terminal color output
+depends on the Unix library. The optional `Fmt_cli` library that
+provides command line support for Fmt depends on [`Cmdliner`][cmdliner].
+
+Fmt is distributed under the ISC license.
+
+[cmdliner]: http://erratique.ch/software/cmdliner
+"""
+url {
+archive: "https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz"
+checksum: "473490fcfdf3ff0a8ccee226b873d4b2"
+}

--- a/js.esy.lock/opam/logs.0.7.0/opam
+++ b/js.esy.lock/opam/logs.0.7.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The logs programmers"]
+homepage: "https://erratique.ch/software/logs"
+doc: "https://erratique.ch/software/logs/doc"
+dev-repo: "git+https://erratique.ch/repos/logs.git"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+tags: [ "log" "system" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mtime" {with-test} ]
+depopts: [
+  "js_of_ocaml"
+  "fmt"
+  "cmdliner"
+  "lwt"
+  "base-threads"
+]
+conflicts: [
+  "js_of_ocaml" { < "3.3.0" } ]
+
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-js_of_ocaml" "%{js_of_ocaml:installed}%"
+          "--with-fmt" "%{fmt:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"
+          "--with-lwt" "%{lwt:installed}%"
+          "--with-base-threads" "%{base-threads:installed}%"
+]]
+
+synopsis: """Logging infrastructure for OCaml"""
+description: """\
+
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
+formatters depends on [Fmt][fmt].  The optional `Logs_browser`
+reporter that reports to the web browser console depends on
+[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
+command line support for controlling Logs depends on
+[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
+Lwt logging functions depends on [`Lwt`][lwt]
+
+Logs and its reporters are distributed under the ISC license.
+
+[fmt]: http://erratique.ch/software/fmt
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+[cmdliner]: http://erratique.ch/software/cmdliner
+[lwt]: http://ocsigen.org/lwt/
+"""
+url {
+archive: "https://erratique.ch/software/logs/releases/logs-0.7.0.tbz"
+checksum: "2bf021ca13331775e33cf34ab60246f7"
+}

--- a/js.esy.lock/opam/stdlib-shims.0.1.0/opam
+++ b/js.esy.lock/opam/stdlib-shims.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "The stdlib-shims programmers"
+authors: "The stdlib-shims programmers"
+homepage: "https://github.com/ocaml/stdlib-shims"
+doc: "https://ocaml.github.io/stdlib-shims/"
+dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
+bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
+tags: ["stdlib" "compatibility" "org:ocaml"]
+license: ["typeof OCaml system"]
+depends: [
+  "dune"
+  "ocaml" {>= "4.02.3"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+synopsis: "Backport some of the new stdlib features to older compiler"
+description: """
+Backport some of the new stdlib features to older compiler,
+such as the Stdlib module.
+
+This allows projects that require compatibility with older compiler to
+use these new features in their code.
+"""
+url {
+  src:
+    "https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz"
+  checksum: "md5=12b5704eed70c6bff5ac39a16db1425d"
+}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@opam/cmdliner": "1.0.2",
     "yarn-pkg-config": "esy-ocaml/yarn-pkg-config#db3a0b6",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
-    "timber": "glennsl/timber#739b490"
+    "timber": "glennsl/timber#37ffa07"
   },
   "devDependencies": {
     "ocaml": ">=4.6.0 <4.8.0",

--- a/package.json
+++ b/package.json
@@ -43,12 +43,14 @@
     "rench": "^1.9.1",
     "rebez": "github:jchavarri/rebez#03fa3b7",
     "reason-sdl2": "^2.10.3011",
-    "revery-text-wrap": "github:revery-ui/revery-text-wrap#005385c"
+    "revery-text-wrap": "github:revery-ui/revery-text-wrap#005385c",
+    "timber": "*"
   },
   "resolutions": {
     "@opam/cmdliner": "1.0.2",
     "yarn-pkg-config": "esy-ocaml/yarn-pkg-config#db3a0b6",
-    "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755"
+    "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
+    "timber": "glennsl/timber#739b490"
   },
   "devDependencies": {
     "ocaml": ">=4.6.0 <4.8.0",

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -1,10 +1,9 @@
+module Log = (val Log.withNamespace("Revery.App"));
+
 type delegatedFunc = unit => unit;
 type idleFunc = unit => unit;
 type canIdleFunc = unit => bool;
 let noop = () => ();
-
-let logError = Log.error("App");
-let logInfo = Log.info("App");
 
 type t = {
   mutable idleCount: int,
@@ -30,17 +29,11 @@ let getWindowById = (app: t, id: int) => {
 
 let _tryToClose = (app: t, window: Window.t) =>
   if (Window.canQuit(window)) {
-    logInfo(
-      "_tryToClose: Window canQuit is true - closing window: "
-      ++ string_of_int(window.uniqueId),
-    );
+    Log.debugf(m => m("canQuit is true for window %i", window.uniqueId));
     Window.destroyWindow(window);
     Hashtbl.remove(app.windows, window.uniqueId);
   } else {
-    logInfo(
-      "_tryToClose: Window canQuit is false "
-      ++ string_of_int(window.uniqueId),
-    );
+    Log.debugf(m => m("canQuit is false for window %i", window.uniqueId));
   };
 
 let _tryToCloseAll = (app: t) => {
@@ -56,7 +49,7 @@ let quit = (~askNicely=false, ~code=0, app: t) => {
   Revery_Native.uninit();
 
   if (Hashtbl.length(app.windows) == 0 || !askNicely) {
-    logInfo("Quitting");
+    Log.info("Quitting");
     exit(code);
   };
 };
@@ -136,11 +129,12 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
       switch (window) {
       | Some(win) => Window._handleEvent(evt, win)
       | None =>
-        logError(
-          "Unable to find window with ID: "
-          ++ string_of_int(windowID)
-          ++ " - event: "
-          ++ Sdl2.Event.show(evt),
+        Log.errorf(m =>
+          m(
+            "Unable to find window with ID: %i - event: %s",
+            windowID,
+            Sdl2.Event.show(evt),
+          )
         )
       };
     };
@@ -160,7 +154,7 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
     | Sdl2.Event.WindowEnter({windowID}) => handleEvent(windowID)
     | Sdl2.Event.WindowLeave({windowID}) => handleEvent(windowID)
     | Sdl2.Event.WindowClosed({windowID, _}) =>
-      logInfo("Got window closed event: " ++ string_of_int(windowID));
+      Log.debugf(m => m("Got WindowClosed event for %i", windowID));
       handleEvent(windowID);
       switch (getWindowById(appInstance, windowID)) {
       | None => ()
@@ -201,7 +195,7 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
         || _anyPendingMainThreadJobs()
         || !appInstance.canIdle^()) {
       if (appInstance.idleCount > 0) {
-        logInfo("Upshifting into active state.");
+        Log.debug("Upshifting into active state.");
       };
 
       Performance.bench("_doPendingMainThreadJobs", () =>
@@ -217,7 +211,7 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
       appInstance.idleCount = appInstance.idleCount + 1;
 
       if (appInstance.idleCount === framesToIdle) {
-        logInfo("Downshifting into idle state...");
+        Log.debug("Downshifting into idle state...");
         appInstance.onIdle();
       };
 

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -1,11 +1,1 @@
-let info = (category, str) => {
-  Timber.info(category ++ ": " ++ str);
-};
-
-let error = (category, str) => {
-  Timber.error(category ++ ": " ++ str);
-};
-
-let perf = str => {
-  Timber.debug(() => str);
-};
+include Timber;

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -1,24 +1,11 @@
-type severity =
-  | Info
-  | Error
-  | Performance;
-
-type logFunc = (severity, string) => unit;
-
-let _logEvent = Event.create();
-
-let listen = logFunc => {
-  Event.subscribe(_logEvent, ((sev, str)) => {logFunc(sev, str)});
-};
-
 let info = (category, str) => {
-  Event.dispatch(_logEvent, (Info, category ++ ": " ++ str));
+  Timber.info(category ++ ": " ++ str);
 };
 
 let error = (category, str) => {
-  Event.dispatch(_logEvent, (Error, category ++ ": " ++ str));
+  Timber.error(category ++ ": " ++ str);
 };
 
 let perf = str => {
-  Event.dispatch(_logEvent, (Performance, str));
+  Timber.debug(() => str);
 };

--- a/src/Core/Log.rei
+++ b/src/Core/Log.rei
@@ -1,0 +1,13 @@
+module type Logger = {
+  let errorf: Timber.msgf(_, unit) => unit;
+  let error: string => unit;
+  let warnf: Timber.msgf(_, unit) => unit;
+  let warn: string => unit;
+  let infof: Timber.msgf(_, unit) => unit;
+  let info: string => unit;
+  let debugf: Timber.msgf(_, unit) => unit;
+  let debug: string => unit;
+  let fn: (string, 'a => 'b, 'a) => 'b;
+};
+
+let withNamespace: string => (module Logger);

--- a/src/Core/Performance.re
+++ b/src/Core/Performance.re
@@ -2,6 +2,8 @@ type performanceFunction('a) = unit => 'a;
 
 let nestingLevel = ref(0);
 
+module Log = (val Log.withNamespace("Revery.Performance"));
+
 module MemoryAllocations = {
   type t = {
     minorWords: int,
@@ -9,15 +11,13 @@ module MemoryAllocations = {
     majorWords: int,
   };
 
-  let toString = ({minorWords, promotedWords, majorWords}: t) => {
-    "| minor: "
-    ++ string_of_int(minorWords)
-    ++ " | major: "
-    ++ string_of_int(majorWords)
-    ++ " | promoted: "
-    ++ string_of_int(promotedWords)
-    ++ " |";
-  };
+  let toString = ({minorWords, promotedWords, majorWords}: t) =>
+    Printf.sprintf(
+      "| minor: %n | major: %n | promoted: %n |",
+      minorWords,
+      majorWords,
+      promotedWords,
+    );
 };
 let getMemoryAllocations = (startCounters, endCounters) => {
   let (startMinor, startPromoted, startMajor) = startCounters;
@@ -43,20 +43,21 @@ let bench: (string, performanceFunction('a)) => 'a =
       nestingLevel := nestingLevel^ + 1;
       let startTime = Unix.gettimeofday();
       let startCounters = GarbageCollector.counters();
-      Log.perf(String.make(nestingLevel^, '-') ++ "[BEGIN: " ++ name ++ "]");
+      Log.debugf(m =>
+        m("%s[BEGIN: %s]", String.make(nestingLevel^, '-'), name)
+      );
       let ret = f();
       let endTime = Unix.gettimeofday();
       let endCounters = GarbageCollector.counters();
       let allocations = getMemoryAllocations(startCounters, endCounters);
-      Log.perf(
-        String.make(nestingLevel^, '-')
-        ++ "[END: "
-        ++ name
-        ++ "] Time: "
-        ++ string_of_float((endTime -. startTime) *. 1000.)
-        ++ "ms"
-        ++ " Memory: "
-        ++ MemoryAllocations.toString(allocations),
+      Log.debugf(m =>
+        m(
+          "%s[END: %s] Time: %fms Memory: %s",
+          String.make(nestingLevel^, '-'),
+          name,
+          (endTime -. startTime) *. 1000.,
+          MemoryAllocations.toString(allocations),
+        )
       );
 
       nestingLevel := nestingLevel^ - 1;

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -187,7 +187,7 @@ let _updateMetrics = (w: t) => {
 };
 
 let setRawSize = (win: t, adjWidth: int, adjHeight: int) => {
-  Log.debugf(m => m("setRawSize - after scaling: %ix%i", adjWidth,adjHeight));
+  Log.debugf(m => m("setRawSize - calling with: %ix%i", adjWidth, adjHeight));
 
   if (adjWidth != win.metrics.size.width
       || adjHeight != win.metrics.size.height) {
@@ -206,7 +206,7 @@ let setRawSize = (win: t, adjWidth: int, adjHeight: int) => {
       win.requestedHeight = None;
       win.areMetricsDirty = true;
       Log.debugf(m => {
-        let Sdl2.Size.{width, height, _} = Sdl2.Window.getSize(win.sdlWindow);
+        let Sdl2.Size.{width, height} = Sdl2.Window.getSize(win.sdlWindow);
         m("setRawSize: SDL size reported after resize: %ux%u", width, height);
       });
     };

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -8,7 +8,7 @@ type size = {
   width: int,
   height: int,
 };
-let log = Log.info("Window");
+module Log = (val Log.withNamespace("Revery.Window"));
 
 module WindowMetrics = {
   type t = {
@@ -113,9 +113,8 @@ let _getScaleFactor = (~forceScaleFactor=None, sdlWindow) => {
     // On Windows, we need to try a Win32 API to get the scale factor
     | Windows =>
       let scale = Sdl2.Window.getWin32ScaleFactor(sdlWindow);
-      log(
-        "_getScaleFactor - from getWin32ScaleFactor: "
-        ++ string_of_float(scale),
+      Log.debugf(m =>
+        m("_getScaleFactor - from getWin32ScaleFactor: %f", scale)
       );
       scale;
 
@@ -126,7 +125,7 @@ let _getScaleFactor = (~forceScaleFactor=None, sdlWindow) => {
       switch (Rench.Environment.getEnvironmentVariable("GDK_SCALE")) {
       | Some(v) =>
         // TODO
-        log("_getScaleFactor - Linux - got GDK_SCALE variable: " ++ v);
+        Log.debug("_getScaleFactor - Linux - got GDK_SCALE variable: " ++ v);
         switch (Float.of_string_opt(v)) {
         | Some(v) => v
         | None => 1.0
@@ -136,9 +135,8 @@ let _getScaleFactor = (~forceScaleFactor=None, sdlWindow) => {
         let dpi = Sdl2.Display.getDPI(display);
         let avgDpi = (dpi.hdpi +. dpi.vdpi +. dpi.ddpi) /. 3.0;
         let scaleFactor = max(1.0, floor(avgDpi /. 96.0));
-        log(
-          "_getScaleFactor - Linux - inferring from DPI: "
-          ++ string_of_float(scaleFactor),
+        Log.debugf(m =>
+          m("_getScaleFactor - Linux - inferring from DPI: %f", scaleFactor)
         );
         scaleFactor;
       }
@@ -183,16 +181,13 @@ let _updateMetrics = (w: t) => {
     zoom: previousZoom,
   };
   w.areMetricsDirty = false;
-  log("_updateMetrics - new metrics: " ++ WindowMetrics.toString(w.metrics));
+  Log.debug(
+    "_updateMetrics - new metrics: " ++ WindowMetrics.toString(w.metrics),
+  );
 };
 
 let setRawSize = (win: t, adjWidth: int, adjHeight: int) => {
-  log(
-    "setRawSize - dimensions adjusted after scaling: "
-    ++ string_of_int(adjWidth)
-    ++ " x "
-    ++ string_of_int(adjHeight),
-  );
+  Log.debugf(m => m("setRawSize - after scaling: %ix%i", adjWidth,adjHeight));
 
   if (adjWidth != win.metrics.size.width
       || adjHeight != win.metrics.size.height) {
@@ -201,33 +196,25 @@ let setRawSize = (win: t, adjWidth: int, adjHeight: int) => {
      *  we'll queue up the render operation for next time.
      */
     if (win.isRendering) {
-      log("setRawSize - queuing for next render");
+      Log.debug("setRawSize - queuing for next render");
       win.requestedWidth = Some(adjWidth);
       win.requestedHeight = Some(adjHeight);
     } else {
-      log("setRawSize - calling Sdl2.Window.setSize");
+      Log.debug("setRawSize - calling Sdl2.Window.setSize");
       Sdl2.Window.setSize(win.sdlWindow, adjWidth, adjHeight);
       win.requestedWidth = None;
       win.requestedHeight = None;
       win.areMetricsDirty = true;
-      let size = Sdl2.Window.getSize(win.sdlWindow);
-      log(
-        "setRawSize: SDL size reported after resize: "
-        ++ string_of_int(size.width)
-        ++ "x"
-        ++ string_of_int(size.height),
-      );
+      Log.debugf(m => {
+        let Sdl2.Size.{width, height, _} = Sdl2.Window.getSize(win.sdlWindow);
+        m("setRawSize: SDL size reported after resize: %ux%u", width, height);
+      });
     };
   };
 };
 
 let setScaledSize = (win: t, width: int, height: int) => {
-  log(
-    "setScaledSize - calling with: "
-    ++ string_of_int(width)
-    ++ "x"
-    ++ string_of_int(height),
-  );
+  Log.debugf(m => m("setScaledSize - calling with: %ux%u", width, height));
   // On platforms that return a non-unit scale factor (Windows and Linux),
   // we also have to scale the window size by the scale factor
   let adjWidth =
@@ -345,7 +332,7 @@ let setVsync =
       _window: t, // TODO: Multiple windows - set context
       vsync: Vsync.t,
     ) => {
-  log("Using vsync: " ++ Vsync.toString(vsync));
+  Log.info("Using vsync: " ++ Vsync.toString(vsync));
 
   switch (vsync) {
   | Vsync.Immediate => Sdl2.Gl.setSwapInterval(0)
@@ -354,7 +341,7 @@ let setVsync =
 };
 
 let create = (name: string, options: WindowCreateOptions.t) => {
-  log("Starting window creation...");
+  Log.debug("Starting window creation...");
 
   let width =
     switch (options.width) {
@@ -368,63 +355,55 @@ let create = (name: string, options: WindowCreateOptions.t) => {
     | v => v
     };
 
-  log(
-    "Creating window "
-    ++ name
-    ++ " width: "
-    ++ string_of_int(width)
-    ++ " height: "
-    ++ string_of_int(height),
+  Log.infof(m =>
+    m("Creating window %s width: %u height: %u", name, width, height)
   );
   let w = Sdl2.Window.create(width, height, name);
-  log("Window created successfully.");
+  Log.info("Window created successfully.");
   let uniqueId = Sdl2.Window.getId(w);
-  log("Window id: " ++ string_of_int(uniqueId));
+  Log.debugf(m => m("Window id: %i", uniqueId));
 
   // We need to let Windows know that we are DPI-aware and that we are going to
   // properly handle scaling. This is a no-op on other platforms.
   Sdl2.Window.setWin32ProcessDPIAware(w);
 
-  log("Setting window context");
+  Log.debug("Setting window context");
   let _ = Sdl2.Gl.setup(w);
-  log("GL setup. Checking GL version...");
+  Log.debug("GL setup. Checking GL version...");
   let version = Sdl2.Gl.glGetString(Sdl2.Gl.Version);
-  log("Checking GL vendor...");
+  Log.debug("Checking GL vendor...");
   let vendor = Sdl2.Gl.glGetString(Sdl2.Gl.Vendor);
-  log("Checking GL shading language version...");
+  Log.debug("Checking GL shading language version...");
   let shadingLanguageVersion =
     Sdl2.Gl.glGetString(Sdl2.Gl.ShadingLanguageVersion);
-  log(
-    Printf.sprintf(
-      "OpenGL hardware info - version: %s vendor: %s shadingLanguageVersion: %s\n",
-      version,
-      vendor,
-      shadingLanguageVersion,
-    ),
-  );
+
+  Log.info("OpenGL hardware info:");
+  Log.infof(m => m("  version: %s", version));
+  Log.infof(m => m("  vendor: %s", vendor));
+  Log.infof(m => m("  shadingLanguageVersion: %s", shadingLanguageVersion));
 
   switch (options.icon) {
-  | None =>
-    log("No icon to load.");
-    ();
+  | None => Log.debug("No icon to load.")
+
   | Some(path) =>
     let execDir = Environment.getExecutingDirectory();
     let relativeImagePath = execDir ++ path;
 
-    log("Loading icon from: " ++ relativeImagePath);
+    Log.debug("Loading icon from: " ++ relativeImagePath);
     switch (Sdl2.Surface.createFromImagePath(relativeImagePath)) {
     | Ok(v) =>
-      log("Icon loaded successfully.");
+      Log.debug("Icon loaded successfully.");
       Sdl2.Window.setIcon(w, v);
-      log("Icon set successfully.");
-    | Error(msg) => log("Error loading icon: " ++ msg)
+      Log.debug("Icon set successfully.");
+
+    | Error(msg) => Log.error("Error loading icon: " ++ msg)
     };
   };
 
-  log("Getting window metrics");
+  Log.debug("Getting window metrics");
   let metrics =
     _getMetricsFromGlfwWindow(~forceScaleFactor=options.forceScaleFactor, w);
-  log("Metrics: " ++ WindowMetrics.toString(metrics));
+  Log.debug("Metrics: " ++ WindowMetrics.toString(metrics));
   let ret: t = {
     backgroundColor: options.backgroundColor,
     sdlWindow: w,

--- a/src/Core/dune
+++ b/src/Core/dune
@@ -4,4 +4,4 @@
     (js_of_ocaml (javascript_files file.js))
     (c_names file)
     (c_flags :standard -Wall -Wextra -Werror)
-    (libraries threads console.lib str lwt sdl2 flex fontkit Rench re Revery_Native revery-text-wrap))
+    (libraries threads console.lib str lwt sdl2 flex fontkit Rench re Revery_Native revery-text-wrap timber))

--- a/src/UI/Focus.re
+++ b/src/UI/Focus.re
@@ -9,11 +9,11 @@ type active = {
 type focused = ref(option(active));
 let focused = ref(None);
 
-let log = Log.info("Focus");
+module Log = (val Log.withNamespace("Focus"));
 
 /* Should happen when user clicks anywhere where no focusable node exists */
 let loseFocus = () => {
-  log("loseFocus()");
+  Log.debug("loseFocus()");
 
   switch (focused^) {
   | Some({handler, _}) =>
@@ -25,7 +25,7 @@ let loseFocus = () => {
 };
 
 let focus = (node: Node.node) => {
-  log("focus()");
+  Log.debug("focus()");
   let _ = node#handleEvent(Focus);
   focused := Some({handler: node#handleEvent, id: node#getInternalId()});
 };

--- a/src/UI/Render.re
+++ b/src/UI/Render.re
@@ -10,6 +10,7 @@ open Revery_Math;
 
 module Layout = Layout;
 module LayoutTypes = Layout.LayoutTypes;
+module Log = (val Log.withNamespace("Revery.Render"));
 
 let _projection = Mat4.create();
 
@@ -21,7 +22,7 @@ let render =
       container: RenderContainer.t,
       component: React.element('node),
     ) => {
-  Log.info("UI", "BEGIN: Render frame");
+  Log.debug("BEGIN: Render frame");
   let {rootNode, window, container, _} = container;
 
   /* Perform reconciliation */
@@ -83,5 +84,5 @@ let render =
     DebugDraw.draw();
     RenderPass.endAlphaPass();
   });
-  Log.info("UI", "END: Render frame");
+  Log.debug("END: Render frame");
 };

--- a/src/UI/Ui.re
+++ b/src/UI/Ui.re
@@ -11,8 +11,8 @@
  * We should call them if we want to have multiple windows support.
  */
 
-module Log = Revery_Core.Log;
 module Window = Revery_Core.Window;
+module Log = (val Revery_Core.Log.withNamespace("Revery.Ui"));
 
 open RenderContainer;
 
@@ -21,7 +21,6 @@ let _activeWindow: ref(option(Window.t)) = ref(None);
 type renderFunction = React.element(React.reveryNode) => unit;
 
 let getActiveWindow = () => _activeWindow^;
-let log = Log.info("UI");
 
 let start = (window: Window.t, element: React.element(React.reveryNode)) => {
   let uiDirty = ref(true);
@@ -69,7 +68,7 @@ let start = (window: Window.t, element: React.element(React.reveryNode)) => {
     Revery_Core.Event.subscribe(
       window.onMouseLeave,
       () => {
-        log("Mouse leaving window");
+        Log.debug("Mouse leaving window");
         Mouse.notifyLeaveWindow(window);
       },
     );
@@ -78,7 +77,7 @@ let start = (window: Window.t, element: React.element(React.reveryNode)) => {
     Revery_Core.Event.subscribe(
       window.onMouseEnter,
       () => {
-        log("Mouse entering window");
+        Log.debug("Mouse entering window");
         Mouse.notifyEnterWindow(window);
       },
     );

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,7 +1,24 @@
 {
-  "checksum": "6f5134af9edfe5618670e21725f48ab0",
+  "checksum": "f0e84d320e078d361bece8b26bd90190",
   "root": "revery@link-dev:./package.json",
   "node": {
+    "timber@github:glennsl/timber#37ffa07@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#37ffa07@d41d8cd9",
+      "name": "timber",
+      "version": "github:glennsl/timber#37ffa07",
+      "source": {
+        "type": "install",
+        "source": [ "github:glennsl/timber#37ffa07" ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
+    },
     "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9": {
       "id":
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
@@ -26,6 +43,7 @@
       },
       "overrides": [ "test.json" ],
       "dependencies": [
+        "timber@github:glennsl/timber#37ffa07@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
@@ -544,6 +562,31 @@
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
+      ]
+    },
+    "@opam/stdlib-shims@opam:0.1.0@d957c903": {
+      "id": "@opam/stdlib-shims@opam:0.1.0@d957c903",
+      "name": "@opam/stdlib-shims",
+      "version": "opam:0.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/12/12b5704eed70c6bff5ac39a16db1425d#md5:12b5704eed70c6bff5ac39a16db1425d",
+          "archive:https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz#md5:12b5704eed70c6bff5ac39a16db1425d"
+        ],
+        "opam": {
+          "name": "stdlib-shims",
+          "version": "0.1.0",
+          "path": "test.esy.lock/opam/stdlib-shims.0.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
     "@opam/stdio@opam:v0.13.0@eb59d879": {
@@ -1203,6 +1246,36 @@
         "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
+    "@opam/logs@opam:0.7.0@1d03143e": {
+      "id": "@opam/logs@opam:0.7.0@1d03143e",
+      "name": "@opam/logs",
+      "version": "opam:0.7.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/2b/2bf021ca13331775e33cf34ab60246f7#md5:2bf021ca13331775e33cf34ab60246f7",
+          "archive:https://erratique.ch/software/logs/releases/logs-0.7.0.tbz#md5:2bf021ca13331775e33cf34ab60246f7"
+        ],
+        "opam": {
+          "name": "logs",
+          "version": "0.7.0",
+          "path": "test.esy.lock/opam/logs.0.7.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/lwt@opam:4.5.0@677655b4",
+        "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
+        "@opam/fmt@opam:0.8.8@01c3a23c",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-threads@opam:base@36803084",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
+    },
     "@opam/lambda-term@opam:2.0.3@9465cf1c": {
       "id": "@opam/lambda-term@opam:2.0.3@9465cf1c",
       "name": "@opam/lambda-term",
@@ -1441,6 +1514,38 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/astring@opam:0.8.3@4e5e17d5"
+      ]
+    },
+    "@opam/fmt@opam:0.8.8@01c3a23c": {
+      "id": "@opam/fmt@opam:0.8.8@01c3a23c",
+      "name": "@opam/fmt",
+      "version": "opam:0.8.8",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/47/473490fcfdf3ff0a8ccee226b873d4b2#md5:473490fcfdf3ff0a8ccee226b873d4b2",
+          "archive:https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz#md5:473490fcfdf3ff0a8ccee226b873d4b2"
+        ],
+        "opam": {
+          "name": "fmt",
+          "version": "0.8.8",
+          "path": "test.esy.lock/opam/fmt.0.8.8"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cmdliner@opam:1.0.2@8ab0598a",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@d957c903",
+        "@opam/seq@opam:base@d8d7de1d"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {

--- a/test.esy.lock/opam/fmt.0.8.8/opam
+++ b/test.esy.lock/opam/fmt.0.8.8/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "The fmt programmers" ]
+homepage: "https://erratique.ch/software/fmt"
+doc: "https://erratique.ch/software/fmt"
+dev-repo: "git+https://erratique.ch/repos/fmt.git"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+tags: [ "string" "format" "pretty-print" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  # Can be removed once ocaml >= 4.07
+  "seq"
+  "stdlib-shims"
+]
+depopts: [ "base-unix" "cmdliner" ]
+conflicts: [ "cmdliner" {< "0.9.8"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%"
+          "--with-base-unix" "%{base-unix:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """OCaml Format pretty-printer combinators"""
+description: """\
+
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
+library that allows to setup formatters for terminal color output
+depends on the Unix library. The optional `Fmt_cli` library that
+provides command line support for Fmt depends on [`Cmdliner`][cmdliner].
+
+Fmt is distributed under the ISC license.
+
+[cmdliner]: http://erratique.ch/software/cmdliner
+"""
+url {
+archive: "https://erratique.ch/software/fmt/releases/fmt-0.8.8.tbz"
+checksum: "473490fcfdf3ff0a8ccee226b873d4b2"
+}

--- a/test.esy.lock/opam/logs.0.7.0/opam
+++ b/test.esy.lock/opam/logs.0.7.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The logs programmers"]
+homepage: "https://erratique.ch/software/logs"
+doc: "https://erratique.ch/software/logs/doc"
+dev-repo: "git+https://erratique.ch/repos/logs.git"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+tags: [ "log" "system" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mtime" {with-test} ]
+depopts: [
+  "js_of_ocaml"
+  "fmt"
+  "cmdliner"
+  "lwt"
+  "base-threads"
+]
+conflicts: [
+  "js_of_ocaml" { < "3.3.0" } ]
+
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--with-js_of_ocaml" "%{js_of_ocaml:installed}%"
+          "--with-fmt" "%{fmt:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"
+          "--with-lwt" "%{lwt:installed}%"
+          "--with-base-threads" "%{base-threads:installed}%"
+]]
+
+synopsis: """Logging infrastructure for OCaml"""
+description: """\
+
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
+formatters depends on [Fmt][fmt].  The optional `Logs_browser`
+reporter that reports to the web browser console depends on
+[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
+command line support for controlling Logs depends on
+[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
+Lwt logging functions depends on [`Lwt`][lwt]
+
+Logs and its reporters are distributed under the ISC license.
+
+[fmt]: http://erratique.ch/software/fmt
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+[cmdliner]: http://erratique.ch/software/cmdliner
+[lwt]: http://ocsigen.org/lwt/
+"""
+url {
+archive: "https://erratique.ch/software/logs/releases/logs-0.7.0.tbz"
+checksum: "2bf021ca13331775e33cf34ab60246f7"
+}

--- a/test.esy.lock/opam/stdlib-shims.0.1.0/opam
+++ b/test.esy.lock/opam/stdlib-shims.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "The stdlib-shims programmers"
+authors: "The stdlib-shims programmers"
+homepage: "https://github.com/ocaml/stdlib-shims"
+doc: "https://ocaml.github.io/stdlib-shims/"
+dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
+bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
+tags: ["stdlib" "compatibility" "org:ocaml"]
+license: ["typeof OCaml system"]
+depends: [
+  "dune"
+  "ocaml" {>= "4.02.3"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+synopsis: "Backport some of the new stdlib features to older compiler"
+description: """
+Backport some of the new stdlib features to older compiler,
+such as the Stdlib module.
+
+This allows projects that require compatibility with older compiler to
+use these new features in their code.
+"""
+url {
+  src:
+    "https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz"
+  checksum: "md5=12b5704eed70c6bff5ac39a16db1425d"
+}


### PR DESCRIPTION
I've extracted the logging framework from Oni2 into https://github.com/glennsl/timber. Moving Revery to this gives us better granularity, namespaces, colors and the ability to filter on specific namespaces in Revery from Oni2 and other apps.