### PR TITLE
Perf: Skip matrix allocation + multiply (preConcat) if no transforms

### DIFF
--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -215,7 +215,7 @@ class node (()) = {
     let bbox = BoundingBox2d.transform(b, worldTransform);
     bbox;
   };
-  pri _recalculateBoundingBoxClipped = (bbox) => {
+  pri _recalculateBoundingBoxClipped = bbox => {
     switch (_this#getParent()) {
     | Some(p) => BoundingBox2d.intersect(bbox, p#getBoundingBoxClipped())
     | None => bbox

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -178,7 +178,7 @@ class node (()) = {
     switch (transforms) {
     // Skip a matrix multiplication if there are no transforms
     | [] => ()
-    | transforms =>
+    | _ =>
       let animationTransform =
         Transform.toMat4(
           float_of_int(dimensions.width) /. 2.,

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -174,22 +174,19 @@ class node (()) = {
         dimensions.top |> float_of_int,
       );
 
-    /*Mat4.create();
-      Mat4.fromTranslation(
-        matrix,
-        Vec3.create(
-          float_of_int(dimensions.left),
-          float_of_int(dimensions.top),
-          0.,
-        ),
-      );*/
-    let animationTransform =
-      Transform.toMat4(
-        float_of_int(dimensions.width) /. 2.,
-        float_of_int(dimensions.height) /. 2.,
-        _this#getStyle().transform,
-      );
-    Skia.Matrix.preConcat(matrix, animationTransform);
+    let transforms = _this#getStyle().transform;
+    switch (transforms) {
+    // Skip a matrix multiplication if there are no transforms
+    | [] => ()
+    | transforms =>
+      let animationTransform =
+        Transform.toMat4(
+          float_of_int(dimensions.width) /. 2.,
+          float_of_int(dimensions.height) /. 2.,
+          _this#getStyle().transform,
+        );
+      Skia.Matrix.preConcat(matrix, animationTransform);
+    };
     matrix;
   };
   pri _recalculateWorldTransform = localTransform => {

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -215,16 +215,7 @@ class node (()) = {
     let bbox = BoundingBox2d.transform(b, worldTransform);
     bbox;
   };
-  pri _recalculateBoundingBoxClipped = worldTransform => {
-    let dimensions = _this#measurements();
-    let b =
-      BoundingBox2d.create(
-        0.,
-        0.,
-        float_of_int(dimensions.width),
-        float_of_int(dimensions.height),
-      );
-    let bbox = BoundingBox2d.transform(b, worldTransform);
+  pri _recalculateBoundingBoxClipped = (bbox) => {
     switch (_this#getParent()) {
     | Some(p) => BoundingBox2d.intersect(bbox, p#getBoundingBoxClipped())
     | None => bbox
@@ -240,7 +231,7 @@ class node (()) = {
     let transform = _this#_recalculateTransform();
     let worldTransform = _this#_recalculateWorldTransform(transform);
     let bbox = _this#_recalculateBoundingBox(worldTransform);
-    let bboxClipped = _this#_recalculateBoundingBoxClipped(worldTransform);
+    let bboxClipped = _this#_recalculateBoundingBoxClipped(bbox);
     let depth = _this#_recalculateDepth();
 
     _cachedNodeState =

--- a/src/UI/Transform.re
+++ b/src/UI/Transform.re
@@ -12,58 +12,72 @@ type t =
   | TranslateX(float)
   | TranslateY(float);
 
-let _rotateWithOrigin = (x: float, y: float, angle, axisX, axisY, axisZ) => {
-  // TODO:
-  // This could be made significantly more efficient, with less allocations,
-  // by using the pre* and post* operations, instead of set*.
-  let preTranslate = Skia.Matrix44.makeEmpty();
-  Skia.Matrix44.setTranslate(preTranslate, (-1.) *. x, (-1.) *. y, 0.0);
+module Internal = {
 
-  let rotation = Skia.Matrix44.makeEmpty();
-  switch (angle) {
-  | Degrees(deg) =>
-    Skia.Matrix44.setRotateAboutDegrees(rotation, axisX, axisY, axisZ, deg)
-  | Radians(rad) =>
-    Skia.Matrix44.setRotateAboutRadians(rotation, axisX, axisY, axisZ, rad)
+  let rotateWithOrigin = (x: float, y: float, angle, axisX, axisY, axisZ) => {
+    // TODO:
+    // This could be made significantly more efficient, with less allocations,
+    // by using the pre* and post* operations, instead of set*.
+    let preTranslate = Skia.Matrix44.makeEmpty();
+    Skia.Matrix44.setTranslate(preTranslate, (-1.) *. x, (-1.) *. y, 0.0);
+
+    let rotation = Skia.Matrix44.makeEmpty();
+    switch (angle) {
+    | Degrees(deg) =>
+      Skia.Matrix44.setRotateAboutDegrees(rotation, axisX, axisY, axisZ, deg)
+    | Radians(rad) =>
+      Skia.Matrix44.setRotateAboutRadians(rotation, axisX, axisY, axisZ, rad)
+    };
+
+    let postTranslate = Skia.Matrix44.makeEmpty();
+    Skia.Matrix44.setTranslate(postTranslate, x, y, 0.);
+
+    let out = Skia.Matrix44.makeEmpty();
+    Skia.Matrix44.setConcat(out, rotation, preTranslate);
+    Skia.Matrix44.setConcat(out, postTranslate, out);
+    let mat = Skia.Matrix.make();
+    Skia.Matrix44.toMatrix(out, mat);
+    mat;
   };
 
-  let postTranslate = Skia.Matrix44.makeEmpty();
-  Skia.Matrix44.setTranslate(postTranslate, x, y, 0.);
+  let toMat4 = (originX: float, originY: float, t) => {
+    switch (t) {
+    | RotateX(a) => rotateWithOrigin(originX, originY, a, 1.0, 0.0, 0.0)
+    | RotateY(a) => rotateWithOrigin(originX, originY, a, 0.0, 1.0, 0.0)
+    | RotateZ(a) => rotateWithOrigin(originX, originY, a, 0.0, 0.0, 1.0)
+    | Rotate(a) => rotateWithOrigin(originX, originY, a, 0.0, 0.0, 1.0)
+    | Scale(a) => Skia.Matrix.makeScale(a, a, 0.0, 0.0)
+    | ScaleX(a) => Skia.Matrix.makeScale(a, 1.0, 0.0, 0.0)
+    | ScaleY(a) => Skia.Matrix.makeScale(1.0, a, 0.0, 0.0)
+    | TranslateX(a) => Skia.Matrix.makeTranslate(a, 0.)
+    | TranslateY(a) => Skia.Matrix.makeTranslate(0., a)
+    };
+  };
 
-  let out = Skia.Matrix44.makeEmpty();
-  Skia.Matrix44.setConcat(out, rotation, preTranslate);
-  Skia.Matrix44.setConcat(out, postTranslate, out);
-  let mat = Skia.Matrix.make();
-  Skia.Matrix44.toMatrix(out, mat);
-  mat;
-};
-
-let _toMat4 = (originX: float, originY: float, t) => {
-  switch (t) {
-  | RotateX(a) => _rotateWithOrigin(originX, originY, a, 1.0, 0.0, 0.0)
-  | RotateY(a) => _rotateWithOrigin(originX, originY, a, 0.0, 1.0, 0.0)
-  | RotateZ(a) => _rotateWithOrigin(originX, originY, a, 0.0, 0.0, 1.0)
-  | Rotate(a) => _rotateWithOrigin(originX, originY, a, 0.0, 0.0, 1.0)
-  | Scale(a) => Skia.Matrix.makeScale(a, a, 0.0, 0.0)
-  | ScaleX(a) => Skia.Matrix.makeScale(a, 1.0, 0.0, 0.0)
-  | ScaleY(a) => Skia.Matrix.makeScale(1.0, a, 0.0, 0.0)
-  | TranslateX(a) => Skia.Matrix.makeTranslate(a, 0.)
-  | TranslateY(a) => Skia.Matrix.makeTranslate(0., a)
+  let identity = {
+     let mat =  Skia.Matrix.make() 
+      Skia.Matrix.setIdentity(mat);
+      mat
   };
 };
 
 let toMat4 = (originX, originY, transforms: list(t)) => {
-  let initial = Skia.Matrix.make();
-  Skia.Matrix.setIdentity(initial);
-  let r =
+  switch (transforms) {
+  | [] => Internal.identity;
+  | transforms =>
+
+    // We can't reuse Internal.identity because we write to this matrix
+    let initial = Skia.Matrix.make();
+    Skia.Matrix.setIdentity(initial);
+    
     List.fold_left(
       (prev, transform) => {
-        let xfm = _toMat4(originX, originY, transform);
+        let xfm = Internal.toMat4(originX, originY, transform);
         Skia.Matrix.concat(prev, prev, xfm);
         prev;
       },
       initial,
       transforms,
     );
-  r;
-};
+  };
+}

--- a/src/UI/Transform.re
+++ b/src/UI/Transform.re
@@ -13,7 +13,6 @@ type t =
   | TranslateY(float);
 
 module Internal = {
-
   let rotateWithOrigin = (x: float, y: float, angle, axisX, axisY, axisZ) => {
     // TODO:
     // This could be made significantly more efficient, with less allocations,
@@ -55,21 +54,20 @@ module Internal = {
   };
 
   let identity = {
-     let mat =  Skia.Matrix.make() 
-      Skia.Matrix.setIdentity(mat);
-      mat
+    let mat = Skia.Matrix.make();
+    Skia.Matrix.setIdentity(mat);
+    mat;
   };
 };
 
 let toMat4 = (originX, originY, transforms: list(t)) => {
   switch (transforms) {
-  | [] => Internal.identity;
+  | [] => Internal.identity
   | transforms =>
-
     // We can't reuse Internal.identity because we write to this matrix
     let initial = Skia.Matrix.make();
     Skia.Matrix.setIdentity(initial);
-    
+
     List.fold_left(
       (prev, transform) => {
         let xfm = Internal.toMat4(originX, originY, transform);
@@ -80,4 +78,4 @@ let toMat4 = (originX, originY, transforms: list(t)) => {
       transforms,
     );
   };
-}
+};


### PR DESCRIPTION
A hot path for Revery performance, besides the core rendering, is the `recalculation` step:
https://github.com/revery-ui/revery/blob/395ed2ed531ddc9c8632cb299067e6ce8b87cf43/src/UI/Node.re#L241

This is where we compute various aspects of the `node`, in preparation for rendering and hit testing:
- `transform`
- `worldTransform`
- `boundingBox`
- `boundingBoxClipped`

These tend to be expensive (because matrix multiplication is expensive), and allocations are also expensive when they happen a lot - reducing allocations is keep to keeping garbage collection at bay!

One inefficiency that was occurring in this phase is that, when we were computing the animation transforms - the `style=Style.[transforms(....)]` property - we were always allocating a matrix and doing a multiply, but most of the time this would be the identity matrix, and would be a no-op.

In the common case, where there are no transforms specified, we should simply do nothing and avoid the allocation + matrix multiplication.
