### PR TITLE
Perf: Cache paint objects for ViewNode/TextNode

### DIFF
--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -13,6 +13,13 @@ class textNode (text: string) = {
   val mutable text = text;
   val mutable _isMeasured = false;
   val mutable _lines: list(string) = [];
+  val _textPaint = {
+    let paint = Skia.Paint.make();
+    Skia.Paint.setTextEncoding(paint, GlyphId);
+    Skia.Paint.setLcdRenderText(paint, true);
+    Skia.Paint.setAntiAlias(paint, true);
+    paint;
+  };
   inherit (class viewNode)() as _super;
   pub! draw = (parentContext: NodeDrawContext.t) => {
     let style = _super#getStyle();
@@ -24,16 +31,12 @@ class textNode (text: string) = {
     switch (Revery_Font.FontCache.load(fontFamily)) {
     | Error(_) => ()
     | Ok(font) =>
-      let paint = Skia.Paint.make();
-      Skia.Paint.setColor(paint, Color.toSkia(colorWithAppliedOpacity));
+      Skia.Paint.setColor(_textPaint, Color.toSkia(colorWithAppliedOpacity));
       Skia.Paint.setTypeface(
-        paint,
+        _textPaint,
         Revery_Font.FontCache.getSkiaTypeface(font),
       );
-      Skia.Paint.setTextEncoding(paint, GlyphId);
-      Skia.Paint.setLcdRenderText(paint, true);
-      Skia.Paint.setAntiAlias(paint, true);
-      Skia.Paint.setTextSize(paint, fontSize);
+      Skia.Paint.setTextSize(_textPaint, fontSize);
 
       let ascentPx = Text.getAscent(~fontFamily, ~fontSize, ());
       let lineHeightPx =
@@ -60,7 +63,7 @@ class textNode (text: string) = {
             |> Revery_Font.ShapeResult.getGlyphString;
 
           CanvasContext.drawText(
-            ~paint,
+            ~paint=_textPaint,
             ~x=0.,
             ~y=baselineY,
             ~text=glyphString,

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -284,7 +284,7 @@ let makeShadowImageFilter = boxShadow => {
 class viewNode (()) = {
   as _this;
   inherit (class node)() as _super;
-  val fillPaint = Skia.Paint.make();
+  val _fillPaint = Skia.Paint.make();
   pub! draw = (parentContext: NodeDrawContext.t) => {
     let dimensions = _this#measurements();
     let width = float_of_int(dimensions.width);
@@ -311,8 +311,6 @@ class viewNode (()) = {
 
     let color = Color.multiplyAlpha(opacity, style.backgroundColor);
     if (color.a > 0.001) {
-      let fill = Skia.Paint.make();
-
       // switch (style.boxShadow) {
       // | {xOffset: 0., yOffset: 0., blurRadius: 0., spreadRadius: 0., color: _} =>
       // ()
@@ -322,15 +320,15 @@ class viewNode (()) = {
               "drawing shadow..." ++ string_of_float(style.boxShadow.blurRadius),
             );*/
         let shadowImageFilter = makeShadowImageFilter(style.boxShadow);
-        Skia.Paint.setImageFilter(fill, shadowImageFilter);
+        Skia.Paint.setImageFilter(_fillPaint, shadowImageFilter);
       };
       // }
       // };
 
       let skiaColor = Color.toSkia(color);
-      Skia.Paint.setColor(fill, skiaColor);
+      Skia.Paint.setColor(_fillPaint, skiaColor);
 
-      Revery_Draw.CanvasContext.drawRRect(canvas, innerRRect, fill);
+      Revery_Draw.CanvasContext.drawRRect(canvas, innerRRect, _fillPaint);
     };
 
     _super#draw(parentContext);


### PR DESCRIPTION
Cache `Skia.Paint` objects for TextNode and ViewNode to reduce allocations on the hot render path.