### PR TITLE
Dependency: reason-skia -> 3cc83e0, use new methods

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "187f753e1768e7230fe0774bce7de85d",
+  "checksum": "3fdda6beacbaba1266425ff62db761ec",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -60,7 +60,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#8156d2b@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#3cc83e0@d41d8cd9",
         "reason-sdl2@2.10.3015@d41d8cd9",
         "reason-harfbuzz@1.91.5002@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -156,13 +156,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#8156d2b@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#8156d2b@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#3cc83e0@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#3cc83e0@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#8156d2b",
+      "version": "github:revery-ui/reason-skia#3cc83e0",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#8156d2b" ]
+        "source": [ "github:revery-ui/reason-skia#3cc83e0" ]
       },
       "overrides": [],
       "dependencies": [
@@ -477,20 +477,20 @@
       ],
       "devDependencies": []
     },
-    "@opam/zed@opam:2.0.4@f9f7c80f": {
-      "id": "@opam/zed@opam:2.0.4@f9f7c80f",
+    "@opam/zed@opam:2.0.5@80585091": {
+      "id": "@opam/zed@opam:2.0.5@80585091",
       "name": "@opam/zed",
-      "version": "opam:2.0.4",
+      "version": "opam:2.0.5",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/c6/c65b4de9f1374e72a8f80cc9cf752d90#md5:c65b4de9f1374e72a8f80cc9cf752d90",
-          "archive:https://github.com/ocaml-community/zed/releases/download/2.0.4/zed-2.0.4.tbz#md5:c65b4de9f1374e72a8f80cc9cf752d90"
+          "archive:https://opam.ocaml.org/cache/md5/56/56414179d7cccba0e20005d958b5d39e#md5:56414179d7cccba0e20005d958b5d39e",
+          "archive:https://github.com/ocaml-community/zed/releases/download/2.0.5/zed-2.0.5.tbz#md5:56414179d7cccba0e20005d958b5d39e"
         ],
         "opam": {
           "name": "zed",
-          "version": "2.0.4",
-          "path": "bench.esy.lock/opam/zed.2.0.4"
+          "version": "2.0.5",
+          "path": "bench.esy.lock/opam/zed.2.0.5"
         }
       },
       "overrides": [],
@@ -1459,7 +1459,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.4@f9f7c80f",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.5@80585091",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
         "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",
@@ -1468,7 +1468,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.4@f9f7c80f",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.5@80585091",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
         "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",

