### PR TITLE
Perf: Benchmark and improve setting Color

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "97de21d20e66fb40524c87194dfe8768",
+  "checksum": "4c1521a1c8dc9de9ef96f99f4988b173",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "d15fdf1bc098ee7a9d4f4d2ab275ad2d",
+  "checksum": "c20db8561dcbaa4746b00e677efa0d38",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -1855,7 +1855,7 @@
         "@opam/conf-pkg-config@opam:1.1@67c69c0c",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9",
-        "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567@d41d8cd9"
+        "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/integers@opam:0.3.0@d6eefd3a",
@@ -2275,13 +2275,13 @@
       ],
       "devDependencies": []
     },
-    "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567@d41d8cd9": {
-      "id": "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567@d41d8cd9",
+    "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9": {
+      "id": "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9",
       "name": "@esy-ocaml/libffi",
-      "version": "github:esy-ocaml/libffi#599bc3567",
+      "version": "github:esy-ocaml/libffi#c61127d",
       "source": {
         "type": "install",
-        "source": [ "github:esy-ocaml/libffi#599bc3567" ]
+        "source": [ "github:esy-ocaml/libffi#c61127d" ]
       },
       "overrides": [],
       "dependencies": [],

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "dbb584e4fc81a1a035563ddd1e285862",
+  "checksum": "97de21d20e66fb40524c87194dfe8768",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -63,7 +63,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#53b10ee@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -159,13 +159,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#53b10ee@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#53b10ee@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#53b10ee",
+      "version": "github:revery-ui/reason-skia#0b52e17",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#53b10ee" ]
+        "source": [ "github:revery-ui/reason-skia#0b52e17" ]
       },
       "overrides": [],
       "dependencies": [

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "4c1521a1c8dc9de9ef96f99f4988b173",
+  "checksum": "d15fdf1bc098ee7a9d4f4d2ab275ad2d",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -63,7 +63,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -159,13 +159,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#0b52e17",
+      "version": "github:revery-ui/reason-skia#668629f",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#0b52e17" ]
+        "source": [ "github:revery-ui/reason-skia#668629f" ]
       },
       "overrides": [],
       "dependencies": [

--- a/bench/lib/PaintBench.re
+++ b/bench/lib/PaintBench.re
@@ -11,7 +11,7 @@ module Data = {
 };
 
 let setPaintColor = () => {
-  let () = Skia.Paint.setColor(Data.paint, Revery.Color.toSkia(Data.color)); 
+  let () = Skia.Paint.setColor(Data.paint, Revery.Color.toSkia(Data.color));
   ();
 };
 

--- a/bench/lib/PaintBench.re
+++ b/bench/lib/PaintBench.re
@@ -1,0 +1,24 @@
+open BenchFramework;
+
+open Revery;
+open Revery.Draw;
+
+let options = Reperf.Options.create(~iterations=10000, ());
+
+module Data = {
+  let color = Colors.red;
+  let paint = Skia.Paint.make();
+};
+
+let setPaintColor = () => {
+  let () = Skia.Paint.setColor(Data.paint, Revery.Color.toSkia(Data.color)); 
+  ();
+};
+
+bench(
+  ~name="Paint: Set color",
+  ~options,
+  ~setup=() => (),
+  ~f=setPaintColor,
+  (),
+);

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "28203675e08f07974e7d447e1adf4bd9",
+  "checksum": "99af8f8c77e2eaaeac04abf0d6bc85ce",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -119,7 +119,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#53b10ee@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -230,13 +230,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#53b10ee@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#53b10ee@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#53b10ee",
+      "version": "github:revery-ui/reason-skia#0b52e17",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#53b10ee" ]
+        "source": [ "github:revery-ui/reason-skia#0b52e17" ]
       },
       "overrides": [],
       "dependencies": [

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "99af8f8c77e2eaaeac04abf0d6bc85ce",
+  "checksum": "9689d90caaf93114d57e2e1946fe8265",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9689d90caaf93114d57e2e1946fe8265",
+  "checksum": "617a4308811df7e2e45aa0d3ea64f75c",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -119,7 +119,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -230,13 +230,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#0b52e17",
+      "version": "github:revery-ui/reason-skia#668629f",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#0b52e17" ]
+        "source": [ "github:revery-ui/reason-skia#668629f" ]
       },
       "overrides": [],
       "dependencies": [

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "617a4308811df7e2e45aa0d3ea64f75c",
+  "checksum": "7c399691e5c157636419862c40c4b560",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -2280,7 +2280,7 @@
         "@opam/conf-pkg-config@opam:1.1@67c69c0c",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9",
-        "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567@d41d8cd9"
+        "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/integers@opam:0.3.0@d6eefd3a",
@@ -2700,13 +2700,13 @@
       ],
       "devDependencies": []
     },
