### PR TITLE
add UI.element and UI.renderFunction type aliases

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -14,7 +14,7 @@ let selectionHighlight = Color.hex("#90f7ff");
 
 type example = {
   name: string,
-  render: Window.t => React.element(React.node),
+  render: Window.t => element,
   source: string,
 };
 

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -30,5 +30,7 @@ module Focus = Focus;
 module Dimensions = Dimensions;
 module Offset = Offset;
 
+type element = React.element(node);
+
 let start = Ui.start;
 let getActiveWindow = Ui.getActiveWindow;

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -32,5 +32,4 @@ module Offset = Offset;
 
 type element = React.element(node);
 
-let start = Ui.start;
-let getActiveWindow = Ui.getActiveWindow;
+include Ui;

--- a/src/UI_Components/ClipContainer.rei
+++ b/src/UI_Components/ClipContainer.rei
@@ -18,7 +18,7 @@ any items outside.
 */
 let make:
   (
-    ~children: Revery_UI.React.React.element(Revery_UI.React.node),
+    ~children: Revery_UI.element,
     ~color: Revery_Core.Color.t=?,
     ~width: int,
     ~height: int,

--- a/src/UI_Components/Container.rei
+++ b/src/UI_Components/Container.rei
@@ -15,7 +15,7 @@ Usage:
 */
 let make:
   (
-    ~children: Revery_UI.React.element(Revery_UI.React.node)=?,
+    ~children: Revery_UI.element=?,
     ~color: Revery_Core.Color.t=?,
     ~width: int,
     ~height: int,

--- a/src/UI_Components/Positioned.rei
+++ b/src/UI_Components/Positioned.rei
@@ -4,7 +4,7 @@ let make:
     ~left: int=?,
     ~right: int=?,
     ~bottom: int=?,
-    ~children: Revery_UI.React.React.element(Revery_UI.React.node),
+    ~children: Revery_UI.element,
     unit
   ) =>
   Brisk_reconciler.element(Revery_UI.viewNode);

--- a/src/UI_Components/Ticker.rei
+++ b/src/UI_Components/Ticker.rei
@@ -21,7 +21,7 @@ let tick tick = (t) => print_endline("Time: " ++ string_of_float(Time.toFloatSec
 let make:
   (
     ~key: Brisk_reconciler.Key.t=?,
-    ~children: Revery_UI.React.element(Revery_UI.React.node)=?,
+    ~children: Revery_UI.element=?,
     ~onTick: tickFunction=?,
     ~tickRate: Revery_Core.Time.t=?,
     unit


### PR DESCRIPTION
`element` is useful as a short-hand when you add interfaces to modules that export components.

`renderFunction` is what `Ui.start` returns, but the type wasn't exposed, so couldn't actually be referenced..