--- a/bench.esy.lock/opam/zed.2.0.5/opam
+++ b/bench.esy.lock/opam/zed.2.0.5/opam
@@ -27,6 +27,6 @@ Unicode buffers. Zed also features a regular expression search on ropes. To
 support efficient text edition capabilities, Zed provides macro recording and
 cursor management facilities."""
 url {
-  src: "https://github.com/ocaml-community/zed/releases/download/2.0.4/zed-2.0.4.tbz"
-  checksum: "c65b4de9f1374e72a8f80cc9cf752d90"
+  src: "https://github.com/ocaml-community/zed/releases/download/2.0.5/zed-2.0.5.tbz"
+  checksum: "md5=56414179d7cccba0e20005d958b5d39e"
 }

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f0729060e2632cc50f2b6dfc283b900f",
+  "checksum": "91516057c779fd1b1743e2fa0dfe26af",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -116,7 +116,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#8156d2b@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#3cc83e0@d41d8cd9",
         "reason-sdl2@2.10.3015@d41d8cd9",
         "reason-harfbuzz@1.91.5002@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -227,13 +227,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#8156d2b@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#8156d2b@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#3cc83e0@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#3cc83e0@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#8156d2b",
+      "version": "github:revery-ui/reason-skia#3cc83e0",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#8156d2b" ]
+        "source": [ "github:revery-ui/reason-skia#3cc83e0" ]
       },
       "overrides": [],
       "dependencies": [
@@ -873,20 +873,20 @@
       ],
       "devDependencies": []
     },
-    "@opam/zed@opam:2.0.4@f9f7c80f": {
-      "id": "@opam/zed@opam:2.0.4@f9f7c80f",
+    "@opam/zed@opam:2.0.5@80585091": {
+      "id": "@opam/zed@opam:2.0.5@80585091",
       "name": "@opam/zed",
-      "version": "opam:2.0.4",
+      "version": "opam:2.0.5",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/c6/c65b4de9f1374e72a8f80cc9cf752d90#md5:c65b4de9f1374e72a8f80cc9cf752d90",
-          "archive:https://github.com/ocaml-community/zed/releases/download/2.0.4/zed-2.0.4.tbz#md5:c65b4de9f1374e72a8f80cc9cf752d90"
+          "archive:https://opam.ocaml.org/cache/md5/56/56414179d7cccba0e20005d958b5d39e#md5:56414179d7cccba0e20005d958b5d39e",
+          "archive:https://github.com/ocaml-community/zed/releases/download/2.0.5/zed-2.0.5.tbz#md5:56414179d7cccba0e20005d958b5d39e"
         ],
         "opam": {
           "name": "zed",
-          "version": "2.0.4",
-          "path": "doc.esy.lock/opam/zed.2.0.4"
+          "version": "2.0.5",
+          "path": "doc.esy.lock/opam/zed.2.0.5"
         }
       },
       "overrides": [],
@@ -1884,7 +1884,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.4@f9f7c80f",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.5@80585091",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
         "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",
@@ -1893,7 +1893,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.4@f9f7c80f",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.5@80585091",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
         "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",

--- a/doc.esy.lock/opam/zed.2.0.5/opam
+++ b/doc.esy.lock/opam/zed.2.0.5/opam
@@ -27,6 +27,6 @@ Unicode buffers. Zed also features a regular expression search on ropes. To
 support efficient text edition capabilities, Zed provides macro recording and
 cursor management facilities."""
 url {
-  src: "https://github.com/ocaml-community/zed/releases/download/2.0.4/zed-2.0.4.tbz"
-  checksum: "c65b4de9f1374e72a8f80cc9cf752d90"
+  src: "https://github.com/ocaml-community/zed/releases/download/2.0.5/zed-2.0.5.tbz"
+  checksum: "md5=56414179d7cccba0e20005d958b5d39e"
 }

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a9edcf55eba53be5d30b861a81d781e1",
+  "checksum": "47b66cf711b5bbdb9e177a8955c9b236",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -60,7 +60,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#8156d2b@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#3cc83e0@d41d8cd9",
         "reason-sdl2@2.10.3015@d41d8cd9",
         "reason-harfbuzz@1.91.5002@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -156,13 +156,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#8156d2b@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#8156d2b@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#3cc83e0@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#3cc83e0@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#8156d2b",
+      "version": "github:revery-ui/reason-skia#3cc83e0",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#8156d2b" ]
+        "source": [ "github:revery-ui/reason-skia#3cc83e0" ]
       },
       "overrides": [],
       "dependencies": [
@@ -477,20 +477,20 @@
       ],
       "devDependencies": []
     },
-    "@opam/zed@opam:2.0.4@f9f7c80f": {
-      "id": "@opam/zed@opam:2.0.4@f9f7c80f",
+    "@opam/zed@opam:2.0.5@80585091": {
+      "id": "@opam/zed@opam:2.0.5@80585091",
       "name": "@opam/zed",
-      "version": "opam:2.0.4",
+      "version": "opam:2.0.5",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/c6/c65b4de9f1374e72a8f80cc9cf752d90#md5:c65b4de9f1374e72a8f80cc9cf752d90",
-          "archive:https://github.com/ocaml-community/zed/releases/download/2.0.4/zed-2.0.4.tbz#md5:c65b4de9f1374e72a8f80cc9cf752d90"
+          "archive:https://opam.ocaml.org/cache/md5/56/56414179d7cccba0e20005d958b5d39e#md5:56414179d7cccba0e20005d958b5d39e",
+          "archive:https://github.com/ocaml-community/zed/releases/download/2.0.5/zed-2.0.5.tbz#md5:56414179d7cccba0e20005d958b5d39e"
         ],
         "opam": {
           "name": "zed",
-          "version": "2.0.4",
-          "path": "esy.lock/opam/zed.2.0.4"
+          "version": "2.0.5",
+          "path": "esy.lock/opam/zed.2.0.5"
         }
       },
       "overrides": [],
