### PR TITLE
Skia: Disable subpixel text until configurable

### DIFF
--- a/src/Font/FontRenderer.re
+++ b/src/Font/FontRenderer.re
@@ -17,7 +17,6 @@ let measure = (font, size, text: string) => {
 
   Skia.Paint.setLcdRenderText(paint, true);
   Skia.Paint.setAntiAlias(paint, true);
-  Skia.Paint.setSubpixelText(paint, true);
   Skia.Paint.setTextEncoding(paint, GlyphId);
 
   Skia.Paint.setTypeface(paint, skiaFace);

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -33,7 +33,6 @@ class textNode (text: string) = {
       Skia.Paint.setTextEncoding(paint, GlyphId);
       Skia.Paint.setLcdRenderText(paint, true);
       Skia.Paint.setAntiAlias(paint, true);
-      Skia.Paint.setSubpixelText(paint, true);
       Skia.Paint.setTextSize(paint, fontSize);
 
       let ascentPx = Text.getAscent(~fontFamily, ~fontSize, ());


### PR DESCRIPTION
Skia supports subpixel character position rendering via `setSubpixelText`, but this can affect measurement and metrics.

On some platforms, subpixel rendering isn't supported - so this can skew our measurements when the rendered text doesn't align with the measurements we expect. For now, I'll turn it off, until we can reliably detect when it will be enabled, or have a configuration story for it.

Note that this doesn't disable anti-aliasing, or lcd striping - just subpixel positioning.