### PR TITLE
Dependency: timber -> 1.0.0

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "c26d11c7a764289c4d28729dbe44203d",
+  "checksum": "764431ed8b041c356f0f40af3961fa67",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -17,23 +17,6 @@
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
-    },
-    "timber@github:glennsl/timber#ae065bb@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#ae065bb@d41d8cd9",
-      "name": "timber",
-      "version": "github:glennsl/timber#ae065bb",
-      "source": {
-        "type": "install",
-        "source": [ "github:glennsl/timber#ae065bb" ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/logs@opam:0.7.0@1d03143e",
-        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
-        "@esy-ocaml/reason@3.5.2@d41d8cd9"
-      ],
-      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
     "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9": {
       "id":
@@ -59,7 +42,6 @@
       },
       "overrides": [ "bench.json" ],
       "dependencies": [
-        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
@@ -76,7 +58,7 @@
         "@opam/js_of_ocaml-lwt@opam:3.5.2@6ea3e3c2",
         "@opam/js_of_ocaml-compiler@opam:3.5.0@9ea7292f",
         "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
-        "@esy-ocaml/reason@3.5.2@d41d8cd9",
+        "@glennsl/timber@1.0.0@d41d8cd9", "@esy-ocaml/reason@3.5.2@d41d8cd9",
         "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#34e5991@d41d8cd9"
       ],
       "devDependencies": [
@@ -2308,6 +2290,25 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/base-bytes@opam:base@19d0c2ff"
       ]
+    },
+    "@glennsl/timber@1.0.0@d41d8cd9": {
+      "id": "@glennsl/timber@1.0.0@d41d8cd9",
+      "name": "@glennsl/timber",
+      "version": "1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@glennsl/timber/-/timber-1.0.0.tgz#sha1:4fc919f19b7849d9877d842008b5960e5a502123"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
+      ],
+      "devDependencies": []
     },
     "@esy-ocaml/substs@0.0.1@d41d8cd9": {
       "id": "@esy-ocaml/substs@0.0.1@d41d8cd9",

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a6802ede6b456d9d19287dd973ae5cc5",
+  "checksum": "1f1b0ff59122c7ba1cefd5fb18b63a78",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -60,23 +60,6 @@
       "dependencies": [ "qs@6.9.1@d41d8cd9" ],
       "devDependencies": []
     },
-    "timber@github:glennsl/timber#ae065bb@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#ae065bb@d41d8cd9",
-      "name": "timber",
-      "version": "github:glennsl/timber#ae065bb",
-      "source": {
-        "type": "install",
-        "source": [ "github:glennsl/timber#ae065bb" ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/logs@opam:0.7.0@1d03143e",
-        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
-        "@esy-ocaml/reason@3.5.2@d41d8cd9"
-      ],
-      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
-    },
     "secure-compare@3.0.1@d41d8cd9": {
       "id": "secure-compare@3.0.1@d41d8cd9",
       "name": "secure-compare",
@@ -115,7 +98,6 @@
       },
       "overrides": [ "doc.json" ],
       "dependencies": [
-        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
@@ -133,7 +115,7 @@
         "@opam/js_of_ocaml-lwt@opam:3.5.2@6ea3e3c2",
         "@opam/js_of_ocaml-compiler@opam:3.5.0@9ea7292f",
         "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
-        "@esy-ocaml/reason@3.5.2@d41d8cd9",
+        "@glennsl/timber@1.0.0@d41d8cd9", "@esy-ocaml/reason@3.5.2@d41d8cd9",
         "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#34e5991@d41d8cd9"
       ],
       "devDependencies": [
@@ -2737,6 +2719,25 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/base-bytes@opam:base@19d0c2ff"
       ]