@@ -1461,7 +1461,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/zed@opam:2.0.4@f9f7c80f",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/zed@opam:2.0.5@80585091",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
         "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",
@@ -1470,7 +1470,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/zed@opam:2.0.4@f9f7c80f",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/zed@opam:2.0.5@80585091",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
         "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",

--- a/esy.lock/opam/zed.2.0.5/opam
+++ b/esy.lock/opam/zed.2.0.5/opam
@@ -27,6 +27,6 @@ Unicode buffers. Zed also features a regular expression search on ropes. To
 support efficient text edition capabilities, Zed provides macro recording and
 cursor management facilities."""
 url {
-  src: "https://github.com/ocaml-community/zed/releases/download/2.0.4/zed-2.0.4.tbz"
-  checksum: "c65b4de9f1374e72a8f80cc9cf752d90"
+  src: "https://github.com/ocaml-community/zed/releases/download/2.0.5/zed-2.0.5.tbz"
+  checksum: "md5=56414179d7cccba0e20005d958b5d39e"
 }

--- a/examples/BenchmarkExample.re
+++ b/examples/BenchmarkExample.re
@@ -21,17 +21,17 @@ module Benchmarks = {
 
   let testString = String.make(50, 'a') ++ String.make(50, 'X');
 
+  let textPaint = Skia.Paint.make();
+  Skia.Paint.setTextEncoding(textPaint, GlyphId);
+  Skia.Paint.setLcdRenderText(textPaint, true);
+  Skia.Paint.setAntiAlias(textPaint, true);
+  Skia.Paint.setTextSize(textPaint, 20.);
   let textBenchmark = (canvasContext, x, y) => {
     switch (Revery.Font.load("Roboto-Regular.ttf")) {
     | Error(_) => ()
     | Ok(font) =>
-      let textPaint = Skia.Paint.make();
       Skia.Paint.setColor(textPaint, Revery_Core.Color.toSkia(Colors.white));
       Skia.Paint.setTypeface(textPaint, Revery.Font.getSkiaTypeface(font));
-      Skia.Paint.setTextEncoding(textPaint, GlyphId);
-      Skia.Paint.setLcdRenderText(textPaint, true);
-      Skia.Paint.setAntiAlias(textPaint, true);
-      Skia.Paint.setTextSize(textPaint, 20.);
 
       let shapedText =
         testString
@@ -48,11 +48,17 @@ module Benchmarks = {
     };
   };
 
+  let rectPaint = Skia.Paint.make();
   let rectBenchmark = (canvasContext, x, y) => {
-    let paint = Skia.Paint.make();
-    Skia.Paint.setColor(paint, Revery.Color.toSkia(Colors.green));
-    let rect = Skia.Rect.makeLtrb(x, y, x +. 10., y +. 20.);
-    CanvasContext.drawRect(~paint, ~rect, canvasContext);
+    Skia.Paint.setColor(rectPaint, Revery.Color.toSkia(Colors.green));
+    CanvasContext.drawRectLtwh(
+      ~paint=rectPaint,
+      ~x,
+      ~y,
+      ~width=10.,
+      ~height=20.,
+      canvasContext,
+    );
   };
 
   let textAndRectBenchmark = (canvasContext, x, y) => {

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "14abf7d4c6c207fec9310dd508e2cf05",
+  "checksum": "f013a0130da496cb0eceb0539052a8f5",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -116,7 +116,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#8156d2b@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#3cc83e0@d41d8cd9",
         "reason-sdl2@2.10.3015@d41d8cd9",
         "reason-harfbuzz@1.91.5002@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -227,13 +227,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#8156d2b@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#8156d2b@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#3cc83e0@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#3cc83e0@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#8156d2b",
+      "version": "github:revery-ui/reason-skia#3cc83e0",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#8156d2b" ]
+        "source": [ "github:revery-ui/reason-skia#3cc83e0" ]
       },
       "overrides": [],
       "dependencies": [
@@ -873,20 +873,20 @@
       ],
       "devDependencies": []
     },
-    "@opam/zed@opam:2.0.4@f9f7c80f": {
-      "id": "@opam/zed@opam:2.0.4@f9f7c80f",
+    "@opam/zed@opam:2.0.5@80585091": {
+      "id": "@opam/zed@opam:2.0.5@80585091",
       "name": "@opam/zed",
-      "version": "opam:2.0.4",
+      "version": "opam:2.0.5",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/c6/c65b4de9f1374e72a8f80cc9cf752d90#md5:c65b4de9f1374e72a8f80cc9cf752d90",
-          "archive:https://github.com/ocaml-community/zed/releases/download/2.0.4/zed-2.0.4.tbz#md5:c65b4de9f1374e72a8f80cc9cf752d90"
+          "archive:https://opam.ocaml.org/cache/md5/56/56414179d7cccba0e20005d958b5d39e#md5:56414179d7cccba0e20005d958b5d39e",
+          "archive:https://github.com/ocaml-community/zed/releases/download/2.0.5/zed-2.0.5.tbz#md5:56414179d7cccba0e20005d958b5d39e"
         ],
         "opam": {
           "name": "zed",
-          "version": "2.0.4",
-          "path": "js.esy.lock/opam/zed.2.0.4"
+          "version": "2.0.5",
+          "path": "js.esy.lock/opam/zed.2.0.5"
         }
       },
       "overrides": [],
@@ -1855,7 +1855,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.4@f9f7c80f",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.5@80585091",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
         "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",
@@ -1864,7 +1864,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.4@f9f7c80f",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.5@80585091",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
         "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",

--- a/js.esy.lock/opam/zed.2.0.5/opam
+++ b/js.esy.lock/opam/zed.2.0.5/opam
@@ -27,6 +27,6 @@ Unicode buffers. Zed also features a regular expression search on ropes. To
 support efficient text edition capabilities, Zed provides macro recording and
 cursor management facilities."""
 url {
-  src: "https://github.com/ocaml-community/zed/releases/download/2.0.4/zed-2.0.4.tbz"
-  checksum: "c65b4de9f1374e72a8f80cc9cf752d90"
+  src: "https://github.com/ocaml-community/zed/releases/download/2.0.5/zed-2.0.5.tbz"
+  checksum: "md5=56414179d7cccba0e20005d958b5d39e"
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "rench": "^1.9.1",
     "rebez": "github:jchavarri/rebez#03fa3b7",
     "reason-sdl2": "^2.10.3015",
-    "reason-skia": "github:revery-ui/reason-skia#8156d2b",
+    "reason-skia": "github:revery-ui/reason-skia#3cc83e0",
     "revery-text-wrap": "github:revery-ui/revery-text-wrap#005385c",
     "timber": "*"
   },

