### PR TITLE
API - Font Measurements: Make smoothing type explicitly required

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -66,7 +66,7 @@
         "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
         "reason-harfbuzz@1.91.5004@d41d8cd9",
-        "reason-gl-matrix@0.9.9306@d41d8cd9",
+        "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
@@ -192,7 +192,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.3.0@d41d8cd9", "reason-gl-matrix@0.9.9306@d41d8cd9",
+        "refmterr@3.3.0@d41d8cd9", "reason-gl-matrix@0.9.9307@d41d8cd9",
         "esy-sdl2@2.0.10005@d41d8cd9",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
         "@opam/lwt_ppx@opam:2.0.0@9a61dd37", "@opam/lwt@opam:4.5.0@677655b4",
@@ -217,20 +217,20 @@
       ],
       "devDependencies": []
     },
-    "reason-gl-matrix@0.9.9306@d41d8cd9": {
-      "id": "reason-gl-matrix@0.9.9306@d41d8cd9",
+    "reason-gl-matrix@0.9.9307@d41d8cd9": {
+      "id": "reason-gl-matrix@0.9.9307@d41d8cd9",
       "name": "reason-gl-matrix",
-      "version": "0.9.9306",
+      "version": "0.9.9307",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-gl-matrix/-/reason-gl-matrix-0.9.9306.tgz#sha1:130c3db5ab9a405a85e3371ab13f99649050489e"
+          "archive:https://registry.npmjs.org/reason-gl-matrix/-/reason-gl-matrix-0.9.9307.tgz#sha1:5dd73573d7f5eecc2383d4a72ed4927520826631"
         ]
       },
       "overrides": [],
       "dependencies": [
         "@opam/js_of_ocaml-compiler@opam:3.5.0@9ea7292f",
-        "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/reason@3.5.2@d41d8cd9"
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -122,7 +122,7 @@
         "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
         "reason-harfbuzz@1.91.5004@d41d8cd9",
-        "reason-gl-matrix@0.9.9306@d41d8cd9",
+        "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "http-server@0.12.1@d41d8cd9",
         "flex@1.2.2@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
@@ -263,7 +263,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.3.0@d41d8cd9", "reason-gl-matrix@0.9.9306@d41d8cd9",
+        "refmterr@3.3.0@d41d8cd9", "reason-gl-matrix@0.9.9307@d41d8cd9",
         "esy-sdl2@2.0.10005@d41d8cd9",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
         "@opam/lwt_ppx@opam:2.0.0@9a61dd37", "@opam/lwt@opam:4.5.0@677655b4",
@@ -288,20 +288,20 @@
       ],
       "devDependencies": []
     },
-    "reason-gl-matrix@0.9.9306@d41d8cd9": {
-      "id": "reason-gl-matrix@0.9.9306@d41d8cd9",
+    "reason-gl-matrix@0.9.9307@d41d8cd9": {
+      "id": "reason-gl-matrix@0.9.9307@d41d8cd9",
       "name": "reason-gl-matrix",
-      "version": "0.9.9306",
+      "version": "0.9.9307",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-gl-matrix/-/reason-gl-matrix-0.9.9306.tgz#sha1:130c3db5ab9a405a85e3371ab13f99649050489e"
+          "archive:https://registry.npmjs.org/reason-gl-matrix/-/reason-gl-matrix-0.9.9307.tgz#sha1:5dd73573d7f5eecc2383d4a72ed4927520826631"
         ]
       },
       "overrides": [],
       "dependencies": [
         "@opam/js_of_ocaml-compiler@opam:3.5.0@9ea7292f",
-        "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/reason@3.5.2@d41d8cd9"
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -66,7 +66,7 @@
         "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
         "reason-harfbuzz@1.91.5004@d41d8cd9",
-        "reason-gl-matrix@0.9.9306@d41d8cd9",
+        "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
@@ -192,7 +192,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.3.0@d41d8cd9", "reason-gl-matrix@0.9.9306@d41d8cd9",
+        "refmterr@3.3.0@d41d8cd9", "reason-gl-matrix@0.9.9307@d41d8cd9",
         "esy-sdl2@2.0.10005@d41d8cd9",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
         "@opam/lwt_ppx@opam:2.0.0@9a61dd37", "@opam/lwt@opam:4.5.0@677655b4",
@@ -217,20 +217,20 @@
       ],
       "devDependencies": []
     },