+    },
+    "@glennsl/timber@1.0.0@d41d8cd9": {
+      "id": "@glennsl/timber@1.0.0@d41d8cd9",
+      "name": "@glennsl/timber",
+      "version": "1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@glennsl/timber/-/timber-1.0.0.tgz#sha1:4fc919f19b7849d9877d842008b5960e5a502123"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
+      ],
+      "devDependencies": []
     },
     "@esy-ocaml/substs@0.0.1@d41d8cd9": {
       "id": "@esy-ocaml/substs@0.0.1@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b26ddd765765a48774135341da0355d7",
+  "checksum": "9131bc15ddc9f0ba59f5a94d11adee05",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -17,23 +17,6 @@
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
-    },
-    "timber@github:glennsl/timber#ae065bb@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#ae065bb@d41d8cd9",
-      "name": "timber",
-      "version": "github:glennsl/timber#ae065bb",
-      "source": {
-        "type": "install",
-        "source": [ "github:glennsl/timber#ae065bb" ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/logs@opam:0.7.0@1d03143e",
-        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
-        "@esy-ocaml/reason@3.5.2@d41d8cd9"
-      ],
-      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
     "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9": {
       "id":
@@ -59,7 +42,6 @@
       },
       "overrides": [],
       "dependencies": [
-        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
@@ -76,7 +58,7 @@
         "@opam/js_of_ocaml-lwt@opam:3.5.2@6ea3e3c2",
         "@opam/js_of_ocaml-compiler@opam:3.5.0@9ea7292f",
         "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
-        "@esy-ocaml/reason@3.5.2@d41d8cd9",
+        "@glennsl/timber@1.0.0@d41d8cd9", "@esy-ocaml/reason@3.5.2@d41d8cd9",
         "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#34e5991@d41d8cd9"
       ],
       "devDependencies": [
@@ -2308,6 +2290,25 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/base-bytes@opam:base@19d0c2ff"
       ]
+    },
+    "@glennsl/timber@1.0.0@d41d8cd9": {
+      "id": "@glennsl/timber@1.0.0@d41d8cd9",
+      "name": "@glennsl/timber",
+      "version": "1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@glennsl/timber/-/timber-1.0.0.tgz#sha1:4fc919f19b7849d9877d842008b5960e5a502123"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
+      ],
+      "devDependencies": []
     },
     "@esy-ocaml/substs@0.0.1@d41d8cd9": {
       "id": "@esy-ocaml/substs@0.0.1@d41d8cd9",

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "d7d8fe7d76c7dc5d4f9bdd6d606f9508",
+  "checksum": "a7e3db9873851b771bc15a915f0478af",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -60,23 +60,6 @@
       "dependencies": [ "qs@6.9.1@d41d8cd9" ],
       "devDependencies": []
     },
-    "timber@github:glennsl/timber#ae065bb@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#ae065bb@d41d8cd9",
-      "name": "timber",
-      "version": "github:glennsl/timber#ae065bb",
-      "source": {
-        "type": "install",
-        "source": [ "github:glennsl/timber#ae065bb" ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/logs@opam:0.7.0@1d03143e",
-        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
-        "@esy-ocaml/reason@3.5.2@d41d8cd9"
-      ],
-      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
-    },
     "secure-compare@3.0.1@d41d8cd9": {
       "id": "secure-compare@3.0.1@d41d8cd9",
       "name": "secure-compare",
@@ -115,7 +98,6 @@
       },
       "overrides": [ "js.json" ],
       "dependencies": [
-        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
@@ -133,7 +115,7 @@
         "@opam/js_of_ocaml-lwt@opam:3.5.2@6ea3e3c2",
         "@opam/js_of_ocaml-compiler@opam:3.5.0@9ea7292f",
         "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
-        "@esy-ocaml/reason@3.5.2@d41d8cd9",
+        "@glennsl/timber@1.0.0@d41d8cd9", "@esy-ocaml/reason@3.5.2@d41d8cd9",
         "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#34e5991@d41d8cd9"
       ],
       "devDependencies": [
@@ -2704,6 +2686,25 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/base-bytes@opam:base@19d0c2ff"
       ]