--- a/src/Draw/CanvasContext.re
+++ b/src/Draw/CanvasContext.re
@@ -116,6 +116,17 @@ let translate = (v: t, x: float, y: float) => {
 let drawRect = (~rect: Skia.Rect.t, ~paint: Paint.t, v: t) => {
   Canvas.drawRect(v.canvas, rect, paint);
 };
+let drawRectLtwh =
+    (
+      ~x: float,
+      ~y: float,
+      ~width: float,
+      ~height: float,
+      ~paint: Paint.t,
+      v: t,
+    ) => {
+  Canvas.drawRectLtwh(v.canvas, x, y, width, height, paint);
+};
 
 let drawRRect = (v: t, rRect: Skia.RRect.t, paint) => {
   Canvas.drawRRect(v.canvas, rRect, paint);

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -33,6 +33,7 @@ class textNode (text: string) = {
       Skia.Paint.setTextEncoding(paint, GlyphId);
       Skia.Paint.setLcdRenderText(paint, true);
       Skia.Paint.setAntiAlias(paint, true);
+      Skia.Paint.setSubpixelText(paint, true);
       Skia.Paint.setTextSize(paint, fontSize);
 
       let ascentPx = Text.getAscent(~fontFamily, ~fontSize, ());

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "187f753e1768e7230fe0774bce7de85d",
+  "checksum": "3fdda6beacbaba1266425ff62db761ec",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -60,7 +60,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.4.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#8156d2b@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#3cc83e0@d41d8cd9",
         "reason-sdl2@2.10.3015@d41d8cd9",
         "reason-harfbuzz@1.91.5002@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -156,13 +156,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#8156d2b@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#8156d2b@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#3cc83e0@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#3cc83e0@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#8156d2b",
+      "version": "github:revery-ui/reason-skia#3cc83e0",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#8156d2b" ]
+        "source": [ "github:revery-ui/reason-skia#3cc83e0" ]
       },
       "overrides": [],
       "dependencies": [
@@ -477,20 +477,20 @@
       ],
       "devDependencies": []
     },
-    "@opam/zed@opam:2.0.4@f9f7c80f": {
-      "id": "@opam/zed@opam:2.0.4@f9f7c80f",
+    "@opam/zed@opam:2.0.5@80585091": {
+      "id": "@opam/zed@opam:2.0.5@80585091",
       "name": "@opam/zed",
-      "version": "opam:2.0.4",
+      "version": "opam:2.0.5",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/c6/c65b4de9f1374e72a8f80cc9cf752d90#md5:c65b4de9f1374e72a8f80cc9cf752d90",
-          "archive:https://github.com/ocaml-community/zed/releases/download/2.0.4/zed-2.0.4.tbz#md5:c65b4de9f1374e72a8f80cc9cf752d90"
+          "archive:https://opam.ocaml.org/cache/md5/56/56414179d7cccba0e20005d958b5d39e#md5:56414179d7cccba0e20005d958b5d39e",
+          "archive:https://github.com/ocaml-community/zed/releases/download/2.0.5/zed-2.0.5.tbz#md5:56414179d7cccba0e20005d958b5d39e"
         ],
         "opam": {
           "name": "zed",
-          "version": "2.0.4",
-          "path": "test.esy.lock/opam/zed.2.0.4"
+          "version": "2.0.5",
+          "path": "test.esy.lock/opam/zed.2.0.5"
         }
       },
       "overrides": [],
@@ -1459,7 +1459,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.4@f9f7c80f",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.5@80585091",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
         "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",
@@ -1468,7 +1468,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.4@f9f7c80f",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.5@80585091",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
         "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.5.0@677655b4",

--- a/test.esy.lock/opam/zed.2.0.5/opam
+++ b/test.esy.lock/opam/zed.2.0.5/opam
@@ -27,6 +27,6 @@ Unicode buffers. Zed also features a regular expression search on ropes. To
 support efficient text edition capabilities, Zed provides macro recording and
 cursor management facilities."""
 url {
-  src: "https://github.com/ocaml-community/zed/releases/download/2.0.4/zed-2.0.4.tbz"
-  checksum: "c65b4de9f1374e72a8f80cc9cf752d90"
+  src: "https://github.com/ocaml-community/zed/releases/download/2.0.5/zed-2.0.5.tbz"
+  checksum: "md5=56414179d7cccba0e20005d958b5d39e"
 }


### PR DESCRIPTION
- Pick up the `Canvas.drawRectLtwh` API, which avoids a rect allocation in the simple case of drawing a rectangle.
- Pick up `Paint.setSubpixelText`