### PR TITLE
Fix slider mouse tracking

### DIFF
--- a/src/UI_Components/Slider.re
+++ b/src/UI_Components/Slider.re
@@ -85,7 +85,12 @@ let%component make =
   let sliderUpdate = (w, startPosition, endPosition, mouseX, mouseY) => {
     let mousePosition = vertical ? mouseY : mouseX;
     let thumbPosition =
-      clamp(mousePosition, startPosition, endPosition) -. startPosition;
+      clamp(
+        mousePosition -. float(thumbLength) /. 2.,
+        startPosition,
+        endPosition,
+      )
+      -. startPosition;
 
     let normalizedValue =
       thumbPosition /. w *. (maximumValue -. minimumValue) +. minimumValue;
@@ -169,6 +174,8 @@ let%component make =
     switch (availableWidth) {
     | Some(w) =>
       int_of_float((v -. minimumValue) /. (maximumValue -. minimumValue) *. w)
+      - thumbLength
+      / 2
     | None => 0
     };
 
@@ -184,18 +191,24 @@ let%component make =
   let beforeTrackStyle =
     Style.[
       top(vertical ? 0 : trackMargins),
-      bottom(vertical ? sliderLength - thumbPosition : trackMargins),
+      bottom(
+        vertical
+          ? sliderLength - thumbPosition - thumbWidth / 2 : trackMargins,
+      ),
       left(vertical ? trackMargins : 0),
-      right(vertical ? trackMargins : sliderLength - thumbPosition),
+      right(
+        vertical
+          ? trackMargins : sliderLength - thumbPosition - thumbWidth / 2,
+      ),
       position(`Absolute),
       backgroundColor(minimumTrackColor),
     ];
 
   let afterTrackStyle =
     Style.[
-      top(vertical ? thumbPosition + thumbWidth : trackMargins),
+      top(vertical ? thumbPosition + thumbWidth * 3 / 2 : trackMargins),
       bottom(vertical ? 0 : trackMargins),
-      left(vertical ? trackMargins : thumbPosition + thumbWidth),
+      left(vertical ? trackMargins : thumbPosition + thumbWidth * 3 / 2),
       right(vertical ? trackMargins : 0),
       position(`Absolute),
       backgroundColor(sliderBackgroundColor),
@@ -210,8 +223,8 @@ let%component make =
           position(`Absolute),
           height(vertical ? thumbWidth : thumbHeight),
           width(vertical ? thumbHeight : thumbWidth),
-          left(vertical ? 0 : thumbPosition),
-          top(vertical ? thumbPosition : 0),
+          left(vertical ? 0 : thumbPosition + thumbWidth / 2),
+          top(vertical ? thumbPosition + thumbWidth / 2 : 0),
           backgroundColor(thumbColor),
         ]
       />


### PR DESCRIPTION
This fixes the slider so that it tracks the mouse at the center of the thumb, rather than at the leading edge.

It would be more correct to have it adjust for the mouse position relative to the thumb on mouse down and have it track the mouse so it stays in the same position rather than "jump" to position the mouse in the center of it, but that would require a significant refactor so this will have to do for now. This is still pretty decent behaviour when clicking outside the thumb, on the track, and mimics vscode's behaviour in that case.