### PR TITLE
 Dependency: timber -> ae065bb 

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "1b96de12d4e05780ee87d014bc923ad2",
+  "checksum": "1a2e735f4039c39699b4677108a74c6b",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -15,13 +15,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "timber@github:glennsl/timber#ae5de6c@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+    "timber@github:glennsl/timber#ae065bb@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#ae065bb@d41d8cd9",
       "name": "timber",
-      "version": "github:glennsl/timber#ae5de6c",
+      "version": "github:glennsl/timber#ae065bb",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/timber#ae5de6c" ]
+        "source": [ "github:glennsl/timber#ae065bb" ]
       },
       "overrides": [],
       "dependencies": [
@@ -56,7 +56,7 @@
       },
       "overrides": [ "bench.json" ],
       "dependencies": [
-        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "11d6e4d908f851990aebba3232b7f090",
+  "checksum": "e3b423f6f8db61b06108b8f3244e0046",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -57,13 +57,13 @@
       "dependencies": [ "qs@6.9.1@d41d8cd9" ],
       "devDependencies": []
     },
-    "timber@github:glennsl/timber#ae5de6c@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+    "timber@github:glennsl/timber#ae065bb@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#ae065bb@d41d8cd9",
       "name": "timber",
-      "version": "github:glennsl/timber#ae5de6c",
+      "version": "github:glennsl/timber#ae065bb",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/timber#ae5de6c" ]
+        "source": [ "github:glennsl/timber#ae065bb" ]
       },
       "overrides": [],
       "dependencies": [
@@ -112,7 +112,7 @@
       },
       "overrides": [ "doc.json" ],
       "dependencies": [
-        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "cd19fe560980255b841c2462262792a1",
+  "checksum": "9e862b85e21a744ce36bc3dd04f13612",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -15,13 +15,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "timber@github:glennsl/timber#ae5de6c@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+    "timber@github:glennsl/timber#ae065bb@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#ae065bb@d41d8cd9",
       "name": "timber",
-      "version": "github:glennsl/timber#ae5de6c",
+      "version": "github:glennsl/timber#ae065bb",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/timber#ae5de6c" ]
+        "source": [ "github:glennsl/timber#ae065bb" ]
       },
       "overrides": [],
       "dependencies": [
@@ -56,7 +56,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -283,7 +283,7 @@ let init = app => {
   Revery.App.initConsole();
 
   Timber.App.enable();
-  Timber.App.setLevel(Timber.Level.trace);
+  Timber.App.setLevel(Timber.Level.perf);
 
   let maximized = Environment.webGL;
 

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -282,8 +282,8 @@ module ExampleHost = {
 let init = app => {
   Revery.App.initConsole();
 
-  Timber.App.enablePrinting();
-  Timber.App.enableDebugLogging();
+  Timber.App.enable();
+  Timber.App.setLevel(Timber.Level.trace);
 
   let maximized = Environment.webGL;
 
@@ -309,14 +309,11 @@ let init = app => {
 
   if (Environment.webGL) {
     Window.maximize(win);
-    ();
   } else {
     Window.center(win);
-    ();
   };
 
-  let _ignore = UI.start(win, <ExampleHost win />);
-  ();
+  UI.start(win, <ExampleHost win />) |> ignore;
 };
 
 let onIdle = () => print_endline("Example: idle callback triggered");

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "54cdd73e5e8b1ee1fad28ed49c497613",
+  "checksum": "d6d274c3fecb502c9b09154c3a799b11",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -57,13 +57,13 @@
       "dependencies": [ "qs@6.9.1@d41d8cd9" ],
       "devDependencies": []
     },
-    "timber@github:glennsl/timber#ae5de6c@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+    "timber@github:glennsl/timber#ae065bb@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#ae065bb@d41d8cd9",
       "name": "timber",
-      "version": "github:glennsl/timber#ae5de6c",
+      "version": "github:glennsl/timber#ae065bb",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/timber#ae5de6c" ]
+        "source": [ "github:glennsl/timber#ae065bb" ]
       },
       "overrides": [],
       "dependencies": [
@@ -112,7 +112,7 @@
       },
       "overrides": [ "js.json" ],
       "dependencies": [
-        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     },
     "exportedEnv": {
       "PKG_CONFIG_PATH": {
-	"val": "/usr/lib64/pkgconfig:$PKG_CONFIG_PATH",
+        "val": "/usr/lib64/pkgconfig:$PKG_CONFIG_PATH",
         "scope": "global"
       }
     },
@@ -63,7 +63,7 @@
     "yarn-pkg-config": "esy-ocaml/yarn-pkg-config#db3a0b6",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
     "esy-skia": "revery-ui/esy-skia#91b10c9",
-    "timber": "glennsl/timber#ae5de6c"
+    "timber": "glennsl/timber#ae065bb"
   },
   "devDependencies": {
     "ocaml": ">=4.6.0 <4.8.0",

--- a/src/Core/Log.re
+++ b/src/Core/Log.re
@@ -1,1 +1,3 @@
-include Timber;
+include Timber.Log;
+
+module type Logger = Timber.Logger;

--- a/src/Core/Log.rei
+++ b/src/Core/Log.rei
@@ -7,7 +7,9 @@ module type Logger = {
   let info: string => unit;
   let debugf: Timber.msgf(_, unit) => unit;
   let debug: string => unit;
-  let fn: (string, 'a => 'b, 'a) => 'b;
+  let tracef: Timber.msgf(_, unit) => unit;
+  let trace: string => unit;
+  let fn: (string, 'a => 'b, ~pp: 'b => string=?, 'a) => 'b;
 };
 
 let withNamespace: string => (module Logger);

--- a/src/Core/Performance.re
+++ b/src/Core/Performance.re
@@ -43,14 +43,14 @@ let bench: (string, performanceFunction('a)) => 'a =
       nestingLevel := nestingLevel^ + 1;
       let startTime = Unix.gettimeofday();
       let startCounters = GarbageCollector.counters();
-      Log.debugf(m =>
+      Log.tracef(m =>
         m("%s[BEGIN: %s]", String.make(nestingLevel^, '-'), name)
       );
       let ret = f();
       let endTime = Unix.gettimeofday();
       let endCounters = GarbageCollector.counters();
       let allocations = getMemoryAllocations(startCounters, endCounters);
-      Log.debugf(m =>
+      Log.tracef(m =>
         m(
           "%s[END: %s] Time: %fms Memory: %s",
           String.make(nestingLevel^, '-'),

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -113,7 +113,7 @@ let _getScaleFactor = (~forceScaleFactor=None, sdlWindow) => {
     // On Windows, we need to try a Win32 API to get the scale factor
     | Windows =>
       let scale = Sdl2.Window.getWin32ScaleFactor(sdlWindow);
-      Log.debugf(m =>
+      Log.tracef(m =>
         m("_getScaleFactor - from getWin32ScaleFactor: %f", scale)
       );
       scale;
@@ -125,7 +125,7 @@ let _getScaleFactor = (~forceScaleFactor=None, sdlWindow) => {
       switch (Rench.Environment.getEnvironmentVariable("GDK_SCALE")) {
       | Some(v) =>
         // TODO
-        Log.debug("_getScaleFactor - Linux - got GDK_SCALE variable: " ++ v);
+        Log.trace("_getScaleFactor - Linux - got GDK_SCALE variable: " ++ v);
         switch (Float.of_string_opt(v)) {
         | Some(v) => v
         | None => 1.0
@@ -135,7 +135,7 @@ let _getScaleFactor = (~forceScaleFactor=None, sdlWindow) => {
         let dpi = Sdl2.Display.getDPI(display);
         let avgDpi = (dpi.hdpi +. dpi.vdpi +. dpi.ddpi) /. 3.0;
         let scaleFactor = max(1.0, floor(avgDpi /. 96.0));
-        Log.debugf(m =>
+        Log.tracef(m =>
           m("_getScaleFactor - Linux - inferring from DPI: %f", scaleFactor)
         );
         scaleFactor;
@@ -181,13 +181,13 @@ let _updateMetrics = (w: t) => {
     zoom: previousZoom,
   };
   w.areMetricsDirty = false;
-  Log.debug(
+  Log.trace(
     "_updateMetrics - new metrics: " ++ WindowMetrics.toString(w.metrics),
   );
 };
 
 let setRawSize = (win: t, adjWidth: int, adjHeight: int) => {
-  Log.debugf(m => m("setRawSize - calling with: %ix%i", adjWidth, adjHeight));
+  Log.tracef(m => m("setRawSize - calling with: %ix%i", adjWidth, adjHeight));
 
   if (adjWidth != win.metrics.size.width
       || adjHeight != win.metrics.size.height) {
@@ -196,16 +196,16 @@ let setRawSize = (win: t, adjWidth: int, adjHeight: int) => {
      *  we'll queue up the render operation for next time.
      */
     if (win.isRendering) {
-      Log.debug("setRawSize - queuing for next render");
+      Log.trace("setRawSize - queuing for next render");
       win.requestedWidth = Some(adjWidth);
       win.requestedHeight = Some(adjHeight);
     } else {
-      Log.debug("setRawSize - calling Sdl2.Window.setSize");
+      Log.trace("setRawSize - calling Sdl2.Window.setSize");
       Sdl2.Window.setSize(win.sdlWindow, adjWidth, adjHeight);
       win.requestedWidth = None;
       win.requestedHeight = None;
       win.areMetricsDirty = true;
-      Log.debugf(m => {
+      Log.tracef(m => {
         let Sdl2.Size.{width, height} = Sdl2.Window.getSize(win.sdlWindow);
         m("setRawSize: SDL size reported after resize: %ux%u", width, height);
       });
@@ -214,7 +214,7 @@ let setRawSize = (win: t, adjWidth: int, adjHeight: int) => {
 };
 
 let setScaledSize = (win: t, width: int, height: int) => {
-  Log.debugf(m => m("setScaledSize - calling with: %ux%u", width, height));
+  Log.tracef(m => m("setScaledSize - calling with: %ux%u", width, height));
   // On platforms that return a non-unit scale factor (Windows and Linux),
   // we also have to scale the window size by the scale factor
   let adjWidth =

--- a/src/UI/Focus.re
+++ b/src/UI/Focus.re
@@ -13,7 +13,7 @@ module Log = (val Log.withNamespace("Revery.UI.Focus"));
 
 /* Should happen when user clicks anywhere where no focusable node exists */
 let loseFocus = () => {
-  Log.debug("loseFocus()");
+  Log.trace("loseFocus()");
 
   switch (focused^) {
   | Some({handler, _}) =>
@@ -25,7 +25,7 @@ let loseFocus = () => {
 };
 
 let focus = (node: Node.node) => {
-  Log.debug("focus()");
+  Log.trace("focus()");
   let _ = node#handleEvent(Focus);
   focused := Some({handler: node#handleEvent, id: node#getInternalId()});
 };

--- a/src/UI/Mouse.re
+++ b/src/UI/Mouse.re
@@ -432,7 +432,7 @@ let rec handleMouseEnterDiff = (deepestNode, evtParams, ~newNodes=[], ()) => {
 let dispatch =
     (cursor: Cursor.t, evt: Events.internalMouseEvents, node: Node.node) => {
   let eventToSend = internalToExternalEvent(cursor, evt);
-  Log.debugf(m =>
+  Log.tracef(m =>
     m(
       "Dispatching event from node %i: %s",
       node#getInternalId(),

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -296,13 +296,13 @@ class node (()) = {
   pub getParent = () => _parent;
   pub getMeasureFunction = () => None;
   pub handleEvent = (evt: NodeEvents.event) => {
-    // Log.debugf(m =>
-    //   m(
-    //     "Received event on node %i: %s",
-    //     _internalId,
-    //     NodeEvents.show_event(evt),
-    //   )
-    // );
+    Log.tracef(m =>
+      m(
+        "Received event on node %i: %s",
+        _internalId,
+        NodeEvents.show_event(evt),
+      )
+    );
     switch (evt, _this#getEvents()) {
     | (MouseDown(c), {onMouseDown: Some(cb), _}) => cb(c)
     | (MouseMove(c), {onMouseMove: Some(cb), _}) => cb(c)

--- a/src/UI/Render.re
+++ b/src/UI/Render.re
@@ -22,7 +22,7 @@ let render =
       container: RenderContainer.t,
       component: React.element('node),
     ) => {
-  Log.debug("BEGIN: Render frame");
+  Log.trace("BEGIN: Render frame");
   let {rootNode, window, container, _} = container;
 
   /* Perform reconciliation */
@@ -84,5 +84,5 @@ let render =
     DebugDraw.draw();
     RenderPass.endAlphaPass();
   });
-  Log.debug("END: Render frame");
+  Log.trace("END: Render frame");
 };

--- a/src/UI/Ui.re
+++ b/src/UI/Ui.re
@@ -68,7 +68,7 @@ let start = (window: Window.t, element: React.element(React.reveryNode)) => {
     Revery_Core.Event.subscribe(
       window.onMouseLeave,
       () => {
-        Log.debug("Mouse leaving window");
+        Log.trace("Mouse leaving window");
         Mouse.notifyLeaveWindow(window);
       },
     );
@@ -77,7 +77,7 @@ let start = (window: Window.t, element: React.element(React.reveryNode)) => {
     Revery_Core.Event.subscribe(
       window.onMouseEnter,
       () => {
-        Log.debug("Mouse entering window");
+        Log.trace("Mouse entering window");
         Mouse.notifyEnterWindow(window);
       },
     );

--- a/src/UI_Components/Clickable.re
+++ b/src/UI_Components/Clickable.re
@@ -10,9 +10,7 @@ open Revery_Core;
 open Revery_UI_Primitives;
 
 module Hooks = Revery_UI_Hooks;
-module Log = (
-  val Revery_Core.Log.withNamespace("Revery.Components.Clickable")
-);
+module Log = (val Log.withNamespace("Revery.Components.Clickable"));
 
 let isMouseCaptured = ref(false);
 
@@ -37,13 +35,13 @@ let%component make =
 
   let capture = () =>
     if (! isMouseCaptured^) {
-      Log.debug("Capture");
+      Log.trace("Capture");
       isMouseCapturedHere := true;
       isMouseCaptured := true;
     };
   let releaseCapture = () =>
     if (isMouseCapturedHere^) {
-      Log.debug("Release");
+      Log.trace("Release");
       isMouseCapturedHere := false;
       isMouseCaptured := false;
     };

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "1b96de12d4e05780ee87d014bc923ad2",
+  "checksum": "1a2e735f4039c39699b4677108a74c6b",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -15,13 +15,13 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "timber@github:glennsl/timber#ae5de6c@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+    "timber@github:glennsl/timber#ae065bb@d41d8cd9": {
+      "id": "timber@github:glennsl/timber#ae065bb@d41d8cd9",
       "name": "timber",
-      "version": "github:glennsl/timber#ae5de6c",
+      "version": "github:glennsl/timber#ae065bb",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/timber#ae5de6c" ]
+        "source": [ "github:glennsl/timber#ae065bb" ]
       },
       "overrides": [],
       "dependencies": [
@@ -56,7 +56,7 @@
       },
       "overrides": [ "test.json" ],
       "dependencies": [
-        "timber@github:glennsl/timber#ae5de6c@d41d8cd9",
+        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",


### PR DESCRIPTION
Adds a trace level for the more intense log messages. amongst a few other things. The default log level in the example is `perf`, which is in between `debug` and `trace`. If `trace` logging is needed it needs to be enabled manually.

Also note that the timber API has changed significantly, so this needs to be merged along with the corresponding Oni2 PR.