### PR TITLE
Spring: Add enabled property to spring; fix bug with rest

### DIFF
--- a/src/UI_Hooks/Spring.re
+++ b/src/UI_Hooks/Spring.re
@@ -1,7 +1,8 @@
 module Time = Revery_Core.Time;
 module Spring = Revery_UI.Spring;
 
-let spring = (~target, ~initialState=?, ~restThreshold=0.1, options) => {
+let spring =
+    (~enabled=true, ~target, ~initialState=?, ~restThreshold=0.1, options) => {
   let initialState =
     switch (initialState) {
     | Some(state) => state
@@ -11,8 +12,11 @@ let spring = (~target, ~initialState=?, ~restThreshold=0.1, options) => {
   let%hook (previousState, setPreviousState) = Ref.ref(initialState);
 
   let isActive =
-    !Spring.isAtRest(~restThreshold, previousState)
-    || Float.abs(target -. previousState.value) > restThreshold;
+    enabled
+    && (
+      !Spring.isAtRest(~restThreshold, previousState)
+      || Float.abs(target -. previousState.value) > restThreshold
+    );
 
   let%hook (time, _) = Timer.timer(~active=isActive, ());
 
@@ -22,5 +26,7 @@ let spring = (~target, ~initialState=?, ~restThreshold=0.1, options) => {
   let setImmediately = position =>
     setPreviousState(Spring.setPosition(position, previousState));
 
-  (state.value, setImmediately);
+  let v = isActive ? state.value : target;
+
+  (v, setImmediately);
 };


### PR DESCRIPTION
This change adds an `enabled` property to the spring.

In addition, I noticed a bug with the `restThreshold` - once the rest threshold has been reached, there would be no further animation. This is OK for low values of `restThreshold`, where the spring would've been close to its final destination, but for higher values, the spring may stop animating far away from the destination. This clamps the spring in the case there is no animation (ie, if it is resting, or not active).