### PR TITLE
Allow ScrollView to be controllable via scrollTop

### DIFF
--- a/examples/ScrollView.re
+++ b/examples/ScrollView.re
@@ -39,7 +39,7 @@ module Sample = {
         style=Style.[
           marginBottom(10),
           fontFamily("Roboto-Regular.ttf"),
-          fontSize(20),
+          fontSize(20.),
         ]
       />
       <Slider
@@ -60,7 +60,8 @@ module Sample = {
         checked=bounce
         style=Style.[marginBottom(10)]
       />
-      <ScrollView style=outerBox bounce scrollTop>
+      <ScrollView
+        style=outerBox bounce scrollTop onScroll={v => setScrollTop(_ => v)}>
         <Image
           src="outrun-logo.png"
           /* Exercise the case in #579 */

--- a/examples/ScrollView.re
+++ b/examples/ScrollView.re
@@ -26,9 +26,27 @@ let innerBox =
 
 module Sample = {
   let%component make = () => {
+    let%hook (scrollTop, setScrollTop) = Hooks.state(0);
     let%hook (bounce, setBounce) = Hooks.state(true);
 
+    let handleScrollTop = s => setScrollTop(_ => Float.to_int(s));
+    Console.out("scrollTop: ");
+    Console.log(scrollTop);
+
     <View style=containerStyle>
+      <Text
+        text="Scroll top"
+        style=Style.[
+          marginBottom(10),
+          fontFamily("Roboto-Regular.ttf"),
+          fontSize(20),
+        ]
+      />
+      <Slider
+        onValueChanged=handleScrollTop
+        value={Float.of_int(scrollTop)}
+        maximumValue=450.0
+      />
       <Text
         text="Bounce"
         style=Style.[
@@ -42,7 +60,7 @@ module Sample = {
         checked=bounce
         style=Style.[marginBottom(10)]
       />
-      <ScrollView style=outerBox bounce>
+      <ScrollView style=outerBox bounce scrollTop>
         <Image
           src="outrun-logo.png"
           /* Exercise the case in #579 */

--- a/src/UI_Components/ScrollView.re
+++ b/src/UI_Components/ScrollView.re
@@ -56,6 +56,16 @@ let%component make =
     Hooks.state(None);
   let%hook (actualScrollLeft, setScrollLeft) = Hooks.state(scrollLeft);
   let%hook (bouncingState, setBouncingState) = Hooks.state(Idle);
+  let%hook () =
+    Hooks.effect(
+      Always,
+      () => {
+        if (scrollTop != actualScrollTop) {
+          dispatch(ScrollUpdated(scrollTop));
+        };
+        None;
+      },
+    );
 
   let%hook (actualScrollTop, _bounceAnimationState, resetBouncingAnimation) =
     switch (bouncingState) {


### PR DESCRIPTION
Allows setting/syncing `scrollTop` property of `ScrollView` so consumers can dynamically update scroll position as needed. Adds `onScroll` prop to allow the parent component to keep the scroll value in sync when the user manually scrolls.