### PR TITLE
Fix Skia rendering on Wayland

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "3c9b20ecc12a96f85b35c77f2715d4a1",
+  "checksum": "f124aa50541b4a8ea2cbceae00d3f47c",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -60,9 +60,9 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#6ffd9c7@d41d8cd9",
-        "reason-sdl2@2.10.3015@d41d8cd9",
-        "reason-harfbuzz@1.91.5002@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#e514427@d41d8cd9",
+        "reason-sdl2@2.10.3016@d41d8cd9",
+        "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@3.1.0@d41d8cd9",
@@ -156,36 +156,34 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#6ffd9c7@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#6ffd9c7@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#e514427@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#e514427@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#6ffd9c7",
+      "version": "github:revery-ui/reason-skia#e514427",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#6ffd9c7" ]
+        "source": [ "github:revery-ui/reason-skia#e514427" ]
       },
       "overrides": [],
       "dependencies": [
-        "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9",
-        "refmterr@3.3.0@d41d8cd9",
+        "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3016@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#91b10c9@d41d8cd9",
-        "esy-freetype2@2.9.1007@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
-        "@opam/lambda-term@opam:2.0.3@9465cf1c",
-        "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "esy-sdl2@2.0.10005@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/ctypes-foreign@opam:0.4.0@72ef8de2",
         "@opam/ctypes@opam:0.15.1@f2708d42",
         "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "reason-sdl2@2.10.3015@d41d8cd9": {
-      "id": "reason-sdl2@2.10.3015@d41d8cd9",
+    "reason-sdl2@2.10.3016@d41d8cd9": {
+      "id": "reason-sdl2@2.10.3016@d41d8cd9",
       "name": "reason-sdl2",
-      "version": "2.10.3015",
+      "version": "2.10.3016",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3015.tgz#sha1:86fdd1b5e0702a8ba6ef0ada5be76405d449c78a"
+          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3016.tgz#sha1:c7d00de137ab6e6d26c80da092558994b426465d"
         ]
       },
       "overrides": [],
@@ -194,21 +192,18 @@
         "esy-sdl2@2.0.10005@d41d8cd9",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
         "@opam/lwt_ppx@opam:2.0.0@9a61dd37", "@opam/lwt@opam:4.5.0@677655b4",
-        "@opam/js_of_ocaml-lwt@opam:3.5.2@6ea3e3c2",
-        "@opam/js_of_ocaml-compiler@opam:3.5.0@9ea7292f",
-        "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@1.91.5002@d41d8cd9": {
-      "id": "reason-harfbuzz@1.91.5002@d41d8cd9",
+    "reason-harfbuzz@1.91.5003@d41d8cd9": {
+      "id": "reason-harfbuzz@1.91.5003@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "1.91.5002",
+      "version": "1.91.5003",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5002.tgz#sha1:7407dbd6dfe6d4e37671a5a42647e56d881f6741"
+          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5003.tgz#sha1:4966a99d2460a07b9d264bcaae5866f40704ad6b"
         ]
       },
       "overrides": [],

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "635df19219ecb5c562bae74286417e4b",
+  "checksum": "f2665bc08390479e7372d716dc4c245d",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -116,9 +116,9 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#6ffd9c7@d41d8cd9",
-        "reason-sdl2@2.10.3015@d41d8cd9",
-        "reason-harfbuzz@1.91.5002@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#e514427@d41d8cd9",
+        "reason-sdl2@2.10.3016@d41d8cd9",
+        "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "http-server@0.12.1@d41d8cd9",
         "flex@1.2.2@d41d8cd9", "@reason-native/rely@3.1.0@d41d8cd9",
@@ -227,36 +227,34 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#6ffd9c7@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#6ffd9c7@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#e514427@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#e514427@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#6ffd9c7",
+      "version": "github:revery-ui/reason-skia#e514427",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#6ffd9c7" ]
+        "source": [ "github:revery-ui/reason-skia#e514427" ]
       },
       "overrides": [],
       "dependencies": [
-        "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9",
-        "refmterr@3.3.0@d41d8cd9",
+        "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3016@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#91b10c9@d41d8cd9",
-        "esy-freetype2@2.9.1007@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
-        "@opam/lambda-term@opam:2.0.3@9465cf1c",
-        "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "esy-sdl2@2.0.10005@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/ctypes-foreign@opam:0.4.0@72ef8de2",
         "@opam/ctypes@opam:0.15.1@f2708d42",
         "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "reason-sdl2@2.10.3015@d41d8cd9": {
-      "id": "reason-sdl2@2.10.3015@d41d8cd9",
+    "reason-sdl2@2.10.3016@d41d8cd9": {
+      "id": "reason-sdl2@2.10.3016@d41d8cd9",
       "name": "reason-sdl2",
-      "version": "2.10.3015",
+      "version": "2.10.3016",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3015.tgz#sha1:86fdd1b5e0702a8ba6ef0ada5be76405d449c78a"
+          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3016.tgz#sha1:c7d00de137ab6e6d26c80da092558994b426465d"
         ]
       },
       "overrides": [],
