### PR TITLE
Bugfix: Text.measure - Use consistent settings with text & measure

### DIFF
--- a/src/Font/FontRenderer.re
+++ b/src/Font/FontRenderer.re
@@ -5,8 +5,8 @@ type measureResult = {
   height: float,
 };
 
-let _cachedPaint = Skia.Paint.make();
-Skia.Paint.setTextEncoding(_cachedPaint, GlyphId);
+let paint = Skia.Paint.make();
+Skia.Paint.setTextEncoding(paint, GlyphId);
 
 let measure = (font, size, text: string) => {
   let {height, _}: FontMetrics.t = FontCache.getMetrics(font, size);
@@ -15,8 +15,13 @@ let measure = (font, size, text: string) => {
   let glyphString =
     text |> FontCache.shape(font) |> ShapeResult.getGlyphString;
 
-  Skia.Paint.setTypeface(_cachedPaint, skiaFace);
-  Skia.Paint.setTextSize(_cachedPaint, size);
-  let width = Skia.Paint.measureText(_cachedPaint, glyphString, None);
+  Skia.Paint.setLcdRenderText(paint, true);
+  Skia.Paint.setAntiAlias(paint, true);
+  Skia.Paint.setSubpixelText(paint, true);
+  Skia.Paint.setTextEncoding(paint, GlyphId);
+
+  Skia.Paint.setTypeface(paint, skiaFace);
+  Skia.Paint.setTextSize(paint, size);
+  let width = Skia.Paint.measureText(paint, glyphString, None);
   {height, width};
 };


### PR DESCRIPTION
On Windows, in Onivim 2, the text was not being spaced and measured correctly.

When measuring a character with the `FiraCode-Regular.ttf` font - on OSX, it would correctly report a width of `8.4`. On Windows, though, it would report a width of `8.0`, which is incorrect, and resulted in the text on the editor surface being 'squished.

Very obviously bad if you look at the semicolons:
![image](https://user-images.githubusercontent.com/13532591/73567957-496ee980-441c-11ea-9486-e9d41be04974.png)


The difference is actually in the parameters we were providing the `Paint` we use to measure the text. On OSX, subpixel text was defaulted to true, but on Windows it wasn't. When we render, we set it, but we weren't setting it when measuring - and this caused the measurement to be slightly off.

The fix for now is to synchronize the settings we use in measure and in drawing. 

If we decide to make subpixel or LCD rendering options, we'll need to revisit that and make sure we're correctly measuring for those cases.

