### PR TITLE
Refactoring - Logging: Switch to Console.log for printing

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -222,7 +222,7 @@ module ExampleHost = {
           Window.setTitle(win, "Revery Example - " ++ x.name);
 
           let sourceFile = getSourceForSample(state, x.name);
-          prerr_endline("SOURCE FILE: " ++ sourceFile);
+          Console.log("SOURCE FILE: " ++ sourceFile);
           notifyExampleSwitched(sourceFile);
           dispatch(SelectExample(x.name));
           ();
@@ -275,6 +275,16 @@ module ExampleHost = {
 };
 
 let init = app => {
+
+  let buffer = Buffer.create(0);
+  let formatter = Format.make_formatter(Buffer.add_substring(buffer), () => {
+    Console.log(Buffer.contents(buffer));
+    Buffer.clear(buffer);
+  });
+
+  Logs.format_reporter(~app=formatter, ~dst=formatter, ())
+  |> Logs.set_reporter;
+
   Timber.App.enablePrinting();
   Timber.App.enableDebugLogging();
 
@@ -312,5 +322,5 @@ let init = app => {
   ();
 };
 
-let onIdle = () => print_endline("Example: idle callback triggered");
+let onIdle = () => Console.log("Example: idle callback triggered");
 App.start(~onIdle, init);

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -275,18 +275,8 @@ module ExampleHost = {
 };
 
 let init = app => {
-
-  let buffer = Buffer.create(0);
-  let formatter = Format.make_formatter(Buffer.add_substring(buffer), () => {
-    Console.log(Buffer.contents(buffer));
-    Buffer.clear(buffer);
-  });
-
-  Logs.format_reporter(~app=formatter, ~dst=formatter, ())
-  |> Logs.set_reporter;
-
-  Timber.App.enablePrinting();
-  Timber.App.enableDebugLogging();
+  Revery.Log.enablePrinting();
+  Revery.Log.enableDebugLogging();
 
   let maximized = Environment.webGL;
 

--- a/examples/FontsExample.re
+++ b/examples/FontsExample.re
@@ -45,7 +45,7 @@ module FontComponent = {
       );
 
     switch (resolvedFont) {
-    | Some(v) => print_endline("New font: " ++ Font.toString(v))
+    | Some(v) => Console.log("New font: " ++ Font.toString(v))
     | None => ()
     };
 

--- a/examples/HoverExample.re
+++ b/examples/HoverExample.re
@@ -43,8 +43,8 @@ module HoverExample = {
         () => {
           let dispose =
             Mouse.registerListeners(
-              ~onMouseEnterWindow=_ => print_endline("enter window"),
-              ~onMouseLeaveWindow=_ => print_endline("leave window"),
+              ~onMouseEnterWindow=_ => Console.log("enter window"),
+              ~onMouseLeaveWindow=_ => Console.log("leave window"),
               (),
             );
 

--- a/examples/ZoomExample.re
+++ b/examples/ZoomExample.re
@@ -43,7 +43,7 @@ module Zoom = {
       };
     };
 
-    print_endline("Zoomv: " ++ string_of_float(currentZoom));
+    Console.log("Zoomv: " ++ string_of_float(currentZoom));
 
     <Center>
       <Column>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:js": "esy b dune build examples/Examples.bc.js",
     "build:js:release": "esy b dune build examples/Examples.bc.js",
     "test": "esy b dune runtest",
-    "format": "esy b bash .ci/format.sh #{os}",
+    "format": "esy bash .ci/format.sh #{os}",
     "run": "esy x Examples"
   },
   "homepage": "https://github.com/bryphe/revery#readme",

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -3,12 +3,16 @@ include Timber;
 let enablePrinting = () => {
   // Additional utilities for logging in Revery
   let buffer = Buffer.create(0);
-  let formatter = Format.make_formatter(Buffer.add_substring(buffer), () => {
-  // We use `Console.log` instead of `print_endline` / default formatter to work around:
-  // https://github.com/ocaml/ocaml/issues/9252
-    Console.log(Buffer.contents(buffer));
-    Buffer.clear(buffer);
-  });
+  let formatter =
+    Format.make_formatter(
+      Buffer.add_substring(buffer),
+      () => {
+        // We use `Console.log` instead of `print_endline` / default formatter to work around:
+        // https://github.com/ocaml/ocaml/issues/9252
+        Console.log(Buffer.contents(buffer));
+        Buffer.clear(buffer);
+      },
+    );
 
   Logs.format_reporter(~app=formatter, ~dst=formatter, ())
   |> Logs.set_reporter;
@@ -17,4 +21,3 @@ let enablePrinting = () => {
 };
 
 let enableDebugLogging = Timber.App.enableDebugLogging;
-

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -1,1 +1,20 @@
 include Timber;
+
+let enablePrinting = () => {
+  // Additional utilities for logging in Revery
+  let buffer = Buffer.create(0);
+  let formatter = Format.make_formatter(Buffer.add_substring(buffer), () => {
+  // We use `Console.log` instead of `print_endline` / default formatter to work around:
+  // https://github.com/ocaml/ocaml/issues/9252
+    Console.log(Buffer.contents(buffer));
+    Buffer.clear(buffer);
+  });
+
+  Logs.format_reporter(~app=formatter, ~dst=formatter, ())
+  |> Logs.set_reporter;
+
+  Timber.App.enablePrinting();
+};
+
+let enableDebugLogging = Timber.App.enableDebugLogging;
+

--- a/src/Core/Log.rei
+++ b/src/Core/Log.rei
@@ -11,3 +11,6 @@ module type Logger = {
 };
 
 let withNamespace: string => (module Logger);
+
+let enablePrinting: unit => unit;
+let enableDebugLogging: unit => unit;

--- a/src/Geometry/Builder.re
+++ b/src/Geometry/Builder.re
@@ -39,7 +39,7 @@ let addVertexChannel =
     builder.vertexCount^ == vertexCount
       ? ()
       /* TODO: Raise exception */
-      : print_endline("Vertex count mismatch")
+      : Console.error("Vertex count mismatch")
   };
 };
 

--- a/src/Native/cocoa/ReveryAppDelegate.c
+++ b/src/Native/cocoa/ReveryAppDelegate.c
@@ -27,7 +27,7 @@
 }
 
 +(id)newWithSDLDelegate:(SDLAppDelegate *)sdlDelegate {
-  return [[ReveryAppDelegate alloc] initWithSDLDelegate:sdlDelegate];
+    return [[ReveryAppDelegate alloc] initWithSDLDelegate:sdlDelegate];
 }
 
 

--- a/src/Native/cocoa/ReveryAppDelegate.h
+++ b/src/Native/cocoa/ReveryAppDelegate.h
@@ -14,9 +14,9 @@
           (longs which represent OCaml callbacks)
       */
   @property(nonatomic, strong) NSMutableDictionary *notificationActions;
-  @property(nonatomic, strong) SDLAppDelegate *sdlDelegate;
+@property(nonatomic, strong) SDLAppDelegate *sdlDelegate;
 
-  -(id)initWithSDLDelegate:(SDLAppDelegate *)sdlDelegate;
-  +(id)newWithSDLDelegate:(SDLAppDelegate *)sdlDelegate;
+-(id)initWithSDLDelegate:(SDLAppDelegate *)sdlDelegate;
++(id)newWithSDLDelegate:(SDLAppDelegate *)sdlDelegate;
 @end
 #endif


### PR DESCRIPTION
This is a prepatory change for: https://github.com/revery-ui/reason-sdl2/pull/36

That PR addresses an issue that's been problematic on Windows for a while - https://github.com/onivim/oni2/issues/523 - the fact that a console window opens up briefly when running Revery (or Onivim 2). 

This isn't noticeable when running from the console, but when running it independently from explorer (ie, after installing it) reproduces it. It's a very jarring and poor user experience.

The fix for that is pretty simple - we just need to tell the compiler that its a GUI app and not a console application.

However, when we do that, it breaks the default `stdout`/`stdin`/`stderr` file descriptors - any call to `print_endline` or related APIs will crash with `Bad file descriptor`. Described in more detail here: https://github.com/ocaml/ocaml/issues/9252

To work around this, I've adjusted the logging strategy to use native `printfs` vs going through the OCaml-exposed file descriptors.

Since this would be a common thing that any Revery app would need to do along with printing - I've wrapped this into the `Revery.Log.enablePrinting` method, which creates a formatter for this and calls `Timber.App.enablePrinting`. Let me know if you have better ideas for this, though, @glennsl !

Once https://github.com/revery-ui/reason-sdl2/pull/36 is in - on Windows, we'll also want to try running `AttachConsole` when logging is enabled, and if that fails, we'll `AllocConsole` so that there is a console window available somewhere (whether an existing session, or worst case, we'll spawn a new one)

__TODO:__
- [ ] Only use `Console.log` formatter on Windows