### PR TITLE
Perf: Improve ViewNode draw performance

### DIFF
--- a/bench/lib/ViewNodeBench.re
+++ b/bench/lib/ViewNodeBench.re
@@ -1,0 +1,35 @@
+open BenchFramework;
+
+open Revery.Draw;
+open Revery.UI;
+open Skia;
+
+let options = Reperf.Options.create(~iterations=10000, ());
+
+let createViewNode = () => {
+  let viewNode = (new viewNode)();
+  viewNode#recalculate();
+  viewNode;
+};
+
+let makeSurface = (width, height) => {
+  let imageInfo = Skia.ImageInfo.make(width, height, Rgba8888, Premul, None);
+  Surface.makeRaster(imageInfo, 0, None);
+};
+
+let setup = () => {
+  let surface = makeSurface(800l, 600l);
+  let canvas = CanvasContext.createFromSurface(surface);
+
+  NodeDrawContext.create(~canvas, ~zIndex=0, ~opacity=1.0, ());
+};
+
+module Data = {
+  let viewNode = createViewNode();
+};
+
+let draw = context => {
+  Data.viewNode#draw(context);
+};
+
+bench(~name="ViewNode: draw single node", ~options, ~setup, ~f=draw, ());

--- a/src/Draw/CanvasContext.re
+++ b/src/Draw/CanvasContext.re
@@ -16,6 +16,12 @@ type t = {
   mutable rootTransform: option(Skia.Matrix.t),
 };
 
+let createFromSurface = (surface: Skia.Surface.t) => {
+  surface,
+  canvas: Skia.Surface.getCanvas(surface),
+  rootTransform: None,
+};
+
 let create = (window: Revery_Core.Window.t) => {
   let sdlGlInterface = Skia.Gr.Gl.Interface.makeSdl2();
   let context = Skia.Gr.Context.makeGl(Some(sdlGlInterface));

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -285,6 +285,8 @@ class viewNode (()) = {
   as _this;
   inherit (class node)() as _super;
   val _fillPaint = Skia.Paint.make();
+  val _outerRRect = Skia.RRect.make();
+  val _helperRect = Skia.Rect.makeLtrb(0., 0., 0., 0.);
   pub! draw = (parentContext: NodeDrawContext.t) => {
     let dimensions = _this#measurements();
     let width = float_of_int(dimensions.width);
@@ -299,15 +301,16 @@ class viewNode (()) = {
     Revery_Draw.CanvasContext.setMatrix(canvas, world);
 
     let borderRadius = style.borderRadius;
-    let outerRRect = Skia.RRect.make();
+    Skia.Rect.Mutable.setLtrb(~out=_helperRect, 0., 0., width, height);
     Skia.RRect.setRectXy(
-      outerRRect,
-      Skia.Rect.makeLtrb(0., 0., width, height),
+      _outerRRect,
+      _helperRect,
       borderRadius,
       borderRadius,
     );
 
-    let innerRRect = renderBorders(~canvas, ~style, ~outerRRect, ~opacity);
+    let innerRRect =
+      renderBorders(~canvas, ~style, ~outerRRect=_outerRRect, ~opacity);
 
     let color = Color.multiplyAlpha(opacity, style.backgroundColor);
     if (color.a > 0.001) {


### PR DESCRIPTION
This improves the `viewNode#draw` performance by pre-allocating some Skia objects, and adds a benchmark to track.

__Previous performance:__
```
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|  BENCHMARK                                                     |  ITERATIONS |  TIME               |  MINOR GC  |  MAJOR GC  |  MINOR ALLOC  |  PROMOTED  |  MAJOR ALLOC  |
|----------------------------------------------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
|  ViewNode: draw single node                                    |  10000      |  0.0239310264587    |  8         |  1         |  1890103      |  81246     |  81246        |
|----------------------------------------------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
```

__After pre-allocations:__
```
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|  BENCHMARK                                                     |  ITERATIONS |  TIME               |  MINOR GC  |  MAJOR GC  |  MINOR ALLOC  |  PROMOTED  |  MAJOR ALLOC  |
|----------------------------------------------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
|  ViewNode: draw single node                                    |  10000      |  0.00235795974731   |  2         |  0         |  480048       |  27        |  27           |
|----------------------------------------------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
```

Order of magnitude improvement in time measurement, and major allocations were completely removed (at least, in the tested case, with no borders).