### PR TITLE
Partially revert #672 to work around #713

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -54,7 +54,7 @@ let quit = (~askNicely=false, ~code=0, app: t) => {
   };
 
   // TODO: Bring back when focus bug is fixed
-  //Revery_Native.uninit();
+  Revery_Native.uninit();
 
   if (Hashtbl.length(app.windows) == 0 || !askNicely) {
     logInfo("Quitting");
@@ -191,7 +191,7 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
   };
 
   // TODO: Bring back when focus bug is fixed
-  //Revery_Native.init();
+  Revery_Native.init();
 
   let appLoop = () => {
     _flushEvents();

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -53,7 +53,8 @@ let quit = (~askNicely=false, ~code=0, app: t) => {
     _tryToCloseAll(app);
   };
 
-  Revery_Native.uninit();
+  // TODO: Bring back when focus bug is fixed
+  //Revery_Native.uninit();
 
   if (Hashtbl.length(app.windows) == 0 || !askNicely) {
     logInfo("Quitting");
@@ -189,7 +190,8 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
     };
   };
 
-  Revery_Native.init();
+  // TODO: Bring back when focus bug is fixed
+  //Revery_Native.init();
 
   let appLoop = () => {
     _flushEvents();

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -53,7 +53,6 @@ let quit = (~askNicely=false, ~code=0, app: t) => {
     _tryToCloseAll(app);
   };
 
-  // TODO: Bring back when focus bug is fixed
   Revery_Native.uninit();
 
   if (Hashtbl.length(app.windows) == 0 || !askNicely) {
@@ -190,7 +189,6 @@ let start = (~onIdle=noop, initFunc: appInitFunc) => {
     };
   };
 
-  // TODO: Bring back when focus bug is fixed
   Revery_Native.init();
 
   let appLoop = () => {

--- a/src/Native/Revery_Native.c
+++ b/src/Native/Revery_Native.c
@@ -20,8 +20,9 @@
 
 CAMLprim value revery_initialize() {
 #ifdef __APPLE__
-    ReveryAppDelegate *delegate = [ReveryAppDelegate new];
-    [NSApp setDelegate:delegate];
+// TODO: Bring back when #713 is fixed
+//    ReveryAppDelegate *delegate = [ReveryAppDelegate new];
+//    [NSApp setDelegate:delegate];
 #elif WIN32
     HRESULT hr = CoInitialize(NULL);
     if (hr != S_OK) {

--- a/src/Native/notification.c
+++ b/src/Native/notification.c
@@ -29,7 +29,12 @@ CAMLprim value revery_dispatchNotification(value vNotificationT) {
     value onClickCaml = Field(vNotificationT, 2);
     mute = Int_val(Field(vNotificationT, 3));
 #ifdef __APPLE__
-    revery_dispatchNotification_cocoa(title, body, onClickCaml, mute);
+    // TODO: Bring back when focus bug is fixed!
+    // revery_dispatchNotification_cocoa(title, body, onClickCaml, mute);
+    UNUSED(title);
+    UNUSED(body);
+    UNUSED(mute);
+    UNUSED(onClickCaml);
 #else
     UNUSED(title);
     UNUSED(body);
@@ -54,7 +59,12 @@ CAMLprim value revery_scheduleNotificationFromNow(value vSeconds, value vNotific
     mute = Int_val(Field(vNotificationT, 3));
     seconds = Int_val(vSeconds);
 #ifdef __APPLE__
-    revery_scheduleNotificationFromNow_cocoa(title, body, onClickCaml, mute, seconds);
+    // TODO: Bring back when focus bug is fixed!
+    // revery_scheduleNotificationFromNow_cocoa(title, body, onClickCaml, mute, seconds);
+    UNUSED(title);
+    UNUSED(body);
+    UNUSED(mute);
+    UNUSED(onClickCaml);
 #else
     UNUSED(title);
     UNUSED(body);


### PR DESCRIPTION
Revert pieces of https://github.com/revery-ui/revery/pull/672 to work around #713 so we can upgrade to latest Revery for Onivim 2.