-    "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567@d41d8cd9": {
-      "id": "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567@d41d8cd9",
+    "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9": {
+      "id": "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9",
       "name": "@esy-ocaml/libffi",
-      "version": "github:esy-ocaml/libffi#599bc3567",
+      "version": "github:esy-ocaml/libffi#c61127d",
       "source": {
         "type": "install",
-        "source": [ "github:esy-ocaml/libffi#599bc3567" ]
+        "source": [ "github:esy-ocaml/libffi#c61127d" ]
       },
       "overrides": [],
       "dependencies": [],

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a844dc9e287a22056223566fd4361911",
+  "checksum": "187815290775acf2c9994db026d3192f",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -63,7 +63,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#53b10ee@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -159,13 +159,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#53b10ee@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#53b10ee@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#53b10ee",
+      "version": "github:revery-ui/reason-skia#0b52e17",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#53b10ee" ]
+        "source": [ "github:revery-ui/reason-skia#0b52e17" ]
       },
       "overrides": [],
       "dependencies": [

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "ad70b5441397b38f838b42525749846b",
+  "checksum": "58957c030d81977fae9278a38ed2f0ea",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -63,7 +63,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -159,13 +159,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#0b52e17",
+      "version": "github:revery-ui/reason-skia#668629f",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#0b52e17" ]
+        "source": [ "github:revery-ui/reason-skia#668629f" ]
       },
       "overrides": [],
       "dependencies": [

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "187815290775acf2c9994db026d3192f",
+  "checksum": "ad70b5441397b38f838b42525749846b",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "58957c030d81977fae9278a38ed2f0ea",
+  "checksum": "124d6efae176652dd272efc0da68d7f0",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -1857,7 +1857,7 @@
         "@opam/conf-pkg-config@opam:1.1@67c69c0c",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9",
-        "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567@d41d8cd9"
+        "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/integers@opam:0.3.0@d6eefd3a",
@@ -2277,13 +2277,13 @@
       ],
       "devDependencies": []
     },
