### PR TITLE
Fix #759: Use Skia.Gr.Gl.Interface.makeNative by default

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f959ef96b0c4e7d380aa2c6052eb44c2",
+  "checksum": "b484d3f0934407c642aa49aac22723e7",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -63,7 +63,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@github:revery-ui/reason-harfbuzz#0848520@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -159,13 +159,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#668629f",
+      "version": "github:revery-ui/reason-skia#03e6acb",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#668629f" ]
+        "source": [ "github:revery-ui/reason-skia#03e6acb" ]
       },
       "overrides": [],
       "dependencies": [

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b484d3f0934407c642aa49aac22723e7",
+  "checksum": "b8c4b72bb14905b7e0707799ed730e75",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -63,7 +63,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@github:revery-ui/reason-harfbuzz#0848520@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -159,13 +159,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#03e6acb",
+      "version": "github:revery-ui/reason-skia#69743dc",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#03e6acb" ]
+        "source": [ "github:revery-ui/reason-skia#69743dc" ]
       },
       "overrides": [],
       "dependencies": [

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "203bc83fb998404500860427833688a4",
+  "checksum": "0b395738a5f1078058a45d0a0bfdd409",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -119,7 +119,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@github:revery-ui/reason-harfbuzz#0848520@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -230,13 +230,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#668629f",
+      "version": "github:revery-ui/reason-skia#03e6acb",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#668629f" ]
+        "source": [ "github:revery-ui/reason-skia#03e6acb" ]
       },
       "overrides": [],
       "dependencies": [

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "0b395738a5f1078058a45d0a0bfdd409",
+  "checksum": "1008e7d85654abd6f4cb5a8af7dd128a",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -119,7 +119,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@github:revery-ui/reason-harfbuzz#0848520@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -230,13 +230,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#03e6acb",
+      "version": "github:revery-ui/reason-skia#69743dc",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#03e6acb" ]
+        "source": [ "github:revery-ui/reason-skia#69743dc" ]
       },
       "overrides": [],
       "dependencies": [

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "3fa35141442c57932c104059900e7456",
+  "checksum": "f9c51e75e4ee1be6b951b38d1dec6d6c",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -63,7 +63,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@github:revery-ui/reason-harfbuzz#0848520@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -159,13 +159,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#668629f",
+      "version": "github:revery-ui/reason-skia#03e6acb",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#668629f" ]
+        "source": [ "github:revery-ui/reason-skia#03e6acb" ]
       },
       "overrides": [],
       "dependencies": [

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f9c51e75e4ee1be6b951b38d1dec6d6c",
+  "checksum": "1a975d8dac1406170e7598d884a2c706",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -63,7 +63,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@github:revery-ui/reason-harfbuzz#0848520@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -159,13 +159,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#03e6acb",
+      "version": "github:revery-ui/reason-skia#69743dc",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#03e6acb" ]
+        "source": [ "github:revery-ui/reason-skia#69743dc" ]
       },
       "overrides": [],
       "dependencies": [

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "8b2cb3c85a2a7b5b2a99eee00369f9df",
+  "checksum": "b2206819c649f49dfc627d5209ef3027",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -119,7 +119,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@github:revery-ui/reason-harfbuzz#0848520@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -230,13 +230,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#668629f",
+      "version": "github:revery-ui/reason-skia#03e6acb",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#668629f" ]
+        "source": [ "github:revery-ui/reason-skia#03e6acb" ]
       },
       "overrides": [],
       "dependencies": [

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b2206819c649f49dfc627d5209ef3027",
+  "checksum": "012828e74df5dd0bb4f86203694170bd",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -119,7 +119,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@github:revery-ui/reason-harfbuzz#0848520@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -230,13 +230,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#03e6acb",
+      "version": "github:revery-ui/reason-skia#69743dc",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#03e6acb" ]
+        "source": [ "github:revery-ui/reason-skia#69743dc" ]
       },
       "overrides": [],
       "dependencies": [

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "rench": "^1.9.1",
     "rebez": "github:jchavarri/rebez#03fa3b7",
     "reason-sdl2": "^2.10.3016",
-    "reason-skia": "github:revery-ui/reason-skia#668629f",
+    "reason-skia": "github:revery-ui/reason-skia#03e6acb",
     "revery-text-wrap": "github:revery-ui/revery-text-wrap#005385c",
     "timber": "*"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "rench": "^1.9.1",
     "rebez": "github:jchavarri/rebez#03fa3b7",
     "reason-sdl2": "^2.10.3016",
-    "reason-skia": "github:revery-ui/reason-skia#03e6acb",
+    "reason-skia": "github:revery-ui/reason-skia#69743dc",
     "revery-text-wrap": "github:revery-ui/revery-text-wrap#005385c",
     "timber": "*"
   },