-    "reason-gl-matrix@0.9.9306@d41d8cd9": {
-      "id": "reason-gl-matrix@0.9.9306@d41d8cd9",
+    "reason-gl-matrix@0.9.9307@d41d8cd9": {
+      "id": "reason-gl-matrix@0.9.9307@d41d8cd9",
       "name": "reason-gl-matrix",
-      "version": "0.9.9306",
+      "version": "0.9.9307",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-gl-matrix/-/reason-gl-matrix-0.9.9306.tgz#sha1:130c3db5ab9a405a85e3371ab13f99649050489e"
+          "archive:https://registry.npmjs.org/reason-gl-matrix/-/reason-gl-matrix-0.9.9307.tgz#sha1:5dd73573d7f5eecc2383d4a72ed4927520826631"
         ]
       },
       "overrides": [],
       "dependencies": [
         "@opam/js_of_ocaml-compiler@opam:3.5.0@9ea7292f",
-        "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/reason@3.5.2@d41d8cd9"
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -122,7 +122,7 @@
         "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
         "reason-harfbuzz@1.91.5004@d41d8cd9",
-        "reason-gl-matrix@0.9.9306@d41d8cd9",
+        "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "http-server@0.12.1@d41d8cd9",
         "flex@1.2.2@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
@@ -263,7 +263,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.3.0@d41d8cd9", "reason-gl-matrix@0.9.9306@d41d8cd9",
+        "refmterr@3.3.0@d41d8cd9", "reason-gl-matrix@0.9.9307@d41d8cd9",
         "esy-sdl2@2.0.10005@d41d8cd9",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
         "@opam/lwt_ppx@opam:2.0.0@9a61dd37", "@opam/lwt@opam:4.5.0@677655b4",
@@ -288,20 +288,20 @@
       ],
       "devDependencies": []
     },
-    "reason-gl-matrix@0.9.9306@d41d8cd9": {
-      "id": "reason-gl-matrix@0.9.9306@d41d8cd9",
+    "reason-gl-matrix@0.9.9307@d41d8cd9": {
+      "id": "reason-gl-matrix@0.9.9307@d41d8cd9",
       "name": "reason-gl-matrix",
-      "version": "0.9.9306",
+      "version": "0.9.9307",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-gl-matrix/-/reason-gl-matrix-0.9.9306.tgz#sha1:130c3db5ab9a405a85e3371ab13f99649050489e"
+          "archive:https://registry.npmjs.org/reason-gl-matrix/-/reason-gl-matrix-0.9.9307.tgz#sha1:5dd73573d7f5eecc2383d4a72ed4927520826631"
         ]
       },
       "overrides": [],
       "dependencies": [
         "@opam/js_of_ocaml-compiler@opam:3.5.0@9ea7292f",
-        "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/reason@3.5.2@d41d8cd9"
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },

--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -29,11 +29,11 @@ type dimensions = {
   height: float,
 };
 