@@ -265,21 +263,18 @@
         "esy-sdl2@2.0.10005@d41d8cd9",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
         "@opam/lwt_ppx@opam:2.0.0@9a61dd37", "@opam/lwt@opam:4.5.0@677655b4",
-        "@opam/js_of_ocaml-lwt@opam:3.5.2@6ea3e3c2",
-        "@opam/js_of_ocaml-compiler@opam:3.5.0@9ea7292f",
-        "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@1.91.5002@d41d8cd9": {
-      "id": "reason-harfbuzz@1.91.5002@d41d8cd9",
+    "reason-harfbuzz@1.91.5003@d41d8cd9": {
+      "id": "reason-harfbuzz@1.91.5003@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "1.91.5002",
+      "version": "1.91.5003",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5002.tgz#sha1:7407dbd6dfe6d4e37671a5a42647e56d881f6741"
+          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5003.tgz#sha1:4966a99d2460a07b9d264bcaae5866f40704ad6b"
         ]
       },
       "overrides": [],

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "4ba4fb938018f3edf533d7b883cbdbb2",
+  "checksum": "772e430cb4cd1387841ee00fcf4bb927",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -60,8 +60,8 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#8493339@d41d8cd9",
-        "reason-sdl2@2.10.3015@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#e514427@d41d8cd9",
+        "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
@@ -156,37 +156,34 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#8493339@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#8493339@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#e514427@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#e514427@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#8493339",
+      "version": "github:revery-ui/reason-skia#e514427",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#8493339" ]
+        "source": [ "github:revery-ui/reason-skia#e514427" ]
       },
       "overrides": [],
       "dependencies": [
-        "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9",
-        "refmterr@3.3.0@d41d8cd9",
+        "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3016@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#91b10c9@d41d8cd9",
         "esy-sdl2@2.0.10005@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
-        "@opam/lwt@opam:4.5.0@677655b4",
-        "@opam/lambda-term@opam:2.0.3@9465cf1c",
-        "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/ctypes-foreign@opam:0.4.0@72ef8de2",
         "@opam/ctypes@opam:0.15.1@f2708d42",
         "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "reason-sdl2@2.10.3015@d41d8cd9": {
-      "id": "reason-sdl2@2.10.3015@d41d8cd9",
+    "reason-sdl2@2.10.3016@d41d8cd9": {
+      "id": "reason-sdl2@2.10.3016@d41d8cd9",
       "name": "reason-sdl2",
-      "version": "2.10.3015",
+      "version": "2.10.3016",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3015.tgz#sha1:86fdd1b5e0702a8ba6ef0ada5be76405d449c78a"
+          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3016.tgz#sha1:c7d00de137ab6e6d26c80da092558994b426465d"
         ]
       },
       "overrides": [],
@@ -195,9 +192,6 @@
         "esy-sdl2@2.0.10005@d41d8cd9",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
         "@opam/lwt_ppx@opam:2.0.0@9a61dd37", "@opam/lwt@opam:4.5.0@677655b4",
-        "@opam/js_of_ocaml-lwt@opam:3.5.2@6ea3e3c2",
-        "@opam/js_of_ocaml-compiler@opam:3.5.0@9ea7292f",
-        "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5f7e9fe4ba346fa18510ff71ae195538",
+  "checksum": "4ba4fb938018f3edf533d7b883cbdbb2",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -60,9 +60,9 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#6ffd9c7@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#8493339@d41d8cd9",
         "reason-sdl2@2.10.3015@d41d8cd9",
