### PR TITLE
Dependency: reason-font-manager -> 2.0.2

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "764431ed8b041c356f0f40af3961fa67",
+  "checksum": "ec20787191c277c226eb6df590a38b3f",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -49,7 +49,7 @@
         "reason-sdl2@2.10.3017@d41d8cd9",
         "reason-harfbuzz@1.91.5004@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
-        "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
+        "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/ppx_deriving@opam:4.4.1@208c6c8f",
@@ -216,14 +216,14 @@
       ],
       "devDependencies": []
     },
-    "reason-font-manager@2.0.1@d41d8cd9": {
-      "id": "reason-font-manager@2.0.1@d41d8cd9",
+    "reason-font-manager@2.0.2@d41d8cd9": {
+      "id": "reason-font-manager@2.0.2@d41d8cd9",
       "name": "reason-font-manager",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-font-manager/-/reason-font-manager-2.0.1.tgz#sha1:739cd6de54ad836e810a60afd066fba9fbc15950"
+          "archive:https://registry.npmjs.org/reason-font-manager/-/reason-font-manager-2.0.2.tgz#sha1:c625a6ffe920fc34a8b433a6b03c2f9b238aa6c2"
         ]
       },
       "overrides": [],

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "1f1b0ff59122c7ba1cefd5fb18b63a78",
+  "checksum": "481394502b1c2b3672f8d3740d8fa56f",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -105,7 +105,7 @@
         "reason-sdl2@2.10.3017@d41d8cd9",
         "reason-harfbuzz@1.91.5004@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
-        "reason-font-manager@2.0.1@d41d8cd9", "http-server@0.12.1@d41d8cd9",
+        "reason-font-manager@2.0.2@d41d8cd9", "http-server@0.12.1@d41d8cd9",
         "flex@1.2.2@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/ppx_deriving@opam:4.4.1@208c6c8f",
@@ -287,14 +287,14 @@
       ],
       "devDependencies": []
     },
-    "reason-font-manager@2.0.1@d41d8cd9": {
-      "id": "reason-font-manager@2.0.1@d41d8cd9",
+    "reason-font-manager@2.0.2@d41d8cd9": {
+      "id": "reason-font-manager@2.0.2@d41d8cd9",
       "name": "reason-font-manager",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-font-manager/-/reason-font-manager-2.0.1.tgz#sha1:739cd6de54ad836e810a60afd066fba9fbc15950"
+          "archive:https://registry.npmjs.org/reason-font-manager/-/reason-font-manager-2.0.2.tgz#sha1:c625a6ffe920fc34a8b433a6b03c2f9b238aa6c2"
         ]
       },
       "overrides": [],

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9131bc15ddc9f0ba59f5a94d11adee05",
+  "checksum": "4d6b0d4594c9e62923a3bef7a6ab596e",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -49,7 +49,7 @@
         "reason-sdl2@2.10.3017@d41d8cd9",
         "reason-harfbuzz@1.91.5004@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
-        "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
+        "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/ppx_deriving@opam:4.4.1@208c6c8f",
@@ -216,14 +216,14 @@
       ],
       "devDependencies": []
     },
-    "reason-font-manager@2.0.1@d41d8cd9": {
-      "id": "reason-font-manager@2.0.1@d41d8cd9",
+    "reason-font-manager@2.0.2@d41d8cd9": {
+      "id": "reason-font-manager@2.0.2@d41d8cd9",
       "name": "reason-font-manager",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-font-manager/-/reason-font-manager-2.0.1.tgz#sha1:739cd6de54ad836e810a60afd066fba9fbc15950"
+          "archive:https://registry.npmjs.org/reason-font-manager/-/reason-font-manager-2.0.2.tgz#sha1:c625a6ffe920fc34a8b433a6b03c2f9b238aa6c2"
         ]
       },
       "overrides": [],

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a7e3db9873851b771bc15a915f0478af",
+  "checksum": "f54d4c14404e86428838a88d5219f160",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -105,7 +105,7 @@
         "reason-sdl2@2.10.3017@d41d8cd9",
         "reason-harfbuzz@1.91.5004@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
-        "reason-font-manager@2.0.1@d41d8cd9", "http-server@0.12.1@d41d8cd9",
+        "reason-font-manager@2.0.2@d41d8cd9", "http-server@0.12.1@d41d8cd9",
         "flex@1.2.2@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/ppx_deriving@opam:4.4.1@208c6c8f",
@@ -287,14 +287,14 @@
       ],
       "devDependencies": []
     },
-    "reason-font-manager@2.0.1@d41d8cd9": {
-      "id": "reason-font-manager@2.0.1@d41d8cd9",
+    "reason-font-manager@2.0.2@d41d8cd9": {
+      "id": "reason-font-manager@2.0.2@d41d8cd9",
       "name": "reason-font-manager",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-font-manager/-/reason-font-manager-2.0.1.tgz#sha1:739cd6de54ad836e810a60afd066fba9fbc15950"
+          "archive:https://registry.npmjs.org/reason-font-manager/-/reason-font-manager-2.0.2.tgz#sha1:c625a6ffe920fc34a8b433a6b03c2f9b238aa6c2"
         ]
       },
       "overrides": [],

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@reason-native/rely": "*",
     "reperf": "^1.4.0",
     "@reason-native/console": "^0.0.3",
-    "reason-font-manager": "^2.0.0",
+    "reason-font-manager": "^2.0.2",
     "reason-harfbuzz": "^1.91.5004",
     "rench": "^1.9.1",
     "rebez": "github:jchavarri/rebez#03fa3b7",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "764431ed8b041c356f0f40af3961fa67",
+  "checksum": "ec20787191c277c226eb6df590a38b3f",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -49,7 +49,7 @@
         "reason-sdl2@2.10.3017@d41d8cd9",
         "reason-harfbuzz@1.91.5004@d41d8cd9",
         "reason-gl-matrix@0.9.9307@d41d8cd9",
-        "reason-font-manager@2.0.1@d41d8cd9", "flex@1.2.2@d41d8cd9",
+        "reason-font-manager@2.0.2@d41d8cd9", "flex@1.2.2@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
         "@opam/ppx_deriving@opam:4.4.1@208c6c8f",
@@ -216,14 +216,14 @@
       ],
       "devDependencies": []
     },
-    "reason-font-manager@2.0.1@d41d8cd9": {
-      "id": "reason-font-manager@2.0.1@d41d8cd9",
+    "reason-font-manager@2.0.2@d41d8cd9": {
+      "id": "reason-font-manager@2.0.2@d41d8cd9",
       "name": "reason-font-manager",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-font-manager/-/reason-font-manager-2.0.1.tgz#sha1:739cd6de54ad836e810a60afd066fba9fbc15950"
+          "archive:https://registry.npmjs.org/reason-font-manager/-/reason-font-manager-2.0.2.tgz#sha1:c625a6ffe920fc34a8b433a6b03c2f9b238aa6c2"
         ]
       },
       "overrides": [],


### PR DESCRIPTION
- Pick up memory leak fix in reason-font-manager: https://github.com/revery-ui/reason-font-manager