+    },
+    "@glennsl/timber@1.0.0@d41d8cd9": {
+      "id": "@glennsl/timber@1.0.0@d41d8cd9",
+      "name": "@glennsl/timber",
+      "version": "1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@glennsl/timber/-/timber-1.0.0.tgz#sha1:4fc919f19b7849d9877d842008b5960e5a502123"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
+      ],
+      "devDependencies": []
     },
     "@esy-ocaml/substs@0.0.1@d41d8cd9": {
       "id": "@esy-ocaml/substs@0.0.1@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -56,13 +56,12 @@
     "reason-sdl2": "^2.10.3016",
     "reason-skia": "github:revery-ui/reason-skia#69743dc",
     "revery-text-wrap": "github:revery-ui/revery-text-wrap#005385c",
-    "timber": "*"
+    "@glennsl/timber": "1.0.0"
   },
   "resolutions": {
     "@esy-ocaml/libffi": "esy-ocaml/libffi#c61127d",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def755",
-    "@opam/cmdliner": "1.0.2",
-    "timber": "glennsl/timber#ae065bb"
+    "@opam/cmdliner": "1.0.2"
   },
   "devDependencies": {
     "ocaml": "~4.8",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "c26d11c7a764289c4d28729dbe44203d",
+  "checksum": "764431ed8b041c356f0f40af3961fa67",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -17,23 +17,6 @@
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
-    },
-    "timber@github:glennsl/timber#ae065bb@d41d8cd9": {
-      "id": "timber@github:glennsl/timber#ae065bb@d41d8cd9",
-      "name": "timber",
-      "version": "github:glennsl/timber#ae065bb",
-      "source": {
-        "type": "install",
-        "source": [ "github:glennsl/timber#ae065bb" ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
-        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/logs@opam:0.7.0@1d03143e",
-        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
-        "@esy-ocaml/reason@3.5.2@d41d8cd9"
-      ],
-      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
     "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9": {
       "id":
@@ -59,7 +42,6 @@
       },
       "overrides": [ "test.json" ],
       "dependencies": [
-        "timber@github:glennsl/timber#ae065bb@d41d8cd9",
         "revery-text-wrap@github:revery-ui/revery-text-wrap#005385c@d41d8cd9",
         "reperf@1.5.0@d41d8cd9", "rench@1.9.1@d41d8cd9",
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
@@ -76,7 +58,7 @@
         "@opam/js_of_ocaml-lwt@opam:3.5.2@6ea3e3c2",
         "@opam/js_of_ocaml-compiler@opam:3.5.0@9ea7292f",
         "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
-        "@esy-ocaml/reason@3.5.2@d41d8cd9",
+        "@glennsl/timber@1.0.0@d41d8cd9", "@esy-ocaml/reason@3.5.2@d41d8cd9",
         "@brisk/brisk-reconciler@github:briskml/brisk-reconciler#34e5991@d41d8cd9"
       ],
       "devDependencies": [
@@ -2308,6 +2290,25 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/base-bytes@opam:base@19d0c2ff"
       ]
+    },
+    "@glennsl/timber@1.0.0@d41d8cd9": {
+      "id": "@glennsl/timber@1.0.0@d41d8cd9",
+      "name": "@glennsl/timber",
+      "version": "1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@glennsl/timber/-/timber-1.0.0.tgz#sha1:4fc919f19b7849d9877d842008b5960e5a502123"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.3.0@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/fmt@opam:0.8.8@01c3a23c", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
+      ],
+      "devDependencies": []
     },
     "@esy-ocaml/substs@0.0.1@d41d8cd9": {
       "id": "@esy-ocaml/substs@0.0.1@d41d8cd9",


### PR DESCRIPTION
Finally got timber published. Tried to publish it to opam first, since I think that's where it belongs and since there's already an npm package of the same name, but I'm unable to authenticate with GitHub using 2FA for some unknown reason, so npm it is! It's now published as `@glennsl/timber`.