### PR TITLE
[macOS] Fix #713

### DIFF
--- a/src/Native/Revery_Native.c
+++ b/src/Native/Revery_Native.c
@@ -1,8 +1,5 @@
 #include <stdio.h>
 
-#include <caml/alloc.h>
-#include <caml/callback.h>
-#include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <string.h>
 
@@ -20,9 +17,10 @@
 
 CAMLprim value revery_initialize() {
 #ifdef __APPLE__
+    SDLAppDelegate *sdlDelegate = [NSApp delegate];
 // TODO: Bring back when #713 is fixed
-//    ReveryAppDelegate *delegate = [ReveryAppDelegate new];
-//    [NSApp setDelegate:delegate];
+    ReveryAppDelegate *delegate = [ReveryAppDelegate newWithSDLDelegate:sdlDelegate];
+    [NSApp setDelegate:delegate];
 #elif WIN32
     HRESULT hr = CoInitialize(NULL);
     if (hr != S_OK) {

--- a/src/Native/Revery_Native.c
+++ b/src/Native/Revery_Native.c
@@ -18,7 +18,6 @@
 CAMLprim value revery_initialize() {
 #ifdef __APPLE__
     SDLAppDelegate *sdlDelegate = [NSApp delegate];
-// TODO: Bring back when #713 is fixed
     ReveryAppDelegate *delegate = [ReveryAppDelegate newWithSDLDelegate:sdlDelegate];
     [NSApp setDelegate:delegate];
 #elif WIN32

--- a/src/Native/cocoa/ReveryAppDelegate.c
+++ b/src/Native/cocoa/ReveryAppDelegate.c
@@ -12,10 +12,11 @@
 /* init - initializes the AppDelegate
   Assigns a mutable dictionary to notificationActions
 */
-- (id)init {
+- (id)initWithSDLDelegate:(SDLAppDelegate *)sdlDelegate {
     self = [super init];
     if (self) {
         _notificationActions = [NSMutableDictionary new];
+        _sdlDelegate = sdlDelegate;
     }
 
     NSString *valueToSave = @"true";
@@ -25,11 +26,17 @@
     return self;
 }
 
++(id)newWithSDLDelegate:(SDLAppDelegate *)sdlDelegate {
+  return [[ReveryAppDelegate alloc] initWithSDLDelegate:sdlDelegate];
+}
+
+
 /* applicationDidFinishLaunching
   Assigns self as the notification center delegate
 */
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
     UNUSED(notification);
+    [_sdlDelegate applicationDidFinishLaunching:notification];
     [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:self];
 }
 

--- a/src/Native/cocoa/ReveryAppDelegate.c
+++ b/src/Native/cocoa/ReveryAppDelegate.c
@@ -35,7 +35,6 @@
   Assigns self as the notification center delegate
 */
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
-    UNUSED(notification);
     [_sdlDelegate applicationDidFinishLaunching:notification];
     [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:self];
 }

--- a/src/Native/cocoa/ReveryAppDelegate.h
+++ b/src/Native/cocoa/ReveryAppDelegate.h
@@ -1,5 +1,6 @@
 #ifdef __APPLE__
 #import <Cocoa/Cocoa.h>
+#import "SDLAppDelegate.h"
 
 /* ReveryAppDelegate
 
@@ -13,5 +14,9 @@
           (longs which represent OCaml callbacks)
       */
   @property(nonatomic, strong) NSMutableDictionary *notificationActions;
+  @property(nonatomic, strong) SDLAppDelegate *sdlDelegate;
+
+  -(id)initWithSDLDelegate:(SDLAppDelegate *)sdlDelegate;
+  +(id)newWithSDLDelegate:(SDLAppDelegate *)sdlDelegate;
 @end
 #endif

--- a/src/Native/cocoa/SDLAppDelegate.h
+++ b/src/Native/cocoa/SDLAppDelegate.h
@@ -1,0 +1,8 @@
+#ifdef __APPLE__
+#import <Cocoa/Cocoa.h>
+
+@interface SDLAppDelegate
+    : NSObject <NSApplicationDelegate>
+@end
+
+#endif

--- a/src/Native/notification.c
+++ b/src/Native/notification.c
@@ -29,8 +29,7 @@ CAMLprim value revery_dispatchNotification(value vNotificationT) {
     value onClickCaml = Field(vNotificationT, 2);
     mute = Int_val(Field(vNotificationT, 3));
 #ifdef __APPLE__
-    // TODO: Bring back when focus bug is fixed!
-    // revery_dispatchNotification_cocoa(title, body, onClickCaml, mute);
+    revery_dispatchNotification_cocoa(title, body, onClickCaml, mute);
     UNUSED(title);
     UNUSED(body);
     UNUSED(mute);
@@ -59,8 +58,7 @@ CAMLprim value revery_scheduleNotificationFromNow(value vSeconds, value vNotific
     mute = Int_val(Field(vNotificationT, 3));
     seconds = Int_val(vSeconds);
 #ifdef __APPLE__
-    // TODO: Bring back when focus bug is fixed!
-    // revery_scheduleNotificationFromNow_cocoa(title, body, onClickCaml, mute, seconds);
+    revery_scheduleNotificationFromNow_cocoa(title, body, onClickCaml, mute, seconds);
     UNUSED(title);
     UNUSED(body);
     UNUSED(mute);


### PR DESCRIPTION
This fixes #713 by adding an `sdlDelegate` attribute to `ReveryAppDelegate` and calling it's `applicationDidLaunch` method (among others) when `ReveryAppDelegate`'s is called.

@bryphe @CrossR this works on my machine, but please verify it on yours! I don't want the same mistake to happen again.

My apologies that this is necessary in the first place.