-        "reason-harfbuzz@1.91.5002@d41d8cd9",
+        "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@3.1.0@d41d8cd9",
@@ -156,20 +156,21 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#6ffd9c7@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#6ffd9c7@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#8493339@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#8493339@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#6ffd9c7",
+      "version": "github:revery-ui/reason-skia#8493339",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#6ffd9c7" ]
+        "source": [ "github:revery-ui/reason-skia#8493339" ]
       },
       "overrides": [],
       "dependencies": [
         "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9",
         "refmterr@3.3.0@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#91b10c9@d41d8cd9",
-        "esy-freetype2@2.9.1007@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
+        "esy-sdl2@2.0.10005@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4",
         "@opam/lambda-term@opam:2.0.3@9465cf1c",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/ctypes-foreign@opam:0.4.0@72ef8de2",
@@ -201,14 +202,14 @@
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@1.91.5002@d41d8cd9": {
-      "id": "reason-harfbuzz@1.91.5002@d41d8cd9",
+    "reason-harfbuzz@1.91.5003@d41d8cd9": {
+      "id": "reason-harfbuzz@1.91.5003@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "1.91.5002",
+      "version": "1.91.5003",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5002.tgz#sha1:7407dbd6dfe6d4e37671a5a42647e56d881f6741"
+          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5003.tgz#sha1:4966a99d2460a07b9d264bcaae5866f40704ad6b"
         ]
       },
       "overrides": [],

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "da004c3c93a65002353af67e0f53fb6f",
+  "checksum": "9e1cfd628a84d564272b341216ac5bad",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -116,9 +116,9 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#6ffd9c7@d41d8cd9",
-        "reason-sdl2@2.10.3015@d41d8cd9",
-        "reason-harfbuzz@1.91.5002@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#e514427@d41d8cd9",
+        "reason-sdl2@2.10.3016@d41d8cd9",
+        "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "http-server@0.12.1@d41d8cd9",
         "flex@1.2.2@d41d8cd9", "@reason-native/rely@3.1.0@d41d8cd9",
@@ -186,7 +186,7 @@
         "refmterr@3.3.0@d41d8cd9", "@reason-native/rely@3.1.0@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/lwt@opam:4.5.0@677655b4",
-        "@opam/lambda-term@opam:2.0@57c9208c",
+        "@opam/lambda-term@opam:2.0.3@9465cf1c",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
@@ -227,36 +227,34 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#6ffd9c7@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#6ffd9c7@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#e514427@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#e514427@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#6ffd9c7",
+      "version": "github:revery-ui/reason-skia#e514427",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#6ffd9c7" ]
+        "source": [ "github:revery-ui/reason-skia#e514427" ]
       },
       "overrides": [],
       "dependencies": [
-        "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9",
-        "refmterr@3.3.0@d41d8cd9",
+        "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3016@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#91b10c9@d41d8cd9",
-        "esy-freetype2@2.9.1007@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
-        "@opam/lambda-term@opam:2.0@57c9208c",
-        "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "esy-sdl2@2.0.10005@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/ctypes-foreign@opam:0.4.0@72ef8de2",
         "@opam/ctypes@opam:0.15.1@f2708d42",
         "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "reason-sdl2@2.10.3015@d41d8cd9": {
-      "id": "reason-sdl2@2.10.3015@d41d8cd9",
+    "reason-sdl2@2.10.3016@d41d8cd9": {
+      "id": "reason-sdl2@2.10.3016@d41d8cd9",
       "name": "reason-sdl2",
-      "version": "2.10.3015",
+      "version": "2.10.3016",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3015.tgz#sha1:86fdd1b5e0702a8ba6ef0ada5be76405d449c78a"
+          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3016.tgz#sha1:c7d00de137ab6e6d26c80da092558994b426465d"
         ]
       },
       "overrides": [],
@@ -265,21 +263,18 @@
         "esy-sdl2@2.0.10005@d41d8cd9",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
         "@opam/lwt_ppx@opam:2.0.0@9a61dd37", "@opam/lwt@opam:4.5.0@677655b4",
-        "@opam/js_of_ocaml-lwt@opam:3.5.2@6ea3e3c2",
-        "@opam/js_of_ocaml-compiler@opam:3.5.0@9ea7292f",
-        "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@1.91.5002@d41d8cd9": {
-      "id": "reason-harfbuzz@1.91.5002@d41d8cd9",
+    "reason-harfbuzz@1.91.5003@d41d8cd9": {
+      "id": "reason-harfbuzz@1.91.5003@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "1.91.5002",
+      "version": "1.91.5003",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5002.tgz#sha1:7407dbd6dfe6d4e37671a5a42647e56d881f6741"
+          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5003.tgz#sha1:4966a99d2460a07b9d264bcaae5866f40704ad6b"
         ]
       },
       "overrides": [],
