### PR TITLE
Bugfix: Ensure timer is always disposed

### DIFF
--- a/src/Core/Tick.re
+++ b/src/Core/Tick.re
@@ -38,6 +38,10 @@ module Make = (ClockImpl: Clock) => {
   let _scheduledTickers: ref(list(tickFunction)) = ref([]);
   let _cancelledTickers: ref(IntMap.t(bool)) = ref(IntMap.empty);
 
+  let getActiveTickers = () => {
+    _activeTickers^ |> List.map(tf => tf.id);
+  };
+
   let _filterMap = (v: list(option('a))): list('a) => {
     let rec f = v =>
       switch (v) {

--- a/src/UI_Hooks/Timer.re
+++ b/src/UI_Hooks/Timer.re
@@ -13,7 +13,7 @@ let timer = (~tickRate=Time.zero, ~active=true, ()) => {
   let%hook (time, setTime) = reducer(~initialState=Time.now(), t => t);
   let%hook startTime = Ref.ref(time);
 
-  // We have to manually track disposal, too, to workaround a bug with
+  // HACK: We have to manually track disposal, too, to workaround a bug with
   // multiple timer hooks. This shouldn't be necessary - the `effect` hook
   // without `OnMountAndIf` should be handling disposal completely for us!
 
@@ -26,6 +26,9 @@ let timer = (~tickRate=Time.zero, ~active=true, ()) => {
 
   // See the test case in:
   // test/UI/HooksTest.re that manifests this bug
+
+  // Ideally, we can fix the underlying bug (perhaps in the effect hook),
+  // and remove this hack while keeping all those tests green.
 
   // It's easy to hit when there are multiple springs associated with a component,
   // which each use an underlying timer.

--- a/test/UI/HooksTest.re
+++ b/test/UI/HooksTest.re
@@ -1,0 +1,116 @@
+open Revery_UI;
+open Revery_UI_Primitives;
+
+module Tick = Revery_Core.Tick;
+module Hooks = Revery_UI_Hooks;
+
+open TestFramework;
+
+let getTickerCount = () => Tick.getActiveTickers() |> List.length;
+
+module SingleTimer = {
+  let%component make = (~timerActive, ()) => {
+    let%hook (_dt, _reset) = Hooks.timer(~active=timerActive, ());
+
+    <View />;
+  };
+};
+
+module DoubleTimer = {
+  let%component make = (~timer1Active, ~timer2Active, ()) => {
+    let%hook (_dt, _reset) = Hooks.timer(~active=timer1Active, ());
+    let%hook (_dt, _reset) = Hooks.timer(~active=timer2Active, ());
+    <View />;
+  };
+};
+
+describe("Hooks", ({describe, _}) => {
+  describe("Timer", ({test, _}) => {
+    test("Single: Timer starts and stops", ({expect, _}) => {
+      expect.int(getTickerCount()).toBe(0);
+
+      let rootNode = (new viewNode)();
+      let container = Container.create(rootNode);
+
+      let container =
+        Container.update(container, <SingleTimer timerActive=true />);
+      Tick.pump();
+      expect.int(getTickerCount()).toBe(1);
+      let container =
+        Container.update(container, <SingleTimer timerActive=false />);
+      Tick.pump();
+      expect.int(getTickerCount()).toBe(0);
+
+      let container =
+        Container.update(container, <SingleTimer timerActive=true />);
+      Tick.pump();
+      expect.int(getTickerCount()).toBe(1);
+
+      let _container =
+        Container.update(container, <SingleTimer timerActive=false />);
+      Tick.pump();
+      expect.int(getTickerCount()).toBe(0);
+    });
+
+    test("Single: Timer starts and stops, in between pumps", ({expect, _}) => {
+      expect.int(getTickerCount()).toBe(0);
+
+      let rootNode = (new viewNode)();
+      let container = Container.create(rootNode);
+
+      let container =
+        Container.update(container, <SingleTimer timerActive=true />);
+      Tick.pump();
+      expect.int(getTickerCount()).toBe(1);
+
+      let container =
+        Container.update(container, <SingleTimer timerActive=false />);
+      let container =
+        Container.update(container, <SingleTimer timerActive=true />);
+
+      let _container =
+        Container.update(container, <SingleTimer timerActive=false />);
+      Tick.pump();
+      expect.int(getTickerCount()).toBe(0);
+    });
+
+    test("Double: Timer starts and stops", ({expect, _}) => {
+      expect.int(getTickerCount()).toBe(0);
+
+      let rootNode = (new viewNode)();
+      let container = Container.create(rootNode);
+
+      let container =
+        Container.update(
+          container,
+          <DoubleTimer timer1Active=true timer2Active=true />,
+        );
+      Tick.pump();
+      expect.int(getTickerCount()).toBe(2);
+      let container =
+        Container.update(
+          container,
+          <DoubleTimer timer1Active=false timer2Active=true />,
+        );
+      Tick.pump();
+      expect.int(getTickerCount()).toBe(1);
+      let container =
+        Container.update(
+          container,
+          <DoubleTimer timer1Active=true timer2Active=false />,
+        );
+      Tick.pump();
+      expect.int(getTickerCount()).toBe(1);
+
+      // Without the 'hack' to force disposal of the timers in Timer.re,
+      // this particular case fails - it will leaving a hanging timer.
+      let _container =
+        Container.update(
+          container,
+          <DoubleTimer timer1Active=false timer2Active=false />,
+        );
+      Tick.pump();
+      expect.int(getTickerCount()).toBe(0);
+    });
+  })
+});

--- a/test/UI/dune
+++ b/test/UI/dune
@@ -3,4 +3,4 @@
     (library_flags (-linkall -g))
     (modules (:standard))
     (preprocess (pps brisk-reconciler.ppx))
-    (libraries Revery_UI Revery_UI_Primitives Revery_Math rely.lib))
+    (libraries Revery_UI Revery_UI_Primitives Revery_UI_Hooks Revery_Math rely.lib))


### PR DESCRIPTION
While experimenting with a cursor animation in `revery-terminal` (https://github.com/revery-ui/revery-terminal/pull/1) - I saw there was a pretty bad bug... Sometimes the spring hook would never settle into a rest state, and continually redraw - even when the animation was completed. This was pretty easy to repro - all it would take is running a `git status` or type commands quickly, but it was intermittent.

I did some logging in the spring hook here: https://github.com/revery-ui/revery/blob/a525e7f07d1417791c6ac2b574ed7fb9e68ceaeb/src/UI_Hooks/Spring.re#L14

And saw that `isActive` was being set to `false` for both springs (the x & y springs), and the `Timer.timer` hook was getting `isActive` of `false`... but one of the timers was still ticking. So it seems like the root issue is in the `Timer.timer` hook - the spring hook is behaving correctly.

Note that this reproduced even before bringing in https://github.com/revery-ui/revery/pull/773 - I brought that in hoping it would fix it 😄 I believe that this bug has occurred in Onivim 2 as well - but less frequently. I have observed cases where we would start re-rendering continuously, and the spring hook could be the culprit.

I was able to fix this by ensuring that we always dispose a previous hook. There may  be a bug somewhere in the way cleanup is occurring in the effect hook: https://github.com/briskml/brisk-reconciler/blob/c22c693099c16a39ad115569c599ddba75cb0736/lib/Hooks.re#L237

It could even be an interplay of the timing when we flush pending effects vs when state changes.

In any case, this 'brute force' fix is to check a previous dispose and run it before we set a new cleanup handler. This seems to fix the issue, but could potentially have re-entrancy issues (although it is safe to call `dispose` an interval multiple times). 

