### PR TITLE
API: OnBoundingBoxChanged + Slider fixes

### DIFF
--- a/examples/Slider.re
+++ b/examples/Slider.re
@@ -92,7 +92,7 @@ module AdjustableLogo = {
             <Text style=textStyle text="Rotation X: " />
             <Slider
               onValueChanged=handleRotationX
-              value=twoPi
+              initialValue=twoPi
               maximumValue=twoPi
             />
             <Text

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -61,8 +61,6 @@ class node (()) = {
   val mutable _queuedCallbacks: list(callback) = [];
   val mutable _lastDimensions: NodeEvents.DimensionsChangedEventParams.t =
     NodeEvents.DimensionsChangedEventParams.create();
-  val mutable _lastBoundingBox: BoundingBox2d.t =
-    BoundingBox2d.create(0., 0., 0., 0.);
   val mutable _isLayoutDirty = true;
   val mutable _forcedMeasurements: option(Dimensions.t) = None;
   val mutable _hasHadNonZeroBlurRadius = false;
@@ -76,6 +74,7 @@ class node (()) = {
   val _bboxLocal = BoundingBox2d.create(0., 0., 0., 0.);
   val _bboxWorld = BoundingBox2d.create(0., 0., 0., 0.);
   val _bboxClipped = BoundingBox2d.create(0., 0., 0., 0.);
+  val _lastBoundingBox: BoundingBox2d.t = BoundingBox2d.create(0., 0., 0., 0.);
   pub draw = (parentContext: NodeDrawContext.t) => {
     let style: Style.t = _this#getStyle();
     let worldTransform = _this#getWorldTransform();

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -287,7 +287,7 @@ class node (()) = {
     | Some(cb) =>
       if (!BoundingBox2d.equals(_lastBoundingBox, bbox)) {
         let (x0, y0, x1, y1) = BoundingBox2d.getBounds(bbox);
-        BoundingBox2d.Mutable.set(_lastBoundingBox, x0, y0, x1, y1);
+        BoundingBox2d.Mutable.set(~out=_lastBoundingBox, x0, y0, x1, y1);
         _this#_queueCallback(() => cb(bbox));
       }
     };

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -61,7 +61,7 @@ class node (()) = {
   val mutable _queuedCallbacks: list(callback) = [];
   val mutable _lastDimensions: NodeEvents.DimensionsChangedEventParams.t =
     NodeEvents.DimensionsChangedEventParams.create();
-  val mutable _lastBoundingBox: BoundingBox2d.t = 
+  val mutable _lastBoundingBox: BoundingBox2d.t =
     BoundingBox2d.create(0., 0., 0., 0.);
   val mutable _isLayoutDirty = true;
   val mutable _forcedMeasurements: option(Dimensions.t) = None;
@@ -270,7 +270,7 @@ class node (()) = {
         height: newDimensions.height,
       };
       _lastDimensions = evt;
-      
+
       /*
        * Defer dispatching the `ref` until AFTER layout has occurred.
        * A common use-case for using the ref will be getting dimension
@@ -282,17 +282,13 @@ class node (()) = {
     };
 
     if (!BoundingBox2d.equals(_lastBoundingBox, bbox)) {
-        print_endline ("UPDATING BBOX: " ++ BoundingBox2d.toString(bbox));
       events.onBoundingBoxChanged
       |> Option.iter(cb => {
-
-        _this#_queueCallback(() => cb(bbox))
+          _this#_queueCallback(() => cb(bbox))
       });
-      
+
       let (x0, y0, x1, y1) = BoundingBox2d.getBounds(bbox);
-      BoundingBox2d.Mutable.set(
-       _lastBoundingBox, x0, y0, x1, y1
-      );
+      BoundingBox2d.Mutable.set(_lastBoundingBox, x0, y0, x1, y1);
     };
   };
   pub getCursorStyle = () => {

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -277,18 +277,20 @@ class node (()) = {
        * and layout information. This won't be available until AFTER
        * layout.
        */
-      events.onDimensionsChanged
-      |> Option.iter(cb => _this#_queueCallback(() => cb(evt)));
+      switch (events.onDimensionsChanged) {
+      | None => ()
+      | Some(cb) => _this#_queueCallback(() => cb(evt))
+      };
     };
 
-    if (!BoundingBox2d.equals(_lastBoundingBox, bbox)) {
-      events.onBoundingBoxChanged
-      |> Option.iter(cb => {
-          _this#_queueCallback(() => cb(bbox))
-      });
-
-      let (x0, y0, x1, y1) = BoundingBox2d.getBounds(bbox);
-      BoundingBox2d.Mutable.set(_lastBoundingBox, x0, y0, x1, y1);
+    switch (events.onBoundingBoxChanged) {
+    | None => ()
+    | Some(cb) =>
+      if (!BoundingBox2d.equals(_lastBoundingBox, bbox)) {
+        let (x0, y0, x1, y1) = BoundingBox2d.getBounds(bbox);
+        BoundingBox2d.Mutable.set(_lastBoundingBox, x0, y0, x1, y1);
+        _this#_queueCallback(() => cb(bbox));
+      }
     };
   };
   pub getCursorStyle = () => {

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -61,6 +61,8 @@ class node (()) = {
   val mutable _queuedCallbacks: list(callback) = [];
   val mutable _lastDimensions: NodeEvents.DimensionsChangedEventParams.t =
     NodeEvents.DimensionsChangedEventParams.create();
+  val mutable _lastBoundingBox: BoundingBox2d.t = 
+    BoundingBox2d.create(0., 0., 0., 0.);
   val mutable _isLayoutDirty = true;
   val mutable _forcedMeasurements: option(Dimensions.t) = None;
   val mutable _hasHadNonZeroBlurRadius = false;

--- a/src/UI/NodeEvents.re
+++ b/src/UI/NodeEvents.re
@@ -3,6 +3,7 @@
 /* A collection of event handlers to be used by the Nodes */
 
 open Revery_Core;
+open Revery_Math;
 
 [@deriving show({with_path: false})]
 type mouseMoveEventParams = {
@@ -108,6 +109,7 @@ type t('a) = {
   onTextInput: option(textInputHandler),
   onTextEdit: option(textEditHandler),
   onDimensionsChanged: option(dimensionsChangedHandler),
+  onBoundingBoxChanged: option(BoundingBox2d.t => unit),
 };
 
 let make =
@@ -129,6 +131,7 @@ let make =
       ~onKeyDown=?,
       ~onKeyUp=?,
       ~onDimensionsChanged=?,
+      ~onBoundingBoxChanged=?,
       _unit: unit,
     ) => {
   ref,
@@ -147,4 +150,5 @@ let make =
   onKeyDown,
   onKeyUp,
   onDimensionsChanged,
+  onBoundingBoxChanged,
 };

--- a/src/UI_Components/Slider.re
+++ b/src/UI_Components/Slider.re
@@ -189,7 +189,6 @@ let%component make =
       onBoundingBoxChanged={bbox => setSliderBoundingBox(_ => bbox)}>
       <View style=beforeTrackStyle />
       <View
-        onBoundingBoxChanged={bbox => setThumbBoundingBox(_ => bbox)}
         style=Style.[
           position(`Absolute),
           height(vertical ? thumbWidth : thumbHeight),

--- a/src/UI_Components/Slider.re
+++ b/src/UI_Components/Slider.re
@@ -37,18 +37,16 @@ let%component make =
                 ~thumbColor=Colors.gray,
                 (),
               ) => {
-  /*let%hook (slideRef, setSlideRefOption) = Hooks.state(None);
-    let%hook (thumbRef, setThumbRefOption) = Hooks.state(None);*/
   let%hook isActive = Hooks.ref(false);
   let%hook (sliderBoundingBox, setSliderBoundingBox) =
     Hooks.state(defaultBoundingBox);
-  let%hook (v, setV) = Hooks.state(initialValue);
+  let%hook (uncontrolledValue, setUncontrolledValue) =
+    Hooks.state(initialValue);
 
-  let origV = v;
   let v =
     switch (value) {
     | Some(controlledValue) => controlledValue
-    | None => origV
+    | None => uncontrolledValue
     };
 
   let availableWidth = {
@@ -72,13 +70,15 @@ let%component make =
 
     let normalizedValue =
       thumbPosition /. w *. (maximumValue -. minimumValue) +. minimumValue;
-    setV(_ => normalizedValue);
+    setUncontrolledValue(_ => normalizedValue);
     onValueChanged(normalizedValue);
   };
 
   let sliderComplete = () => {
     isActive := false;
-    setV(v => v);
+    // Force a re-render of the UI, since setting the ref
+    // won't be enough to do that.
+    setUncontrolledValue(v => v);
   };
 
   let%hook () =

--- a/src/UI_Components/Slider.re
+++ b/src/UI_Components/Slider.re
@@ -38,38 +38,27 @@ let%component make =
                 (),
               ) => {
   /*let%hook (slideRef, setSlideRefOption) = Hooks.state(None);
-  let%hook (thumbRef, setThumbRefOption) = Hooks.state(None);*/
-  let%hook (isActive) = Hooks.ref(false);
-  let%hook (sliderBoundingBox, setSliderBoundingBox) = Hooks.state(defaultBoundingBox);
-  let%hook (thumbBoundingBox, setThumbBoundingBox) = Hooks.state(defaultBoundingBox);
-  /* Initial value is used to detect if the 'value' parameter ever changes */
-  //let%hook (initialValue) = Hooks.ref(value);
+    let%hook (thumbRef, setThumbRefOption) = Hooks.state(None);*/
+  let%hook isActive = Hooks.ref(false);
+  let%hook (sliderBoundingBox, setSliderBoundingBox) =
+    Hooks.state(defaultBoundingBox);
   let%hook (v, setV) = Hooks.state(initialValue);
 
   let origV = v;
-  let v = switch (value) {
-  | Some(controlledValue) => 
-    print_endline ("CONTROLLED VALUE: " ++ string_of_float(controlledValue));
-    controlledValue;
-  | None => origV;
-  }
-
-  print_endline (
-    Printf.sprintf("SLIDER: Passed in value: %f v: %f", v, origV ));
-  
-  //let setSlideRef = r => setSlideRefOption(_ => Some(r));
-
-  //let setThumbRef = r => setThumbRefOption(_ => Some(r));
+  let v =
+    switch (value) {
+    | Some(controlledValue) => controlledValue
+    | None => origV
+    };
 
   let availableWidth = {
-      let (sliderX0, sliderY0, sliderX1, sliderY1) = BoundingBox2d.getBounds(sliderBoundingBox);
-      //let (thumbX0, thumbY0, thumbX1, thumbY1) = BoundingBox2d.getBounds(thumbBoundingBox);
-      
+    let (sliderX0, sliderY0, sliderX1, sliderY1) =
+      BoundingBox2d.getBounds(sliderBoundingBox);
 
-      let sliderWidth = vertical ? sliderY1 -. sliderY0 : sliderX1 -. sliderX0;
-      let thumbWidth = float(thumbLength);
-      sliderWidth -. thumbWidth;
-    };
+    let sliderWidth = vertical ? sliderY1 -. sliderY0 : sliderX1 -. sliderX0;
+    let thumbWidth = float(thumbLength);
+    sliderWidth -. thumbWidth;
+  };
 
   let sliderUpdate = (w, startPosition, endPosition, mouseX, mouseY) => {
     let mousePosition = vertical ? mouseY : mouseX;
@@ -99,24 +88,24 @@ let%component make =
         let isCaptured = isActive^;
 
         if (isCaptured) {
-            let (x0, y0, _x1, _y1) =
-              BoundingBox2d.getBounds(sliderBoundingBox);
-            let startPosition = vertical ? y0 : x0;
-            let endPosition = startPosition +. availableWidth;
+          let (x0, y0, _x1, _y1) =
+            BoundingBox2d.getBounds(sliderBoundingBox);
+          let startPosition = vertical ? y0 : x0;
+          let endPosition = startPosition +. availableWidth;
 
-            Mouse.setCapture(
-              ~onMouseMove=
-                evt =>
-                  sliderUpdate(
-                    availableWidth,
-                    startPosition,
-                    endPosition,
-                    evt.mouseX,
-                    evt.mouseY,
-                  ),
-              ~onMouseUp=_evt => sliderComplete(),
-              (),
-            );
+          Mouse.setCapture(
+            ~onMouseMove=
+              evt =>
+                sliderUpdate(
+                  availableWidth,
+                  startPosition,
+                  endPosition,
+                  evt.mouseX,
+                  evt.mouseY,
+                ),
+            ~onMouseUp=_evt => sliderComplete(),
+            (),
+          );
         };
 
         Some(
@@ -129,12 +118,18 @@ let%component make =
     );
 
   let onMouseDown = (evt: NodeEvents.mouseButtonEventParams) => {
-      let (x0, y0, _, _) = BoundingBox2d.getBounds(sliderBoundingBox);
-      let startPosition = vertical ? y0 : x0;
-      let endPosition = startPosition +. availableWidth;
-      isActive := true;
-      sliderUpdate(availableWidth, startPosition, endPosition, evt.mouseX, evt.mouseY);
-    };
+    let (x0, y0, _, _) = BoundingBox2d.getBounds(sliderBoundingBox);
+    let startPosition = vertical ? y0 : x0;
+    let endPosition = startPosition +. availableWidth;
+    isActive := true;
+    sliderUpdate(
+      availableWidth,
+      startPosition,
+      endPosition,
+      evt.mouseX,
+      evt.mouseY,
+    );
+  };
 
   let sliderBackgroundColor = maximumTrackColor;
 
@@ -146,9 +141,11 @@ let%component make =
   let trackMargins = (sliderHeight - trackHeight) / 2;
 
   let thumbPosition =
-      int_of_float((v -. minimumValue) /. (maximumValue -. minimumValue) *. availableWidth)
-      - thumbLength
-      / 2;
+    int_of_float(
+      (v -. minimumValue) /. (maximumValue -. minimumValue) *. availableWidth,
+    )
+    - thumbLength
+    / 2;
 
   let style =
     Style.[
@@ -186,14 +183,13 @@ let%component make =
     ];
 
   <Opacity opacity=sliderOpacity>
-    <View onMouseDown style onBoundingBoxChanged={bbox => setSliderBoundingBox(_ => bbox)}>
+    <View
+      onMouseDown
+      style
+      onBoundingBoxChanged={bbox => setSliderBoundingBox(_ => bbox)}>
       <View style=beforeTrackStyle />
       <View
-        onBoundingBoxChanged={bbox => {
-          print_endline ("THUMB BBOX: " ++ BoundingBox2d.toString(bbox));
-  
-        setThumbBoundingBox(_ => bbox)}
-        }
+        onBoundingBoxChanged={bbox => setThumbBoundingBox(_ => bbox)}
         style=Style.[
           position(`Absolute),
           height(vertical ? thumbWidth : thumbHeight),

--- a/src/UI_Primitives/Canvas.re
+++ b/src/UI_Primitives/Canvas.re
@@ -19,6 +19,7 @@ let%nativeComponent make =
                       ~onKeyDown=?,
                       ~onKeyUp=?,
                       ~onDimensionsChanged=?,
+                      ~onBoundingBoxChanged=?,
                       ~render=?,
                       (),
                       hooks,
@@ -42,6 +43,7 @@ let%nativeComponent make =
           ~onKeyDown?,
           ~onKeyUp?,
           ~onDimensionsChanged?,
+          ~onBoundingBoxChanged?,
           (),
         );
       let node = (new canvasNode)();
@@ -68,6 +70,7 @@ let%nativeComponent make =
           ~onKeyDown?,
           ~onKeyUp?,
           ~onDimensionsChanged?,
+          ~onBoundingBoxChanged?,
           (),
         );
       let canvasNode: canvasNode = Obj.magic(node);

--- a/src/UI_Primitives/View.re
+++ b/src/UI_Primitives/View.re
@@ -22,6 +22,7 @@ let%nativeComponent make =
                       ~onTextInput=?,
                       ~onTextEdit=?,
                       ~onDimensionsChanged=?,
+                      ~onBoundingBoxChanged=?,
                       (),
                       hooks,
                     ) => (
@@ -46,6 +47,7 @@ let%nativeComponent make =
           ~onTextEdit?,
           ~onTextInput?,
           ~onDimensionsChanged?,
+          ~onBoundingBoxChanged?,
           (),
         );
       let node = PrimitiveNodeFactory.get().createViewNode();
@@ -73,6 +75,7 @@ let%nativeComponent make =
           ~onKeyUp?,
           ~onTextEdit?,
           ~onTextInput?,
+          ~onBoundingBoxChanged?,
           ~onDimensionsChanged?,
           (),
         );


### PR DESCRIPTION
While adding the scrollbar / scrollback to [`revery-terminal`](https://github.com/revery-ui/revery-terminal/pull/13) - I noticed a bug with the slider (which we're using as a scrollbar).

In some cases - when using it in a 'controlled' manner, it would pick up stale values. There were two contributing factors:
- The `ref` + query for bounding box strategy could sometimes be out of date. The fix for this was to have an explicit event to listen to bounding box changes.
- The 'controlled' scenario relied on calling a `setState` handler, but this wasn't reliable - we'd still get stale values back. Instead, I made a slight API change - for uncontrolled components, `initialValue` is enough to set, and isn't monitored. For controlled components - the `value` property should be used.

__TODO:__
- [x] Test Onivim scrollbars in high DPI / retina display