-let measureCharWidth = (~fontFamily, ~fontSize, char) => {
+let measureCharWidth = (~smoothing, ~fontFamily, ~fontSize, char) => {
   switch (FontCache.load(fontFamily)) {
   | Ok(font) =>
     let text = String.make(1, char);
-    let dimensions = FontRenderer.measure(font, fontSize, text);
+    let dimensions = FontRenderer.measure(~smoothing, font, fontSize, text);
     dimensions.width;
   | Error(_) => 0.
   };
@@ -64,10 +64,10 @@ let getDescent = (~fontFamily, ~fontSize, ()) => {
   metrics.descent;
 };
 
-let measure = (~fontFamily, ~fontSize, text) => {
+let measure = (~smoothing, ~fontFamily, ~fontSize, text) => {
   switch (FontCache.load(fontFamily)) {
   // TODO: Properly implement
-  | Ok(font) => FontRenderer.measure(font, fontSize, text)
+  | Ok(font) => FontRenderer.measure(~smoothing, font, fontSize, text)
 
   | Error(_) => {width: 0., height: 0.}
   };

--- a/src/Font/FontRenderer.re
+++ b/src/Font/FontRenderer.re
@@ -15,8 +15,6 @@ let measure = (~smoothing: Smoothing.t, font, size, text: string) => {
 
   Smoothing.setPaint(~smoothing, paint);
 
-  Skia.Paint.setTextEncoding(paint, GlyphId);
-
   Skia.Paint.setTypeface(paint, skiaFace);
   Skia.Paint.setTextSize(paint, size);
   let width = Skia.Paint.measureText(paint, glyphString, None);

--- a/src/Font/FontRenderer.re
+++ b/src/Font/FontRenderer.re
@@ -3,20 +3,23 @@ type measureResult = {
   height: float,
 };
 
-let paint = Skia.Paint.make();
-Skia.Paint.setTextEncoding(paint, GlyphId);
 
-let measure = (~smoothing: Smoothing.t, font, size, text: string) => {
-  let {height, _}: FontMetrics.t = FontCache.getMetrics(font, size);
-  let skiaFace = FontCache.getSkiaTypeface(font);
+let measure = {
+  let paint = Skia.Paint.make();
+  Skia.Paint.setTextEncoding(paint, GlyphId);
 
-  let glyphString =
-    text |> FontCache.shape(font) |> ShapeResult.getGlyphString;
+  (~smoothing: Smoothing.t, font, size, text: string) => {
+    let {height, _}: FontMetrics.t = FontCache.getMetrics(font, size);
+    let skiaFace = FontCache.getSkiaTypeface(font);
 
-  Smoothing.setPaint(~smoothing, paint);
+    let glyphString =
+      text |> FontCache.shape(font) |> ShapeResult.getGlyphString;
 
-  Skia.Paint.setTypeface(paint, skiaFace);
-  Skia.Paint.setTextSize(paint, size);
-  let width = Skia.Paint.measureText(paint, glyphString, None);
-  {height, width};
+    Smoothing.setPaint(~smoothing, paint);
+
+    Skia.Paint.setTypeface(paint, skiaFace);
+    Skia.Paint.setTextSize(paint, size);
+    let width = Skia.Paint.measureText(paint, glyphString, None);
+    {height, width};
+  };
 };

--- a/src/Font/FontRenderer.re
+++ b/src/Font/FontRenderer.re
@@ -6,15 +6,15 @@ type measureResult = {
 let paint = Skia.Paint.make();
 Skia.Paint.setTextEncoding(paint, GlyphId);
 
-let measure = (font, size, text: string) => {
+let measure = (~smoothing: Smoothing.t, font, size, text: string) => {
   let {height, _}: FontMetrics.t = FontCache.getMetrics(font, size);
   let skiaFace = FontCache.getSkiaTypeface(font);
 
   let glyphString =
     text |> FontCache.shape(font) |> ShapeResult.getGlyphString;
 
-  Skia.Paint.setLcdRenderText(paint, true);
-  Skia.Paint.setAntiAlias(paint, true);
+  Smoothing.setPaint(~smoothing, paint);
+
   Skia.Paint.setTextEncoding(paint, GlyphId);
 
   Skia.Paint.setTypeface(paint, skiaFace);

--- a/src/Font/FontRenderer.re
+++ b/src/Font/FontRenderer.re
@@ -3,7 +3,6 @@ type measureResult = {
   height: float,
 };
 
-
 let measure = {
   let paint = Skia.Paint.make();
   Skia.Paint.setTextEncoding(paint, GlyphId);

--- a/src/Font/Revery_Font.re
+++ b/src/Font/Revery_Font.re
@@ -11,6 +11,7 @@ module FontMetrics = FontMetrics;
 module FontCache = FontCache;
 module FontRenderer = FontRenderer;
 module ShapeResult = ShapeResult;
+module Smoothing = Smoothing;
 
 type t = FontCache.t;
 

--- a/src/Font/Smoothing.re
+++ b/src/Font/Smoothing.re
@@ -1,0 +1,29 @@
+open Revery_Core;
+
+type t =
+  | None
+  | Antialiased
+  | SubpixelAntialiased;
+
+let default =
+  switch (Environment.os) {
+  | Windows => SubpixelAntialiased
+  // On OSX, default to non-subpixel for Retina displays.
+  // On Linux, subpixel does not reliably set subpixel rendering,
+  // so default to false and make it opt-in
+  | _ => Antialiased
+  };
+
+let setPaint = (~smoothing: t, paint: Skia.Paint.t) => {
+  switch (smoothing) {
+  | None =>
+    Skia.Paint.setAntiAlias(paint, false);
+    Skia.Paint.setSubpixelText(paint, false);
+  | Antialiased =>
+    Skia.Paint.setAntiAlias(paint, true);
+    Skia.Paint.setSubpixelText(paint, false);
+  | SubpixelAntialiased =>
+    Skia.Paint.setAntiAlias(paint, true);
+    Skia.Paint.setSubpixelText(paint, true);
+  };
+};

--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -232,9 +232,13 @@ let%component make =
     Option.value(cursorPosition, ~default=state.cursorPosition)
     |> min(String.length(value));
 
+  // TODO: Expose as argument
+  let smoothing = Revery_Font.Smoothing.default;
+
   let measureTextWidth = text => {
     let dimensions =
       Revery_Draw.Text.measure(
+        ~smoothing,
         ~fontFamily=textAttrs.fontFamily,
         ~fontSize=textAttrs.fontSize,
         text,
@@ -366,6 +370,7 @@ let%component make =
     <Text
       ref={node => textRef := Some(node)}
       text={showPlaceholder ? placeholder : value}
+      smoothing
       style={Styles.text(
         ~showPlaceholder,
         ~scrollOffset,

--- a/src/UI_Primitives/Text.re
+++ b/src/UI_Primitives/Text.re
@@ -15,6 +15,7 @@ let%nativeComponent make =
                       ~ref=?,
                       ~style=emptyTextStyle,
                       ~text="",
+                      ~smoothing=Revery_Font.Smoothing.default,
                       ~children=React.empty,
                       (),
                       hooks,
@@ -38,6 +39,7 @@ let%nativeComponent make =
       let node = PrimitiveNodeFactory.get().createTextNode(text);
       node#setEvents(events);
       node#setStyle(styles);
+      node#setSmoothing(smoothing);
       Obj.magic(node);
     },
     configureInstance: (~isFirstRender as _, node) => {
@@ -61,6 +63,7 @@ let%nativeComponent make =
       tn#setEvents(events);
       tn#setStyle(styles);
       tn#setText(text);
+      tn#setSmoothing(smoothing);
       node;
     },
     children,

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -66,7 +66,7 @@
         "reason-skia@github:revery-ui/reason-skia#69743dc@d41d8cd9",
         "reason-sdl2@2.10.3017@d41d8cd9",
         "reason-harfbuzz@1.91.5004@d41d8cd9",
-        "reason-gl-matrix@0.9.9306@d41d8cd9",
+        "reason-gl-matrix@0.9.9307@d41d8cd9",
         "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
@@ -192,7 +192,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.3.0@d41d8cd9", "reason-gl-matrix@0.9.9306@d41d8cd9",
+        "refmterr@3.3.0@d41d8cd9", "reason-gl-matrix@0.9.9307@d41d8cd9",
         "esy-sdl2@2.0.10005@d41d8cd9",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9",
         "@opam/lwt_ppx@opam:2.0.0@9a61dd37", "@opam/lwt@opam:4.5.0@677655b4",
@@ -217,20 +217,20 @@
       ],
       "devDependencies": []
     },
-    "reason-gl-matrix@0.9.9306@d41d8cd9": {
-      "id": "reason-gl-matrix@0.9.9306@d41d8cd9",
+    "reason-gl-matrix@0.9.9307@d41d8cd9": {
+      "id": "reason-gl-matrix@0.9.9307@d41d8cd9",
       "name": "reason-gl-matrix",
-      "version": "0.9.9306",
+      "version": "0.9.9307",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-gl-matrix/-/reason-gl-matrix-0.9.9306.tgz#sha1:130c3db5ab9a405a85e3371ab13f99649050489e"
+          "archive:https://registry.npmjs.org/reason-gl-matrix/-/reason-gl-matrix-0.9.9307.tgz#sha1:5dd73573d7f5eecc2383d4a72ed4927520826631"
         ]
       },
       "overrides": [],
       "dependencies": [
         "@opam/js_of_ocaml-compiler@opam:3.5.0@9ea7292f",
-        "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/reason@3.5.2@d41d8cd9"
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },


### PR DESCRIPTION
This is the revery-side fix for: https://github.com/onivim/oni2/issues/1364

The measurement / metrics of character width are impacted by the font smoothing settings (specifically, whether subpixel text is allowed). 

Because this is an important consideration for measurements, we should make our measurement APIs take a required argument for this - to ensure the caller has considered the smoothing type.