--- a/src/Draw/CanvasContext.re
+++ b/src/Draw/CanvasContext.re
@@ -30,10 +30,10 @@ let create = (window: Revery_Core.Window.t) => {
   let interface =
     switch (Skia.Gr.Gl.Interface.makeNative()) {
     | None =>
-      Log.info("Unable to create native interface. Falling back to SDL2...");
+      Log.trace("Unable to create native interface. Falling back to SDL2...");
       Skia.Gr.Gl.Interface.makeSdl2();
     | Some(_) as nativeInterface =>
-      Log.info("Native interface created successfully.");
+      Log.trace("Native interface created successfully.");
       nativeInterface;
     };
   Log.info("Creating Skia context...");
@@ -43,7 +43,7 @@ let create = (window: Revery_Core.Window.t) => {
     Log.error("Unable to create skia context");
     None;
   | Some(glContext) =>
-    Log.info("Skia context created successfully.");
+    Log.trace("Skia context created successfully.");
     let framebufferInfo =
       Gr.Gl.FramebufferInfo.make(
         Unsigned.UInt.of_int(0),

--- a/src/Draw/CanvasContext.re
+++ b/src/Draw/CanvasContext.re
@@ -30,10 +30,10 @@ let create = (window: Revery_Core.Window.t) => {
   let interface =
     switch (Skia.Gr.Gl.Interface.makeNative()) {
     | None =>
-      Log.trace("Unable to create native interface. Falling back to SDL2...");
+      Log.debug("Unable to create native interface. Falling back to SDL2...");
       Skia.Gr.Gl.Interface.makeSdl2();
     | Some(_) as nativeInterface =>
-      Log.trace("Native interface created successfully.");
+      Log.debug("Native interface created successfully.");
       nativeInterface;
     };
   Log.info("Creating Skia context...");
@@ -43,7 +43,7 @@ let create = (window: Revery_Core.Window.t) => {
     Log.error("Unable to create skia context");
     None;
   | Some(glContext) =>
-    Log.trace("Skia context created successfully.");
+    Log.debug("Skia context created successfully.");
     let framebufferInfo =
       Gr.Gl.FramebufferInfo.make(
         Unsigned.UInt.of_int(0),

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f959ef96b0c4e7d380aa2c6052eb44c2",
+  "checksum": "b484d3f0934407c642aa49aac22723e7",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -63,7 +63,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@github:revery-ui/reason-harfbuzz#0848520@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -159,13 +159,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#668629f@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#668629f",
+      "version": "github:revery-ui/reason-skia#03e6acb",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#668629f" ]
+        "source": [ "github:revery-ui/reason-skia#03e6acb" ]
       },
       "overrides": [],
       "dependencies": [

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b484d3f0934407c642aa49aac22723e7",
+  "checksum": "b8c4b72bb14905b7e0707799ed730e75",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -63,7 +63,7 @@
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
-        "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
+        "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9",
         "reason-sdl2@2.10.3016@d41d8cd9",
         "reason-harfbuzz@github:revery-ui/reason-harfbuzz#0848520@d41d8cd9",
         "reason-gl-matrix@0.9.9306@d41d8cd9",
@@ -159,13 +159,13 @@
       ],
       "devDependencies": []
     },
-    "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9": {
-      "id": "reason-skia@github:revery-ui/reason-skia#03e6acb@d41d8cd9",
+    "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9": {
+      "id": "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9",
       "name": "reason-skia",
-      "version": "github:revery-ui/reason-skia#03e6acb",
+      "version": "github:revery-ui/reason-skia#69743dc",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/reason-skia#03e6acb" ]
+        "source": [ "github:revery-ui/reason-skia#69743dc" ]
       },
       "overrides": [],
       "dependencies": [


### PR DESCRIPTION
...and fallback to `makeSdl2` only if that fails

Picks up https://github.com/revery-ui/reason-skia/pull/51

Hopefully fixes #759 