@@ -1837,20 +1832,20 @@
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "@opam/lambda-term@opam:2.0@57c9208c": {
-      "id": "@opam/lambda-term@opam:2.0@57c9208c",
+    "@opam/lambda-term@opam:2.0.3@9465cf1c": {
+      "id": "@opam/lambda-term@opam:2.0.3@9465cf1c",
       "name": "@opam/lambda-term",
-      "version": "opam:2.0",
+      "version": "opam:2.0.3",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/92/9284c51c2ef18ebf6c17281879f2ff13#md5:9284c51c2ef18ebf6c17281879f2ff13",
-          "archive:https://github.com/ocaml-community/lambda-term/releases/download/2.0/lambda-term-2.0.tbz#md5:9284c51c2ef18ebf6c17281879f2ff13"
+          "archive:https://opam.ocaml.org/cache/md5/90/903b6cc234598d67c7c905dfb5230209#md5:903b6cc234598d67c7c905dfb5230209",
+          "archive:https://github.com/ocaml-community/lambda-term/releases/download/2.0.3/lambda-term-2.0.3.tbz#md5:903b6cc234598d67c7c905dfb5230209"
         ],
         "opam": {
           "name": "lambda-term",
-          "version": "2.0",
-          "path": "js.esy.lock/opam/lambda-term.2.0"
+          "version": "2.0.3",
+          "path": "js.esy.lock/opam/lambda-term.2.0.3"
         }
       },
       "overrides": [],

--- a/js.esy.lock/opam/lambda-term.2.0.3/opam
+++ b/js.esy.lock/opam/lambda-term.2.0.3/opam
@@ -6,7 +6,6 @@ bug-reports: "https://github.com/ocaml-community/lambda-term/issues"
 dev-repo: "git://github.com/ocaml-community/lambda-term.git"
 license: "BSD-3-Clause"
 build: [
-  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
@@ -15,10 +14,10 @@ depends: [
   "lwt"   {>= "4.0.0"}
   "lwt_log"
   "react"
-  "zed"   {>= "2.0" & < "3.0"}
-  "camomile" {>= "0.8.6"}
+  "zed"   {>= "2.0.3" & < "3.0"}
+  "camomile" {>= "1.0.1"}
   "lwt_react"
-  "dune" {>= "1.0.0"}
+  "dune" {>= "1.1.0"}
 ]
 synopsis: "Terminal manipulation library for OCaml"
 description: """
@@ -30,7 +29,6 @@ for example, ncurses, by providing a native OCaml interface instead of bindings
 to a C library. Lambda-term integrates with zed to provide text edition
 facilities in console applications."""
 url {
-  src:
-    "https://github.com/ocaml-community/lambda-term/releases/download/2.0/lambda-term-2.0.tbz"
-  checksum: "md5=9284c51c2ef18ebf6c17281879f2ff13"
+  src: "https://github.com/ocaml-community/lambda-term/releases/download/2.0.3/lambda-term-2.0.3.tbz"
+  checksum: "md5=903b6cc234598d67c7c905dfb5230209"
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "rench": "^1.9.1",
     "rebez": "github:jchavarri/rebez#03fa3b7",
     "reason-sdl2": "^2.10.3015",
-    "reason-skia": "github:revery-ui/reason-skia#6ffd9c7",
+    "reason-skia": "github:revery-ui/reason-skia#8493339",
     "revery-text-wrap": "github:revery-ui/revery-text-wrap#005385c",
     "timber": "*"
   },

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "reason-harfbuzz": "*",
     "rench": "^1.9.1",
     "rebez": "github:jchavarri/rebez#03fa3b7",
-    "reason-sdl2": "^2.10.3015",
-    "reason-skia": "github:revery-ui/reason-skia#8493339",
+    "reason-sdl2": "^2.10.3016",
+    "reason-skia": "github:revery-ui/reason-skia#e514427",
     "revery-text-wrap": "github:revery-ui/revery-text-wrap#005385c",
     "timber": "*"
   },