-    "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567@d41d8cd9": {
-      "id": "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567@d41d8cd9",
+    "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9": {
+      "id": "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9",
       "name": "@esy-ocaml/libffi",
-      "version": "github:esy-ocaml/libffi#599bc3567",
+      "version": "github:esy-ocaml/libffi#c61127d",
       "source": {
         "type": "install",
-        "source": [ "github:esy-ocaml/libffi#599bc3567" ]
+        "source": [ "github:esy-ocaml/libffi#c61127d" ]
       },
       "overrides": [],
       "dependencies": [],

--- a/examples/CanvasExample.re
+++ b/examples/CanvasExample.re
@@ -27,7 +27,7 @@ module Sample = {
           let paint = Skia.Paint.make();
           Skia.Paint.setColor(
             paint,
-            Skia.Color.makeArgb(0xFF, 0xFF, 0x00, 0x00),
+            Skia.Color.makeArgb(0xFFl, 0xFFl, 0x00l, 0x00l),
           );
 
           let rect = Skia.Rect.makeLtrb(1.0, 1.0, 101., 201.);

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "0d74e2d5adedafa773874a260648fcbf",
+  "checksum": "c0d28872e6aa24a0ede15d3b6acfd68e",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -2251,7 +2251,7 @@
         "@opam/conf-pkg-config@opam:1.1@67c69c0c",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9",
-        "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567@d41d8cd9"
+        "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/integers@opam:0.3.0@d6eefd3a",
@@ -2671,13 +2671,13 @@
       ],
       "devDependencies": []
     },
-    "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567@d41d8cd9": {
-      "id": "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567@d41d8cd9",
+    "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9": {
+      "id": "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9",
       "name": "@esy-ocaml/libffi",
-      "version": "github:esy-ocaml/libffi#599bc3567",
+      "version": "github:esy-ocaml/libffi#c61127d",
       "source": {
         "type": "install",
-        "source": [ "github:esy-ocaml/libffi#599bc3567" ]
+        "source": [ "github:esy-ocaml/libffi#c61127d" ]
       },
       "overrides": [],
       "dependencies": [],

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "1d3efbe911da571043b8aee72be96630",
+  "checksum": "05759d47855b69a09be3de35dca74862",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -119,7 +119,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#53b10ee@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -230,13 +230,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#53b10ee@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#53b10ee@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#53b10ee",
+      "version": "github:revery-ui/reason-skia#0b52e17",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#53b10ee" ]
+        "source": [ "github:revery-ui/reason-skia#0b52e17" ]
       },
       "overrides": [],
       "dependencies": [

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "05759d47855b69a09be3de35dca74862",
+  "checksum": "c8d73fdd9dbcab7f9907af4f5a54da99",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "c8d73fdd9dbcab7f9907af4f5a54da99",
+  "checksum": "0d74e2d5adedafa773874a260648fcbf",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -119,7 +119,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -230,13 +230,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#0b52e17",
+      "version": "github:revery-ui/reason-skia#668629f",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#0b52e17" ]
+        "source": [ "github:revery-ui/reason-skia#668629f" ]
       },
       "overrides": [],
       "dependencies": [

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "resolutions": {
     "@esy-ocaml/libffi": "esy-ocaml/libffi#599bc3567",
+    "reason-skia": "revery-ui/reason-skia#0b52e17",
     "@opam/cmdliner": "1.0.2",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
     "timber": "glennsl/timber#ae065bb"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "timber": "*"
   },
   "resolutions": {
-    "@esy-ocaml/libffi": "esy-ocaml/libffi#599bc3567",
+    "@esy-ocaml/libffi": "esy-ocaml/libffi#c61127d",
     "@opam/cmdliner": "1.0.2",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
     "timber": "glennsl/timber#ae065bb"

--- a/package.json
+++ b/package.json
@@ -53,13 +53,12 @@
     "rench": "^1.9.1",
     "rebez": "github:jchavarri/rebez#03fa3b7",
     "reason-sdl2": "^2.10.3016",
-    "reason-skia": "github:revery-ui/reason-skia#7a753c6",
+    "reason-skia": "github:revery-ui/reason-skia#668629f",
     "revery-text-wrap": "github:revery-ui/revery-text-wrap#005385c",
     "timber": "*"
   },
   "resolutions": {
     "@esy-ocaml/libffi": "esy-ocaml/libffi#599bc3567",
-    "reason-skia": "revery-ui/reason-skia#0b52e17",
     "@opam/cmdliner": "1.0.2",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
     "timber": "glennsl/timber#ae065bb"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "rench": "^1.9.1",
     "rebez": "github:jchavarri/rebez#03fa3b7",
     "reason-sdl2": "^2.10.3016",
-    "reason-skia": "github:revery-ui/reason-skia#53b10ee",
+    "reason-skia": "github:revery-ui/reason-skia#7a753c6",
     "revery-text-wrap": "github:revery-ui/revery-text-wrap#005385c",
     "timber": "*"
   },

--- a/src/Core/Color.re
+++ b/src/Core/Color.re
@@ -107,10 +107,7 @@ let toRgba = (color: t) => {
 };
 
 let equals = (a: t, b: t) => {
-  print_endline("Before qual...");
-  let ret = a == b;
-  print_endline("After qual...");
-  ret;
+  a == b;
 };
 
 let toString = (color: t) => {

--- a/src/Core/Color.re
+++ b/src/Core/Color.re
@@ -109,7 +109,7 @@ let toString = (color: t) =>
   );
 
 let _toInt = (v: float) => {
-  int_of_float(255. *. v);
+  int_of_float(255. *. v) |> Int32.of_int;
 };
 
 let toSkia = (color: t) => {

--- a/src/Core/Color.re
+++ b/src/Core/Color.re
@@ -1,13 +1,10 @@
-type t = {
-  r: float,
-  g: float,
-  b: float,
-  a: float,
-};
+type t = Skia.Color.t;
 
-let rgba = (r, g, b, a) => {r, g, b, a};
+let rgba = (r, g, b, a) => Skia.Color.Float.makeArgb(a, r, g, b);
 
-let rgb = (r, g, b) => {r, g, b, a: 1.0};
+let rgb = (r, g, b) => Skia.Color.Float.makeArgb(1.0, r, g, b);
+
+let getAlpha = Skia.Color.Float.getA;
 
 // Matches:
 // #FFF
@@ -77,46 +74,53 @@ let hex = str =>
   };
 
 let multiplyAlpha = (opacity: float, color: t) => {
-  let ret: t = {...color, a: opacity *. color.a};
-  ret;
+  let a = Skia.Color.Float.getA(color);
+  let r = Skia.Color.Float.getR(color);
+  let g = Skia.Color.Float.getG(color);
+  let b = Skia.Color.Float.getB(color);
+  Skia.Color.Float.makeArgb(a *. opacity, r, g, b);
 };
 
 let mix = (~start, ~stop, ~amount) => {
-  r: (stop.r -. start.r) *. amount +. start.r,
-  g: (stop.g -. start.g) *. amount +. start.g,
-  b: (stop.b -. start.b) *. amount +. start.b,
-  a: (stop.a -. start.a) *. amount +. start.a,
+  let startA = Skia.Color.Float.getA(start);
+  let startR = Skia.Color.Float.getR(start);
+  let startG = Skia.Color.Float.getG(start);
+  let startB = Skia.Color.Float.getB(start);
+
+  let stopA = Skia.Color.Float.getA(stop);
+  let stopR = Skia.Color.Float.getR(stop);
+  let stopG = Skia.Color.Float.getG(stop);
+  let stopB = Skia.Color.Float.getB(stop);
+  let r = (stopR -. startR) *. amount +. startR;
+  let g = (stopG -. startG) *. amount +. startG;
+  let b = (stopB -. startB) *. amount +. startB;
+  let a = (stopA -. startA) *. amount +. startA;
+  Skia.Color.Float.makeArgb(a, r, g, b);
 };
 
 let toRgba = (color: t) => {
-  (color.r, color.g, color.b, color.a);
+  let a = Skia.Color.Float.getA(color);
+  let r = Skia.Color.Float.getR(color);
+  let g = Skia.Color.Float.getG(color);
+  let b = Skia.Color.Float.getB(color);
+  (r, g, b, a);
 };
 
 let equals = (a: t, b: t) => {
-  Float.equal(a.r, b.r)
-  && Float.equal(a.g, b.g)
-  && Float.equal(a.b, b.b)
-  && Float.equal(a.a, b.a);
+  print_endline("Before qual...");
+  let ret = a == b;
+  print_endline("After qual...");
+  ret;
 };
 
-let toString = (color: t) =>
-  Printf.sprintf(
-    "(r: %f g: %f b: %f a: %f)",
-    color.r,
-    color.g,
-    color.b,
-    color.a,
-  );
-
-let _toInt = (v: float) => {
-  int_of_float(255. *. v) |> Int32.of_int;
+let toString = (color: t) => {
+  let a = Skia.Color.Float.getA(color);
+  let r = Skia.Color.Float.getR(color);
+  let g = Skia.Color.Float.getG(color);
+  let b = Skia.Color.Float.getB(color);
+  Printf.sprintf("(r: %f g: %f b: %f a: %f)", r, g, b, a);
 };
 
 let toSkia = (color: t) => {
-  let a = _toInt(color.a);
-  let r = _toInt(color.r);
-  let g = _toInt(color.g);
-  let b = _toInt(color.b);
-
-  Skia.Color.makeArgb(a, r, g, b);
+  color;
 };

--- a/src/Core/Color.rei
+++ b/src/Core/Color.rei
@@ -1,11 +1,6 @@
 exception ColorHexParseException(string);
 
-type t = {
-  r: float,
-  g: float,
-  b: float,
-  a: float,
-};
+type t;
 
 let rgba: (float, float, float, float) => t;
 let rgb: (float, float, float) => t;
@@ -15,6 +10,7 @@ let multiplyAlpha: (float, t) => t;
 let mix: (~start: t, ~stop: t, ~amount: float) => t;
 
 let toRgba: t => (float, float, float, float);
+let getAlpha: t => float;
 
 let equals: (t, t) => bool;
 

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -286,7 +286,8 @@ let render = (w: t) => {
   Sdl2.Gl.glDisable(GL_DEPTH_TEST);
 
   let color = w.backgroundColor;
-  Sdl2.Gl.glClearColor(color.r, color.g, color.b, color.a);
+  let (r, g, b, a) = Color.toRgba(color);
+  Sdl2.Gl.glClearColor(r, g, b, a);
 
   Event.dispatch(w.onBeforeRender, ());
   w.render();

--- a/src/Draw/DebugDraw.re
+++ b/src/Draw/DebugDraw.re
@@ -19,7 +19,7 @@ let setActive = (bbox: BoundingBox2d.t) => {
 };
 
 let paint = Skia.Paint.make();
-Skia.Paint.setColor(paint, Skia.Color.makeArgb(50, 255, 0, 0));
+Skia.Paint.setColor(paint, Skia.Color.makeArgb(50l, 255l, 0l, 0l));
 
 let draw = (canvas: CanvasContext.t) =>
   if (_isEnabled^) {

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -71,9 +71,13 @@ let renderBorders = (~canvas, ~style, ~outerRRect, ~opacity) => {
     );
 
     let tbc = Color.multiplyAlpha(opacity, topBorderColor);
+    let tbcAlpha = Color.getAlpha(tbc);
     let lbc = Color.multiplyAlpha(opacity, leftBorderColor);
+    let lbcAlpha = Color.getAlpha(lbc);
     let rbc = Color.multiplyAlpha(opacity, rightBorderColor);
+    let rbcAlpha = Color.getAlpha(rbc);
     let bbc = Color.multiplyAlpha(opacity, bottomBorderColor);
+    let bbcAlpha = Color.getAlpha(bbc);
 
     let borderPaint = Skia.Paint.make();
     Skia.Paint.setAntiAlias(borderPaint, true);
@@ -97,7 +101,7 @@ let renderBorders = (~canvas, ~style, ~outerRRect, ~opacity) => {
     let hasTopOrBottomBorder =
       topBorderWidth !== 0. || bottomBorderWidth !== 0.;
 
-    if (leftBorderWidth != 0. && lbc.a > 0.001) {
+    if (leftBorderWidth != 0. && lbcAlpha > 0.001) {
       let _id: int = Revery_Draw.CanvasContext.save(canvas);
 
       let clippingRectangle =
@@ -133,7 +137,7 @@ let renderBorders = (~canvas, ~style, ~outerRRect, ~opacity) => {
       Revery_Draw.CanvasContext.restore(canvas);
     };
 
-    if (topBorderWidth != 0. && tbc.a > 0.001) {
+    if (topBorderWidth != 0. && tbcAlpha > 0.001) {
       let _id: int = Revery_Draw.CanvasContext.save(canvas);
 
       let clippingRectangle =
@@ -169,7 +173,7 @@ let renderBorders = (~canvas, ~style, ~outerRRect, ~opacity) => {
       Revery_Draw.CanvasContext.restore(canvas);
     };
 
-    if (rightBorderWidth != 0. && rbc.a > 0.001) {
+    if (rightBorderWidth != 0. && rbcAlpha > 0.001) {
       let _id: int = Revery_Draw.CanvasContext.save(canvas);
 
       let clippingRectangle =
@@ -205,7 +209,7 @@ let renderBorders = (~canvas, ~style, ~outerRRect, ~opacity) => {
       Revery_Draw.CanvasContext.restore(canvas);
     };
 
-    if (bottomBorderWidth != 0. && bbc.a > 0.001) {
+    if (bottomBorderWidth != 0. && bbcAlpha > 0.001) {
       let _id: int = Revery_Draw.CanvasContext.save(canvas);
 
       let clippingRectangle =
@@ -310,7 +314,8 @@ class viewNode (()) = {
     let innerRRect = renderBorders(~canvas, ~style, ~outerRRect, ~opacity);
 
     let color = Color.multiplyAlpha(opacity, style.backgroundColor);
-    if (color.a > 0.001) {
+    let colorAlpha = Color.getAlpha(color);
+    if (colorAlpha > 0.001) {
       let fill = Skia.Paint.make();
 
       // switch (style.boxShadow) {

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "97de21d20e66fb40524c87194dfe8768",
+  "checksum": "4c1521a1c8dc9de9ef96f99f4988b173",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "d15fdf1bc098ee7a9d4f4d2ab275ad2d",
+  "checksum": "c20db8561dcbaa4746b00e677efa0d38",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -1855,7 +1855,7 @@
         "@opam/conf-pkg-config@opam:1.1@67c69c0c",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9",
-        "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567@d41d8cd9"
+        "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/integers@opam:0.3.0@d6eefd3a",
@@ -2275,13 +2275,13 @@
       ],
       "devDependencies": []
     },
-    "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567@d41d8cd9": {
-      "id": "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567@d41d8cd9",
+    "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9": {
+      "id": "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9",
       "name": "@esy-ocaml/libffi",
-      "version": "github:esy-ocaml/libffi#599bc3567",
+      "version": "github:esy-ocaml/libffi#c61127d",
       "source": {
         "type": "install",
-        "source": [ "github:esy-ocaml/libffi#599bc3567" ]
+        "source": [ "github:esy-ocaml/libffi#c61127d" ]
       },
       "overrides": [],
       "dependencies": [],

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "dbb584e4fc81a1a035563ddd1e285862",
+  "checksum": "97de21d20e66fb40524c87194dfe8768",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -63,7 +63,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#53b10ee@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -159,13 +159,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#53b10ee@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#53b10ee@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#53b10ee",
+      "version": "github:revery-ui/reason-skia#0b52e17",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#53b10ee" ]
+        "source": [ "github:revery-ui/reason-skia#0b52e17" ]
       },
       "overrides": [],
       "dependencies": [

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "4c1521a1c8dc9de9ef96f99f4988b173",
+  "checksum": "d15fdf1bc098ee7a9d4f4d2ab275ad2d",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -63,7 +63,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@1.91.5003@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -159,13 +159,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#0b52e17@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#0b52e17",
+      "version": "github:revery-ui/reason-skia#668629f",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#0b52e17" ]
+        "source": [ "github:revery-ui/reason-skia#668629f" ]
       },
       "overrides": [],
       "dependencies": [

--- a/test/Core/ColorTests.re
+++ b/test/Core/ColorTests.re
@@ -74,10 +74,9 @@ describe("Color", ({describe, _}) => {
       let start = Colors.red;
       let stop = Colors.lime;
 
-      expect.equal(
-        Color.mix(~start, ~stop, ~amount=0.5),
-        Color.{r: 0.5, g: 0.5, b: 0., a: 1.},
-      );
+      let mix = Color.mix(~start, ~stop, ~amount=0.5);
+      let rgba = Color.rgba(0.5, 0.5, 0., 1.);
+      expect.bool(Color.equals(mix, rgba)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
This picks up performance improvements in https://github.com/revery-ui/reason-skia/pull/48 , so that the hot-path of setting the paint color is as fast and streamlined as it can be.

This adds a benchmark for setting paint colors:
```
|----------------------------------------------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
|  Paint: Set color                                              |  10000      |  0.000262975692749  |  0         |  0         |  30027        |  0         |  0            |
|----------------------------------------------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
```

And brings in several fixes, including streamlining our `Color.t` type to minimize allocations, such 

After the fixes:
```
|----------------------------------------------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
|  Paint: Set color                                              |  10000      |  6.48498535156e-05  |  0         |  0         |  27           |  0         |  0            |
|----------------------------------------------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
```
__TODO:__
- [x] Update once https://github.com/revery-ui/reason-skia/pull/48 is in `master`