### PR TITLE
Bugfix - OSX: Fix titlebar style on restore

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -291,6 +291,7 @@ let init = app => {
           ~width=windowWidth,
           ~height=windowHeight,
           ~maximized,
+          ~titlebarStyle=Transparent,
           ~icon=Some("revery-icon.png"),
           (),
         ),


### PR DESCRIPTION
__Issue:__ When `titlebarStyle` is set to `Transparent`, after minimize + restore (or maximize + restore), the titlebar is visible again.

__Fix:__ Reset the titlebar style on window restore.