--- a/src/Draw/CanvasContext.re
+++ b/src/Draw/CanvasContext.re
@@ -17,7 +17,8 @@ type t = {
 };
 
 let create = (window: Revery_Core.Window.t) => {
-  let context = Skia.Gr.Context.makeGl(None);
+  let sdlGlInterface = Skia.Gr.Gl.Interface.makeSdl2();
+  let context = Skia.Gr.Context.makeGl(Some(sdlGlInterface));
   switch (context) {
   | None =>
     Log.error("Unable to create skia context");

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "3c9b20ecc12a96f85b35c77f2715d4a1",
+  "checksum": "f124aa50541b4a8ea2cbceae00d3f47c",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9": {
@@ -60,9 +60,9 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#6ffd9c7@d41d8cd9",
-        "reason-sdl2@2.10.3015@d41d8cd9",
-        "reason-harfbuzz@1.91.5002@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#e514427@d41d8cd9",
+        "reason-sdl2@2.10.3016@d41d8cd9",
+        "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@3.1.0@d41d8cd9",
@@ -156,36 +156,34 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#6ffd9c7@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#6ffd9c7@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#e514427@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#e514427@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#6ffd9c7",
+      "version": "github:revery-ui/reason-skia#e514427",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#6ffd9c7" ]
+        "source": [ "github:revery-ui/reason-skia#e514427" ]
       },
       "overrides": [],
       "dependencies": [
-        "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b6@d41d8cd9",
-        "refmterr@3.3.0@d41d8cd9",
+        "refmterr@3.3.0@d41d8cd9", "reason-sdl2@2.10.3016@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#91b10c9@d41d8cd9",
-        "esy-freetype2@2.9.1007@d41d8cd9", "@opam/lwt@opam:4.5.0@677655b4",
-        "@opam/lambda-term@opam:2.0.3@9465cf1c",
-        "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "esy-sdl2@2.0.10005@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
+        "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/ctypes-foreign@opam:0.4.0@72ef8de2",
         "@opam/ctypes@opam:0.15.1@f2708d42",
         "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "reason-sdl2@2.10.3015@d41d8cd9": {
-      "id": "reason-sdl2@2.10.3015@d41d8cd9",
+    "reason-sdl2@2.10.3016@d41d8cd9": {
+      "id": "reason-sdl2@2.10.3016@d41d8cd9",
       "name": "reason-sdl2",
-      "version": "2.10.3015",
+      "version": "2.10.3016",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3015.tgz#sha1:86fdd1b5e0702a8ba6ef0ada5be76405d449c78a"
+          "archive:https://registry.npmjs.org/reason-sdl2/-/reason-sdl2-2.10.3016.tgz#sha1:c7d00de137ab6e6d26c80da092558994b426465d"
         ]
       },
       "overrides": [],
@@ -194,21 +192,18 @@
         "esy-sdl2@2.0.10005@d41d8cd9",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
         "@opam/lwt_ppx@opam:2.0.0@9a61dd37", "@opam/lwt@opam:4.5.0@677655b4",
-        "@opam/js_of_ocaml-lwt@opam:3.5.2@6ea3e3c2",
-        "@opam/js_of_ocaml-compiler@opam:3.5.0@9ea7292f",
-        "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "reason-harfbuzz@1.91.5002@d41d8cd9": {
-      "id": "reason-harfbuzz@1.91.5002@d41d8cd9",
+    "reason-harfbuzz@1.91.5003@d41d8cd9": {
+      "id": "reason-harfbuzz@1.91.5003@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "1.91.5002",
+      "version": "1.91.5003",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5002.tgz#sha1:7407dbd6dfe6d4e37671a5a42647e56d881f6741"
+          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5003.tgz#sha1:4966a99d2460a07b9d264bcaae5866f40704ad6b"
         ]
       },
       "overrides": [],


### PR DESCRIPTION
On Wayland, with the Skia integration, we are seeing a blue (empty) screen on rendering:
https://github.com/onivim/oni2/issues/1283

The root cause is that the default Skia Gl interface, on Linux, defined here: https://github.com/revery-ui/esy-skia/blob/master/src/gpu/gl/glx/GrGLMakeNativeInterface_glx.cpp

uses X11 APIs, like `glXGetProcAddress` to get the OpenGL API surface. On Wayland, though, that API won't work.

Instead, we pick up a change in `reason-skia` (https://github.com/revery-ui/reason-skia/pull/3) to use the `SDL_GL_GetProcAddress` method to supply the GL interface.