### PR TITLE
Example: Add benchmarks

### DIFF
--- a/examples/BenchmarkExample.re
+++ b/examples/BenchmarkExample.re
@@ -1,7 +1,6 @@
 open Sdl2;
 
 open Revery;
-/* open Revery.Draw; */
 open Revery.UI;
 
 module Styles = {

--- a/examples/BenchmarkExample.re
+++ b/examples/BenchmarkExample.re
@@ -5,147 +5,185 @@ open Revery;
 open Revery.UI;
 
 module Styles = {
+  let column =
+    Style.[
+      flexDirection(`Column),
+      justifyContent(`Center),
+      alignItems(`Center),
+    ];
+  let container =
+    Style.[position(`Absolute), top(0), bottom(0), left(0), right(0)];
 
-let column = Style.[
-  flexDirection(`Column),
-  justifyContent(`Center),
-  alignItems(`Center)
-];
+  let outer =
+    Style.[width(300), height(300), backgroundColor(Colors.black)];
 };
 
-let containerStyle =
-  Style.[
-    position(`Absolute),
-    top(0),
-    bottom(0),
-    left(0),
-    right(0),
-  ];
+module Benchmarks = {
+  type t = (Window.t, Reglm.Mat4.t, float, float) => unit;
+
+  let testString = String.make(50, 'a') ++ String.make(50, 'X');
+
+  let textBenchmark = (window, transform, x, y) => {
+    Revery.Draw.Text.drawString(
+      ~backgroundColor=Colors.red,
+      ~color=Colors.white,
+      ~fontFamily="Roboto-Regular.ttf",
+      ~fontSize=20,
+      ~transform,
+      ~x,
+      ~y,
+      ~window,
+      testString,
+    );
+  };
+
+  let rectBenchmark = (_window, transform, x, y) => {
+    Revery.Draw.Shapes.drawRect(
+      ~transform,
+      ~color=Colors.green,
+      ~x,
+      ~y,
+      ~width=10.,
+      ~height=20.,
+      (),
+    );
+  };
+  let textAndRectBenchmark = (window, transform, x, y) => {
+    Revery.Draw.Shapes.drawRect(
+      ~transform,
+      ~color=Colors.green,
+      ~x,
+      ~y,
+      ~width=10.,
+      ~height=20.,
+      (),
+    );
+
+    Revery.Draw.Text.drawString(
+      ~backgroundColor=Colors.red,
+      ~color=Colors.white,
+      ~fontFamily="Roboto-Regular.ttf",
+      ~fontSize=20,
+      ~transform,
+      ~x,
+      ~y,
+      ~window,
+      testString,
+    );
+  };
+};
+
+module Counters = {
   let startTime = ref(0.);
   let endTime = ref(0.);
-  let flushStartTime = ref(0.);
-  let flushEndTime = ref(0.);
-
-type benchmarkFunction = (Window.t, Reglm.Mat4.t, float, float) => unit;
-
-let testString = String.make(50, 'a') ++ String.make(50, 'X');
-
-let textBenchmark = (window, transform, x, y)  => {
-            Revery.Draw.Text.drawString(
-              ~backgroundColor=Colors.red,
-              ~color=Colors.white,
-              ~fontFamily="Roboto-Regular.ttf",
-              ~fontSize=20,
-              ~transform,
-              ~x,
-              ~y,
-              ~window,
-              testString);
-};
-
-let rectBenchmark = (window, transform, x, y) => {
-         Revery.Draw.Shapes.drawRect(
-           ~transform,
-           ~color=Colors.green,
-           ~x,
-           ~y,
-           ~width=10.,
-           ~height=20.,
-           (),
-         );
-};
-
-let rectAndTextBenchmark = (window, transform, x, y) => {
-  
-         Revery.Draw.Shapes.drawRect(
-           ~transform,
-           ~color=Colors.green,
-           ~x,
-           ~y,
-           ~width=10.,
-           ~height=20.,
-           (),
-         );
-
-            Revery.Draw.Text.drawString(
-              ~backgroundColor=Colors.red,
-              ~color=Colors.white,
-              ~fontFamily="Roboto-Regular.ttf",
-              ~fontSize=20,
-              ~transform,
-              ~x,
-              ~y,
-              ~window,
-              testString);
-};
-
-let outerBox =
-  Style.[width(300), height(300), backgroundColor(Colors.black)];
-module Benchmark = {
+  let swapStartTime = ref(0.);
+  let swapEndTime = ref(0.);
 
   let getDrawTime = () => endTime^ -. startTime^;
-  let getFlushTime = () => flushStartTime^ -. flushEndTime^;
-  let getTotalTime = () => flushEndTime^ -. flushStartTime^;
-  
-  let%component make = () => {
-    let%hook () = Hooks.effect(Always, () => {
-      print_endline ("Rendering!");
-      None 
-    });
+  let getFlushTime = () => swapEndTime^ -. swapStartTime^;
+  let getTotalTime = () => swapEndTime^ -. startTime^;
 
-    <View style=Styles.column>
-    <View style=outerBox>
-      <OpenGL
-        style=containerStyle
-        render={(transform, _pctx) => {
-          startTime := Unix.gettimeofday();
-          print_endline ("start: " ++ string_of_float(startTime^));
-          Gl.glClearColor(1.0, 0.0, 0.0, 1.0);
-          let window = getActiveWindow();
-
-          let x = ref(0);
-          let y = ref(0);
-          let iterations = 200;
-
-          while (x^ < iterations) {
-            while(y^ < iterations) {
-              let yPos = float_of_int(y^);
-              let xPos = float_of_int(x^);
-              let () = rectAndTextBenchmark(window, transform, xPos, yPos);
-              incr(y);
-            };
-            y := 0;
-            incr(x);
-          };
-  
-          endTime := Unix.gettimeofday();
-          print_endline ("end: " ++ string_of_float(startTime^));
-          print_endline (" Draw time: " ++ string_of_float(getDrawTime()));
-
-        }}
-      />
-    </View>
-    <View style=Styles.column>
-      <Text style=Style.[
-        fontFamily("Roboto-Regular.ttf"),
-        fontSize(20),
-        color(Colors.white),
-      ] text="Hello" />
-      <Text style=Style.[
-        fontFamily("Roboto-Regular.ttf"),
-        fontSize(20),
-        color(Colors.white),
-      ] text={"Draw time: " ++  string_of_float(getDrawTime())} />
-    </View>
-    </View>
-
-  };
-}
-
-module Sample = {
-  let make = () => {
-    <Benchmark />
+  let printReport = () => {
+    Console.log(
+      Printf.sprintf(
+        {|
+    ** Benchmark results:
+    - Total Time: %f
+    -- Draw Time: %f
+    -- Flush Time: %f
+    |},
+        getTotalTime(),
+        getDrawTime(),
+        getFlushTime(),
+      ),
+    );
   };
 };
 
-let render = () => <Sample />;
+type benchmarkType =
+  | Text
+  | Rect
+  | TextAndRect;
+
+module Benchmark = {
+  let%component make = (~benchmark, ()) => {
+    let%hook () =
+      Hooks.effect(
+        Always,
+        () => {
+          let win = getActiveWindow();
+          let window =
+            switch (win) {
+            | Some(v) => v
+            | None => failwith("Unable to get window reference")
+            };
+          let u1 =
+            Window.onBeforeSwap(window, () => {
+              Counters.swapStartTime := Unix.gettimeofday()
+            });
+          let u2 =
+            Window.onAfterSwap(
+              window,
+              () => {
+                Counters.swapEndTime := Unix.gettimeofday();
+                Counters.printReport();
+              },
+            );
+          Some(
+            () => {
+              u1();
+              u2();
+            },
+          );
+        },
+      );
+
+    <View style=Styles.column>
+      <View style=Styles.outer>
+        <OpenGL
+          style=Styles.container
+          render={(transform, _pctx) => {
+            Gl.glClearColor(1.0, 0.0, 0.0, 1.0);
+            let window = getActiveWindow();
+
+            let (iterations, benchmarkFunction) =
+              switch (benchmark) {
+              | Text => (200, Benchmarks.textBenchmark)
+              | Rect => (500, Benchmarks.rectBenchmark)
+              | TextAndRect => (200, Benchmarks.textAndRectBenchmark)
+              };
+
+            Counters.startTime := Unix.gettimeofday();
+            let x = ref(0);
+            let y = ref(0);
+
+            while (x^ < iterations) {
+              while (y^ < iterations) {
+                let yPos = float_of_int(y^);
+                let xPos = float_of_int(x^);
+                let () = benchmarkFunction(window, transform, xPos, yPos);
+                incr(y);
+              };
+              y := 0;
+              incr(x);
+            };
+
+            Counters.endTime := Unix.gettimeofday();
+          }}
+        />
+      </View>
+      <View style=Styles.column>
+        <Text
+          style=Style.[
+            fontFamily("Roboto-Regular.ttf"),
+            fontSize(20),
+            color(Colors.white),
+          ]
+          text="Results will be shown in console"
+        />
+      </View>
+    </View>;
+  };
+};
+
+let render = benchmark => <Benchmark benchmark />;

--- a/examples/BenchmarkExample.re
+++ b/examples/BenchmarkExample.re
@@ -1,0 +1,151 @@
+open Sdl2;
+
+open Revery;
+/* open Revery.Draw; */
+open Revery.UI;
+
+module Styles = {
+
+let column = Style.[
+  flexDirection(`Column),
+  justifyContent(`Center),
+  alignItems(`Center)
+];
+};
+
+let containerStyle =
+  Style.[
+    position(`Absolute),
+    top(0),
+    bottom(0),
+    left(0),
+    right(0),
+  ];
+  let startTime = ref(0.);
+  let endTime = ref(0.);
+  let flushStartTime = ref(0.);
+  let flushEndTime = ref(0.);
+
+type benchmarkFunction = (Window.t, Reglm.Mat4.t, float, float) => unit;
+
+let testString = String.make(50, 'a') ++ String.make(50, 'X');
+
+let textBenchmark = (window, transform, x, y)  => {
+            Revery.Draw.Text.drawString(
+              ~backgroundColor=Colors.red,
+              ~color=Colors.white,
+              ~fontFamily="Roboto-Regular.ttf",
+              ~fontSize=20,
+              ~transform,
+              ~x,
+              ~y,
+              ~window,
+              testString);
+};
+
+let rectBenchmark = (window, transform, x, y) => {
+         Revery.Draw.Shapes.drawRect(
+           ~transform,
+           ~color=Colors.green,
+           ~x,
+           ~y,
+           ~width=10.,
+           ~height=20.,
+           (),
+         );
+};
+
+let rectAndTextBenchmark = (window, transform, x, y) => {
+  
+         Revery.Draw.Shapes.drawRect(
+           ~transform,
+           ~color=Colors.green,
+           ~x,
+           ~y,
+           ~width=10.,
+           ~height=20.,
+           (),
+         );
+
+            Revery.Draw.Text.drawString(
+              ~backgroundColor=Colors.red,
+              ~color=Colors.white,
+              ~fontFamily="Roboto-Regular.ttf",
+              ~fontSize=20,
+              ~transform,
+              ~x,
+              ~y,
+              ~window,
+              testString);
+};
+
+let outerBox =
+  Style.[width(300), height(300), backgroundColor(Colors.black)];
+module Benchmark = {
+
+  let getDrawTime = () => endTime^ -. startTime^;
+  let getFlushTime = () => flushStartTime^ -. flushEndTime^;
+  let getTotalTime = () => flushEndTime^ -. flushStartTime^;
+  
+  let%component make = () => {
+    let%hook () = Hooks.effect(Always, () => {
+      print_endline ("Rendering!");
+      None 
+    });
+
+    <View style=Styles.column>
+    <View style=outerBox>
+      <OpenGL
+        style=containerStyle
+        render={(transform, _pctx) => {
+          startTime := Unix.gettimeofday();
+          print_endline ("start: " ++ string_of_float(startTime^));
+          Gl.glClearColor(1.0, 0.0, 0.0, 1.0);
+          let window = getActiveWindow();
+
+          let x = ref(0);
+          let y = ref(0);
+          let iterations = 200;
+
+          while (x^ < iterations) {
+            while(y^ < iterations) {
+              let yPos = float_of_int(y^);
+              let xPos = float_of_int(x^);
+              let () = rectAndTextBenchmark(window, transform, xPos, yPos);
+              incr(y);
+            };
+            y := 0;
+            incr(x);
+          };
+  
+          endTime := Unix.gettimeofday();
+          print_endline ("end: " ++ string_of_float(startTime^));
+          print_endline (" Draw time: " ++ string_of_float(getDrawTime()));
+
+        }}
+      />
+    </View>
+    <View style=Styles.column>
+      <Text style=Style.[
+        fontFamily("Roboto-Regular.ttf"),
+        fontSize(20),
+        color(Colors.white),
+      ] text="Hello" />
+      <Text style=Style.[
+        fontFamily("Roboto-Regular.ttf"),
+        fontSize(20),
+        color(Colors.white),
+      ] text={"Draw time: " ++  string_of_float(getDrawTime())} />
+    </View>
+    </View>
+
+  };
+}
+
+module Sample = {
+  let make = () => {
+    <Benchmark />
+  };
+};
+
+let render = () => <Sample />;

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -150,6 +150,11 @@ let examples = [
     render: _ => SkiaExample.render(),
     source: "SkiaExample.re",
   },
+  {
+    name: "Benchmark 1: Text",
+    render: _ => BenchmarkExample.render(),
+    source: "BenchmarkExample.re",
+  },
 ];
 
 let getExampleByName = name =>

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -151,8 +151,18 @@ let examples = [
     source: "SkiaExample.re",
   },
   {
-    name: "Benchmark 1: Text",
-    render: _ => BenchmarkExample.render(),
+    name: "Benchmark: drawString",
+    render: _ => BenchmarkExample.render(Text),
+    source: "BenchmarkExample.re",
+  },
+  {
+    name: "Benchmark: drawRect",
+    render: _ => BenchmarkExample.render(Rect),
+    source: "BenchmarkExample.re",
+  },
+  {
+    name: "Benchmark: drawRect&drawString",
+    render: _ => BenchmarkExample.render(TextAndRect),
     source: "BenchmarkExample.re",
   },
 ];

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -458,7 +458,7 @@ let create = (name: string, options: WindowCreateOptions.t) => {
     onAfterRender: Event.create(),
     onBeforeSwap: Event.create(),
     onAfterSwap: Event.create(),
-    
+
     onFocusGained: Event.create(),
     onFocusLost: Event.create(),
 

--- a/src/Core/Window.rei
+++ b/src/Core/Window.rei
@@ -9,6 +9,10 @@ type size = {
 
 type unsubscribe = unit => unit;
 
+let onBeforeRender: (t, unit => unit) => unsubscribe;
+let onAfterRender: (t, unit => unit) => unsubscribe;
+let onBeforeSwap: (t, unit => unit) => unsubscribe;
+let onAfterSwap: (t, unit => unit) => unsubscribe;
 let onFocusGained: (t, unit => unit) => unsubscribe;
 let onFocusLost: (t, unit => unit) => unsubscribe;
 let onMaximized: (t, unit => unit) => unsubscribe;


### PR DESCRIPTION
This adds some benchmarks for basic drawing primitives (`drawString`, `drawRect`), so we can compare the performance before/after integrating Skia.

Current results on my Mac Mini:

`master`:

| `drawString` | `drawRect` | `drawString`+`drawRect` |
| --- | --- | --- |
| ~9.152s | ~0.428s | ~9.58s |

`skia` (unoptimized - can be further improved by caching `Paint.t` objects)

| `drawString` | `drawRect` | `drawString`+`drawRect` |
| --- | --- | --- |
| ~2.3s | ~0.289s | ~2.65s |