### PR TITLE
API: Add a helper API to allocate a console on Windows

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -275,6 +275,8 @@ module ExampleHost = {
 };
 
 let init = app => {
+  Revery.App.initConsole();
+
   Timber.App.enablePrinting();
   Timber.App.enableDebugLogging();
 

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -109,6 +109,21 @@ let _anyWindowsDirty = (app: t) =>
     getWindows(app),
   );
 
+let initConsole = () =>
+  if (Sys.win32) {
+    // First, try attaching to an existing console.
+    let attachResult = Sdl2.Platform.win32AttachConsole();
+
+    // If that wasn't available - try to allocate a new one.
+    let _code =
+      if (attachResult == 0) {
+        Sdl2.Platform.win32AllocConsole();
+      } else {
+        attachResult;
+      };
+    ();
+  };
+
 let start = (~onIdle=noop, initFunc: appInitFunc) => {
   let appInstance: t = {
     windows: Hashtbl.create(1),

--- a/src/Core/App.rei
+++ b/src/Core/App.rei
@@ -67,3 +67,8 @@ let createWindow:
   when multiple frames have passed without requiring a render.
 */
 let start: (~onIdle: idleFunc=?, initFunc) => unit;
+
+/** [initConsole] (Windows-only) attaches or allocates a console,
+  to show logging output. No-op on other platforms.
+*/
+let initConsole: unit => unit;


### PR DESCRIPTION
This adds a `Revery.App.initConsole` API, which, on Windows, does the following:

- If there is a console available in a parent process, it will attach to that console (ie, running the example app from the command line)
- If there is no console available in the parent process, it will allocate a new console (which creates a console session in a new window).

In the case where we do not log out, no console window will be created, which speeds up startup time.