### PR TITLE
Bugfix - Environment: Ensure executingDirectory is absolute

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ jobs:
 
   steps:
   - template: .ci/use-node.yml
-  - template: .ci/restore-build-cache.yml
+  # - template: .ci/restore-build-cache.yml
   - template: .ci/esy-build-steps.yml
   - template: .ci/esy-bench.yml
   - template: .ci/publish-build-cache.yml

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -47,7 +47,7 @@
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#fec55ce@d41d8cd9",
         "reason-sdl2@2.10.3018@d41d8cd9",
-        "reason-harfbuzz@1.91.5007@d41d8cd9",
+        "reason-harfbuzz@1.91.5008@d41d8cd9",
         "reason-font-manager@2.1.1@d41d8cd9", "flex@1.2.3@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
@@ -196,19 +196,19 @@
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "reason-harfbuzz@1.91.5007@d41d8cd9": {
-      "id": "reason-harfbuzz@1.91.5007@d41d8cd9",
+    "reason-harfbuzz@1.91.5008@d41d8cd9": {
+      "id": "reason-harfbuzz@1.91.5008@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "1.91.5007",
+      "version": "1.91.5008",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5007.tgz#sha1:c27b3575badab09532e343166611e1cb1df10674"
+          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5008.tgz#sha1:c0bccd880fe4aa7480d62d0da0c0480d316959f4"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "esy-harfbuzz@1.9.1005@d41d8cd9",
+        "ocaml@4.8.1000@d41d8cd9", "esy-harfbuzz@1.9.1006@d41d8cd9",
         "@opam/dune-configurator@opam:2.3.1@f275cf9a",
         "@opam/dune@opam:2.3.1@b10b59bf", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
@@ -320,14 +320,14 @@
       ],
       "devDependencies": []
     },
-    "esy-harfbuzz@1.9.1005@d41d8cd9": {
-      "id": "esy-harfbuzz@1.9.1005@d41d8cd9",
+    "esy-harfbuzz@1.9.1006@d41d8cd9": {
+      "id": "esy-harfbuzz@1.9.1006@d41d8cd9",
       "name": "esy-harfbuzz",
-      "version": "1.9.1005",
+      "version": "1.9.1006",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/esy-harfbuzz/-/esy-harfbuzz-1.9.1005.tgz#sha1:04651c73d33ce8004e61fde35a7549a7b9e908b6"
+          "archive:https://registry.npmjs.org/esy-harfbuzz/-/esy-harfbuzz-1.9.1006.tgz#sha1:d706f1562513ea0f7c2e454f8dd5d9cd54f94d87"
         ]
       },
       "overrides": [],
@@ -952,20 +952,20 @@
         "@opam/dune@opam:2.3.1@b10b59bf"
       ]
     },
-    "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80": {
-      "id": "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+    "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023": {
+      "id": "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
       "name": "@opam/ppx_tools_versioned",
-      "version": "opam:5.2.3",
+      "version": "opam:5.3.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/b1/b1455e5a4a1bcd9ddbfcf712ccbd4262#md5:b1455e5a4a1bcd9ddbfcf712ccbd4262",
-          "archive:https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.2.3.tar.gz#md5:b1455e5a4a1bcd9ddbfcf712ccbd4262"
+          "archive:https://opam.ocaml.org/cache/md5/c2/c285c0524fc05f27cd642591d951a48d#md5:c285c0524fc05f27cd642591d951a48d",
+          "archive:https://github.com/ocaml-ppx/ppx_tools_versioned/releases/download/5.3.0/ppx_tools_versioned-5.3.0.tbz#md5:c285c0524fc05f27cd642591d951a48d"
         ],
         "opam": {
           "name": "ppx_tools_versioned",
-          "version": "5.2.3",
-          "path": "bench.esy.lock/opam/ppx_tools_versioned.5.2.3"
+          "version": "5.3.0",
+          "path": "bench.esy.lock/opam/ppx_tools_versioned.5.3.0"
         }
       },
       "overrides": [],
@@ -1336,8 +1336,8 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.3.1@b10b59bf"
       ]
     },
-    "@opam/menhir@opam:20200211@90483d81": {
-      "id": "@opam/menhir@opam:20200211@90483d81",
+    "@opam/menhir@opam:20200211@26571604": {
+      "id": "@opam/menhir@opam:20200211@26571604",
       "name": "@opam/menhir",
       "version": "opam:20200211",
       "source": {
@@ -1352,11 +1352,17 @@
           "path": "bench.esy.lock/opam/menhir.20200211"
         }
       },
-      "overrides": [],
+      "overrides": [
+        {
+          "opamoverride":
+            "bench.esy.lock/overrides/opam__s__menhir_opam__c__20200211_opam_override"
+        }
+      ],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/menhirSdk@opam:20200211@1b43927c",
         "@opam/menhirLib@opam:20200211@99279102",
-        "@opam/dune@opam:2.3.1@b10b59bf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.3.1@b10b59bf",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/menhirSdk@opam:20200211@1b43927c",
@@ -1410,14 +1416,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+        "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.3.1@b10b59bf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+        "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.3.1@b10b59bf"
       ]
@@ -1695,6 +1701,31 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@d957c903",
         "@opam/seq@opam:base@d8d7de1d"
+      ]
+    },
+    "@opam/fix@opam:20200131@0ecd2f01": {
+      "id": "@opam/fix@opam:20200131@0ecd2f01",
+      "name": "@opam/fix",
+      "version": "opam:20200131",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/99/991ff031666c662eaab638d2e0f4ac1d#md5:991ff031666c662eaab638d2e0f4ac1d",
+          "archive:https://gitlab.inria.fr/fpottier/fix/repository/20200131/archive.tar.gz#md5:991ff031666c662eaab638d2e0f4ac1d"
+        ],
+        "opam": {
+          "name": "fix",
+          "version": "20200131",
+          "path": "bench.esy.lock/opam/fix.20200131"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.3.1@b10b59bf",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.3.1@b10b59bf"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {
@@ -2172,7 +2203,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/menhir@opam:20200211@90483d81",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/menhir@opam:20200211@26571604",
         "@opam/jbuilder@opam:1.0+beta20.2@053ddcf2",
         "@opam/easy-format@opam:1.3.2@0484b3c4",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -2260,7 +2291,7 @@
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/merlin-extend@opam:0.5@a5dd7d4b",
-        "@opam/menhir@opam:20200211@90483d81",
+        "@opam/menhir@opam:20200211@26571604",
         "@opam/dune@opam:2.3.1@b10b59bf"
       ],
       "devDependencies": []

--- a/bench.esy.lock/opam/fix.20200131/opam
+++ b/bench.esy.lock/opam/fix.20200131/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/fix"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/fix.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "1.3" }
+]
+synopsis: "Facilities for memoization and fixed points"
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/fix/repository/20200131/archive.tar.gz"
+  checksum: [
+    "md5=991ff031666c662eaab638d2e0f4ac1d"
+    "sha512=01c45a1d90b02ec0939e968b185a6a373ac6117e2287b9a26d3db9d71e9569d086cea50da60710fcab5c2ed9d3b4c72b76839c0651e436f1fb39c77dc7c04b5e"
+  ]
+}

--- a/bench.esy.lock/opam/ppx_tools_versioned.5.3.0/opam
+++ b/bench.esy.lock/opam/ppx_tools_versioned.5.3.0/opam
@@ -17,14 +17,14 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.0"}
-  "ocaml-migrate-parsetree" {>= "1.4.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
 ]
 synopsis: "A variant of ppx_tools based on ocaml-migrate-parsetree"
 url {
   src:
-    "https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.2.3.tar.gz"
+    "https://github.com/ocaml-ppx/ppx_tools_versioned/releases/download/5.3.0/ppx_tools_versioned-5.3.0.tbz"
   checksum: [
-    "md5=b1455e5a4a1bcd9ddbfcf712ccbd4262"
-    "sha512=af20aa0031b9c638537bcdb52c75de95f316ae8fd455a38672a60da5c7c6895cca9dbecd5d56a88c3c40979c6a673a047d986b5b41e1e84b528b7df5d905b9b1"
+    "md5=c285c0524fc05f27cd642591d951a48d"
+    "sha512=26be7b3b2d112718fd44f82de6296c58ec7c341b7261e984d5a762daa89cee4b6df61ce60e757482e5e0980da64555fa0d3e9b6d4bbe3437255ee837343995fe"
   ]
 }

--- a/bench.esy.lock/overrides/opam__s__menhir_opam__c__20200211_opam_override/package.json
+++ b/bench.esy.lock/overrides/opam__s__menhir_opam__c__20200211_opam_override/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@opam/fix": "*"
+  }
+}

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -103,7 +103,7 @@
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#fec55ce@d41d8cd9",
         "reason-sdl2@2.10.3018@d41d8cd9",
-        "reason-harfbuzz@1.91.5007@d41d8cd9",
+        "reason-harfbuzz@1.91.5008@d41d8cd9",
         "reason-font-manager@2.1.1@d41d8cd9", "http-server@0.12.1@d41d8cd9",
         "flex@1.2.3@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
@@ -267,19 +267,19 @@
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "reason-harfbuzz@1.91.5007@d41d8cd9": {
-      "id": "reason-harfbuzz@1.91.5007@d41d8cd9",
+    "reason-harfbuzz@1.91.5008@d41d8cd9": {
+      "id": "reason-harfbuzz@1.91.5008@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "1.91.5007",
+      "version": "1.91.5008",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5007.tgz#sha1:c27b3575badab09532e343166611e1cb1df10674"
+          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5008.tgz#sha1:c0bccd880fe4aa7480d62d0da0c0480d316959f4"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "esy-harfbuzz@1.9.1005@d41d8cd9",
+        "ocaml@4.8.1000@d41d8cd9", "esy-harfbuzz@1.9.1006@d41d8cd9",
         "@opam/dune-configurator@opam:2.3.1@f275cf9a",
         "@opam/dune@opam:2.3.1@b10b59bf", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
@@ -629,14 +629,14 @@
       ],
       "devDependencies": []
     },
-    "esy-harfbuzz@1.9.1005@d41d8cd9": {
-      "id": "esy-harfbuzz@1.9.1005@d41d8cd9",
+    "esy-harfbuzz@1.9.1006@d41d8cd9": {
+      "id": "esy-harfbuzz@1.9.1006@d41d8cd9",
       "name": "esy-harfbuzz",
-      "version": "1.9.1005",
+      "version": "1.9.1006",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/esy-harfbuzz/-/esy-harfbuzz-1.9.1005.tgz#sha1:04651c73d33ce8004e61fde35a7549a7b9e908b6"
+          "archive:https://registry.npmjs.org/esy-harfbuzz/-/esy-harfbuzz-1.9.1006.tgz#sha1:d706f1562513ea0f7c2e454f8dd5d9cd54f94d87"
         ]
       },
       "overrides": [],
@@ -1349,20 +1349,20 @@
         "@opam/dune@opam:2.3.1@b10b59bf"
       ]
     },
-    "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80": {
-      "id": "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+    "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023": {
+      "id": "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
       "name": "@opam/ppx_tools_versioned",
-      "version": "opam:5.2.3",
+      "version": "opam:5.3.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/b1/b1455e5a4a1bcd9ddbfcf712ccbd4262#md5:b1455e5a4a1bcd9ddbfcf712ccbd4262",
-          "archive:https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.2.3.tar.gz#md5:b1455e5a4a1bcd9ddbfcf712ccbd4262"
+          "archive:https://opam.ocaml.org/cache/md5/c2/c285c0524fc05f27cd642591d951a48d#md5:c285c0524fc05f27cd642591d951a48d",
+          "archive:https://github.com/ocaml-ppx/ppx_tools_versioned/releases/download/5.3.0/ppx_tools_versioned-5.3.0.tbz#md5:c285c0524fc05f27cd642591d951a48d"
         ],
         "opam": {
           "name": "ppx_tools_versioned",
-          "version": "5.2.3",
-          "path": "doc.esy.lock/opam/ppx_tools_versioned.5.2.3"
+          "version": "5.3.0",
+          "path": "doc.esy.lock/opam/ppx_tools_versioned.5.3.0"
         }
       },
       "overrides": [],
@@ -1766,8 +1766,8 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.3.1@b10b59bf"
       ]
     },
-    "@opam/menhir@opam:20200211@90483d81": {
-      "id": "@opam/menhir@opam:20200211@90483d81",
+    "@opam/menhir@opam:20200211@26571604": {
+      "id": "@opam/menhir@opam:20200211@26571604",
       "name": "@opam/menhir",
       "version": "opam:20200211",
       "source": {
@@ -1782,11 +1782,17 @@
           "path": "doc.esy.lock/opam/menhir.20200211"
         }
       },
-      "overrides": [],
+      "overrides": [
+        {
+          "opamoverride":
+            "doc.esy.lock/overrides/opam__s__menhir_opam__c__20200211_opam_override"
+        }
+      ],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/menhirSdk@opam:20200211@1b43927c",
         "@opam/menhirLib@opam:20200211@99279102",
-        "@opam/dune@opam:2.3.1@b10b59bf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.3.1@b10b59bf",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/menhirSdk@opam:20200211@1b43927c",
@@ -1840,14 +1846,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+        "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.3.1@b10b59bf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+        "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.3.1@b10b59bf"
       ]
@@ -2127,6 +2133,31 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@d957c903",
         "@opam/seq@opam:base@d8d7de1d"
+      ]
+    },
+    "@opam/fix@opam:20200131@0ecd2f01": {
+      "id": "@opam/fix@opam:20200131@0ecd2f01",
+      "name": "@opam/fix",
+      "version": "opam:20200131",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/99/991ff031666c662eaab638d2e0f4ac1d#md5:991ff031666c662eaab638d2e0f4ac1d",
+          "archive:https://gitlab.inria.fr/fpottier/fix/repository/20200131/archive.tar.gz#md5:991ff031666c662eaab638d2e0f4ac1d"
+        ],
+        "opam": {
+          "name": "fix",
+          "version": "20200131",
+          "path": "doc.esy.lock/opam/fix.20200131"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.3.1@b10b59bf",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.3.1@b10b59bf"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {
@@ -2632,7 +2663,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/menhir@opam:20200211@90483d81",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/menhir@opam:20200211@26571604",
         "@opam/jbuilder@opam:1.0+beta20.2@053ddcf2",
         "@opam/easy-format@opam:1.3.2@0484b3c4",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -2720,7 +2751,7 @@
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/merlin-extend@opam:0.5@a5dd7d4b",
-        "@opam/menhir@opam:20200211@90483d81",
+        "@opam/menhir@opam:20200211@26571604",
         "@opam/dune@opam:2.3.1@b10b59bf"
       ],
       "devDependencies": []

--- a/doc.esy.lock/opam/fix.20200131/opam
+++ b/doc.esy.lock/opam/fix.20200131/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/fix"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/fix.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "1.3" }
+]
+synopsis: "Facilities for memoization and fixed points"
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/fix/repository/20200131/archive.tar.gz"
+  checksum: [
+    "md5=991ff031666c662eaab638d2e0f4ac1d"
+    "sha512=01c45a1d90b02ec0939e968b185a6a373ac6117e2287b9a26d3db9d71e9569d086cea50da60710fcab5c2ed9d3b4c72b76839c0651e436f1fb39c77dc7c04b5e"
+  ]
+}

--- a/doc.esy.lock/opam/ppx_tools_versioned.5.3.0/opam
+++ b/doc.esy.lock/opam/ppx_tools_versioned.5.3.0/opam
@@ -17,14 +17,14 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.0"}
-  "ocaml-migrate-parsetree" {>= "1.4.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
 ]
 synopsis: "A variant of ppx_tools based on ocaml-migrate-parsetree"
 url {
   src:
-    "https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.2.3.tar.gz"
+    "https://github.com/ocaml-ppx/ppx_tools_versioned/releases/download/5.3.0/ppx_tools_versioned-5.3.0.tbz"
   checksum: [
-    "md5=b1455e5a4a1bcd9ddbfcf712ccbd4262"
-    "sha512=af20aa0031b9c638537bcdb52c75de95f316ae8fd455a38672a60da5c7c6895cca9dbecd5d56a88c3c40979c6a673a047d986b5b41e1e84b528b7df5d905b9b1"
+    "md5=c285c0524fc05f27cd642591d951a48d"
+    "sha512=26be7b3b2d112718fd44f82de6296c58ec7c341b7261e984d5a762daa89cee4b6df61ce60e757482e5e0980da64555fa0d3e9b6d4bbe3437255ee837343995fe"
   ]
 }

--- a/doc.esy.lock/overrides/opam__s__menhir_opam__c__20200211_opam_override/package.json
+++ b/doc.esy.lock/overrides/opam__s__menhir_opam__c__20200211_opam_override/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@opam/fix": "*"
+  }
+}

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -47,7 +47,7 @@
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#fec55ce@d41d8cd9",
         "reason-sdl2@2.10.3018@d41d8cd9",
-        "reason-harfbuzz@1.91.5007@d41d8cd9",
+        "reason-harfbuzz@1.91.5008@d41d8cd9",
         "reason-font-manager@2.1.1@d41d8cd9", "flex@1.2.3@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
@@ -196,19 +196,19 @@
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "reason-harfbuzz@1.91.5007@d41d8cd9": {
-      "id": "reason-harfbuzz@1.91.5007@d41d8cd9",
+    "reason-harfbuzz@1.91.5008@d41d8cd9": {
+      "id": "reason-harfbuzz@1.91.5008@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "1.91.5007",
+      "version": "1.91.5008",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5007.tgz#sha1:c27b3575badab09532e343166611e1cb1df10674"
+          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5008.tgz#sha1:c0bccd880fe4aa7480d62d0da0c0480d316959f4"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "esy-harfbuzz@1.9.1005@d41d8cd9",
+        "ocaml@4.8.1000@d41d8cd9", "esy-harfbuzz@1.9.1006@d41d8cd9",
         "@opam/dune-configurator@opam:2.3.1@f275cf9a",
         "@opam/dune@opam:2.3.1@b10b59bf", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
@@ -320,14 +320,14 @@
       ],
       "devDependencies": []
     },
-    "esy-harfbuzz@1.9.1005@d41d8cd9": {
-      "id": "esy-harfbuzz@1.9.1005@d41d8cd9",
+    "esy-harfbuzz@1.9.1006@d41d8cd9": {
+      "id": "esy-harfbuzz@1.9.1006@d41d8cd9",
       "name": "esy-harfbuzz",
-      "version": "1.9.1005",
+      "version": "1.9.1006",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/esy-harfbuzz/-/esy-harfbuzz-1.9.1005.tgz#sha1:04651c73d33ce8004e61fde35a7549a7b9e908b6"
+          "archive:https://registry.npmjs.org/esy-harfbuzz/-/esy-harfbuzz-1.9.1006.tgz#sha1:d706f1562513ea0f7c2e454f8dd5d9cd54f94d87"
         ]
       },
       "overrides": [],
@@ -952,20 +952,20 @@
         "@opam/dune@opam:2.3.1@b10b59bf"
       ]
     },
-    "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80": {
-      "id": "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+    "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023": {
+      "id": "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
       "name": "@opam/ppx_tools_versioned",
-      "version": "opam:5.2.3",
+      "version": "opam:5.3.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/b1/b1455e5a4a1bcd9ddbfcf712ccbd4262#md5:b1455e5a4a1bcd9ddbfcf712ccbd4262",
-          "archive:https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.2.3.tar.gz#md5:b1455e5a4a1bcd9ddbfcf712ccbd4262"
+          "archive:https://opam.ocaml.org/cache/md5/c2/c285c0524fc05f27cd642591d951a48d#md5:c285c0524fc05f27cd642591d951a48d",
+          "archive:https://github.com/ocaml-ppx/ppx_tools_versioned/releases/download/5.3.0/ppx_tools_versioned-5.3.0.tbz#md5:c285c0524fc05f27cd642591d951a48d"
         ],
         "opam": {
           "name": "ppx_tools_versioned",
-          "version": "5.2.3",
-          "path": "esy.lock/opam/ppx_tools_versioned.5.2.3"
+          "version": "5.3.0",
+          "path": "esy.lock/opam/ppx_tools_versioned.5.3.0"
         }
       },
       "overrides": [],
@@ -1336,8 +1336,8 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.3.1@b10b59bf"
       ]
     },
-    "@opam/menhir@opam:20200211@90483d81": {
-      "id": "@opam/menhir@opam:20200211@90483d81",
+    "@opam/menhir@opam:20200211@26571604": {
+      "id": "@opam/menhir@opam:20200211@26571604",
       "name": "@opam/menhir",
       "version": "opam:20200211",
       "source": {
@@ -1352,11 +1352,17 @@
           "path": "esy.lock/opam/menhir.20200211"
         }
       },
-      "overrides": [],
+      "overrides": [
+        {
+          "opamoverride":
+            "esy.lock/overrides/opam__s__menhir_opam__c__20200211_opam_override"
+        }
+      ],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/menhirSdk@opam:20200211@1b43927c",
         "@opam/menhirLib@opam:20200211@99279102",
-        "@opam/dune@opam:2.3.1@b10b59bf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.3.1@b10b59bf",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/menhirSdk@opam:20200211@1b43927c",
@@ -1410,14 +1416,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+        "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.3.1@b10b59bf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+        "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.3.1@b10b59bf"
       ]
@@ -1695,6 +1701,31 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@d957c903",
         "@opam/seq@opam:base@d8d7de1d"
+      ]
+    },
+    "@opam/fix@opam:20200131@0ecd2f01": {
+      "id": "@opam/fix@opam:20200131@0ecd2f01",
+      "name": "@opam/fix",
+      "version": "opam:20200131",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/99/991ff031666c662eaab638d2e0f4ac1d#md5:991ff031666c662eaab638d2e0f4ac1d",
+          "archive:https://gitlab.inria.fr/fpottier/fix/repository/20200131/archive.tar.gz#md5:991ff031666c662eaab638d2e0f4ac1d"
+        ],
+        "opam": {
+          "name": "fix",
+          "version": "20200131",
+          "path": "esy.lock/opam/fix.20200131"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.3.1@b10b59bf",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.3.1@b10b59bf"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {
@@ -2172,7 +2203,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/menhir@opam:20200211@90483d81",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/menhir@opam:20200211@26571604",
         "@opam/jbuilder@opam:1.0+beta20.2@053ddcf2",
         "@opam/easy-format@opam:1.3.2@0484b3c4",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -2260,7 +2291,7 @@
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/merlin-extend@opam:0.5@a5dd7d4b",
-        "@opam/menhir@opam:20200211@90483d81",
+        "@opam/menhir@opam:20200211@26571604",
         "@opam/dune@opam:2.3.1@b10b59bf"
       ],
       "devDependencies": []

--- a/esy.lock/opam/fix.20200131/opam
+++ b/esy.lock/opam/fix.20200131/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/fix"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/fix.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "1.3" }
+]
+synopsis: "Facilities for memoization and fixed points"
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/fix/repository/20200131/archive.tar.gz"
+  checksum: [
+    "md5=991ff031666c662eaab638d2e0f4ac1d"
+    "sha512=01c45a1d90b02ec0939e968b185a6a373ac6117e2287b9a26d3db9d71e9569d086cea50da60710fcab5c2ed9d3b4c72b76839c0651e436f1fb39c77dc7c04b5e"
+  ]
+}

--- a/esy.lock/opam/ppx_tools_versioned.5.3.0/opam
+++ b/esy.lock/opam/ppx_tools_versioned.5.3.0/opam
@@ -17,14 +17,14 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.0"}
-  "ocaml-migrate-parsetree" {>= "1.4.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
 ]
 synopsis: "A variant of ppx_tools based on ocaml-migrate-parsetree"
 url {
   src:
-    "https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.2.3.tar.gz"
+    "https://github.com/ocaml-ppx/ppx_tools_versioned/releases/download/5.3.0/ppx_tools_versioned-5.3.0.tbz"
   checksum: [
-    "md5=b1455e5a4a1bcd9ddbfcf712ccbd4262"
-    "sha512=af20aa0031b9c638537bcdb52c75de95f316ae8fd455a38672a60da5c7c6895cca9dbecd5d56a88c3c40979c6a673a047d986b5b41e1e84b528b7df5d905b9b1"
+    "md5=c285c0524fc05f27cd642591d951a48d"
+    "sha512=26be7b3b2d112718fd44f82de6296c58ec7c341b7261e984d5a762daa89cee4b6df61ce60e757482e5e0980da64555fa0d3e9b6d4bbe3437255ee837343995fe"
   ]
 }

--- a/esy.lock/overrides/opam__s__menhir_opam__c__20200211_opam_override/package.json
+++ b/esy.lock/overrides/opam__s__menhir_opam__c__20200211_opam_override/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@opam/fix": "*"
+  }
+}

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -103,7 +103,7 @@
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#fec55ce@d41d8cd9",
         "reason-sdl2@2.10.3018@d41d8cd9",
-        "reason-harfbuzz@1.91.5007@d41d8cd9",
+        "reason-harfbuzz@1.91.5008@d41d8cd9",
         "reason-font-manager@2.1.1@d41d8cd9", "http-server@0.12.1@d41d8cd9",
         "flex@1.2.3@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
@@ -270,19 +270,19 @@
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "reason-harfbuzz@1.91.5007@d41d8cd9": {
-      "id": "reason-harfbuzz@1.91.5007@d41d8cd9",
+    "reason-harfbuzz@1.91.5008@d41d8cd9": {
+      "id": "reason-harfbuzz@1.91.5008@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "1.91.5007",
+      "version": "1.91.5008",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5007.tgz#sha1:c27b3575badab09532e343166611e1cb1df10674"
+          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5008.tgz#sha1:c0bccd880fe4aa7480d62d0da0c0480d316959f4"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "esy-harfbuzz@1.9.1005@d41d8cd9",
+        "ocaml@4.8.1000@d41d8cd9", "esy-harfbuzz@1.9.1006@d41d8cd9",
         "@opam/dune-configurator@opam:2.3.1@f275cf9a",
         "@opam/dune@opam:2.3.1@b10b59bf", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
@@ -632,14 +632,14 @@
       ],
       "devDependencies": []
     },
-    "esy-harfbuzz@1.9.1005@d41d8cd9": {
-      "id": "esy-harfbuzz@1.9.1005@d41d8cd9",
+    "esy-harfbuzz@1.9.1006@d41d8cd9": {
+      "id": "esy-harfbuzz@1.9.1006@d41d8cd9",
       "name": "esy-harfbuzz",
-      "version": "1.9.1005",
+      "version": "1.9.1006",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/esy-harfbuzz/-/esy-harfbuzz-1.9.1005.tgz#sha1:04651c73d33ce8004e61fde35a7549a7b9e908b6"
+          "archive:https://registry.npmjs.org/esy-harfbuzz/-/esy-harfbuzz-1.9.1006.tgz#sha1:d706f1562513ea0f7c2e454f8dd5d9cd54f94d87"
         ]
       },
       "overrides": [],
@@ -1353,20 +1353,20 @@
         "@opam/dune@opam:2.3.1@b10b59bf"
       ]
     },
-    "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80": {
-      "id": "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+    "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023": {
+      "id": "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
       "name": "@opam/ppx_tools_versioned",
-      "version": "opam:5.2.3",
+      "version": "opam:5.3.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/b1/b1455e5a4a1bcd9ddbfcf712ccbd4262#md5:b1455e5a4a1bcd9ddbfcf712ccbd4262",
-          "archive:https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.2.3.tar.gz#md5:b1455e5a4a1bcd9ddbfcf712ccbd4262"
+          "archive:https://opam.ocaml.org/cache/md5/c2/c285c0524fc05f27cd642591d951a48d#md5:c285c0524fc05f27cd642591d951a48d",
+          "archive:https://github.com/ocaml-ppx/ppx_tools_versioned/releases/download/5.3.0/ppx_tools_versioned-5.3.0.tbz#md5:c285c0524fc05f27cd642591d951a48d"
         ],
         "opam": {
           "name": "ppx_tools_versioned",
-          "version": "5.2.3",
-          "path": "js.esy.lock/opam/ppx_tools_versioned.5.2.3"
+          "version": "5.3.0",
+          "path": "js.esy.lock/opam/ppx_tools_versioned.5.3.0"
         }
       },
       "overrides": [],
@@ -1737,8 +1737,8 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.3.1@b10b59bf"
       ]
     },
-    "@opam/menhir@opam:20200211@90483d81": {
-      "id": "@opam/menhir@opam:20200211@90483d81",
+    "@opam/menhir@opam:20200211@26571604": {
+      "id": "@opam/menhir@opam:20200211@26571604",
       "name": "@opam/menhir",
       "version": "opam:20200211",
       "source": {
@@ -1753,11 +1753,17 @@
           "path": "js.esy.lock/opam/menhir.20200211"
         }
       },
-      "overrides": [],
+      "overrides": [
+        {
+          "opamoverride":
+            "js.esy.lock/overrides/opam__s__menhir_opam__c__20200211_opam_override"
+        }
+      ],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/menhirSdk@opam:20200211@1b43927c",
         "@opam/menhirLib@opam:20200211@99279102",
-        "@opam/dune@opam:2.3.1@b10b59bf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.3.1@b10b59bf",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/menhirSdk@opam:20200211@1b43927c",
@@ -1811,14 +1817,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+        "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.3.1@b10b59bf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+        "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.3.1@b10b59bf"
       ]
@@ -2012,14 +2018,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+        "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
         "@opam/dune@opam:2.3.1@b10b59bf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+        "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/js_of_ocaml@opam:3.5.2@c5bae178",
         "@opam/dune@opam:2.3.1@b10b59bf"
@@ -2107,14 +2113,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
-        "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+        "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/js_of_ocaml-compiler@opam:3.5.2@092d6ef6",
         "@opam/dune@opam:2.3.1@b10b59bf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
-        "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+        "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/js_of_ocaml-compiler@opam:3.5.2@092d6ef6",
         "@opam/dune@opam:2.3.1@b10b59bf"
@@ -2227,6 +2233,31 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@d957c903",
         "@opam/seq@opam:base@d8d7de1d"
+      ]
+    },
+    "@opam/fix@opam:20200131@0ecd2f01": {
+      "id": "@opam/fix@opam:20200131@0ecd2f01",
+      "name": "@opam/fix",
+      "version": "opam:20200131",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/99/991ff031666c662eaab638d2e0f4ac1d#md5:991ff031666c662eaab638d2e0f4ac1d",
+          "archive:https://gitlab.inria.fr/fpottier/fix/repository/20200131/archive.tar.gz#md5:991ff031666c662eaab638d2e0f4ac1d"
+        ],
+        "opam": {
+          "name": "fix",
+          "version": "20200131",
+          "path": "js.esy.lock/opam/fix.20200131"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.3.1@b10b59bf",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.3.1@b10b59bf"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {
@@ -2732,7 +2763,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/menhir@opam:20200211@90483d81",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/menhir@opam:20200211@26571604",
         "@opam/jbuilder@opam:1.0+beta20.2@053ddcf2",
         "@opam/easy-format@opam:1.3.2@0484b3c4",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -2820,7 +2851,7 @@
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/merlin-extend@opam:0.4@64c45329",
-        "@opam/menhir@opam:20200211@90483d81",
+        "@opam/menhir@opam:20200211@26571604",
         "@opam/dune@opam:2.3.1@b10b59bf"
       ],
       "devDependencies": []

--- a/js.esy.lock/opam/fix.20200131/opam
+++ b/js.esy.lock/opam/fix.20200131/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/fix"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/fix.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "1.3" }
+]
+synopsis: "Facilities for memoization and fixed points"
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/fix/repository/20200131/archive.tar.gz"
+  checksum: [
+    "md5=991ff031666c662eaab638d2e0f4ac1d"
+    "sha512=01c45a1d90b02ec0939e968b185a6a373ac6117e2287b9a26d3db9d71e9569d086cea50da60710fcab5c2ed9d3b4c72b76839c0651e436f1fb39c77dc7c04b5e"
+  ]
+}

--- a/js.esy.lock/opam/ppx_tools_versioned.5.3.0/opam
+++ b/js.esy.lock/opam/ppx_tools_versioned.5.3.0/opam
@@ -17,14 +17,14 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.0"}
-  "ocaml-migrate-parsetree" {>= "1.4.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
 ]
 synopsis: "A variant of ppx_tools based on ocaml-migrate-parsetree"
 url {
   src:
-    "https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.2.3.tar.gz"
+    "https://github.com/ocaml-ppx/ppx_tools_versioned/releases/download/5.3.0/ppx_tools_versioned-5.3.0.tbz"
   checksum: [
-    "md5=b1455e5a4a1bcd9ddbfcf712ccbd4262"
-    "sha512=af20aa0031b9c638537bcdb52c75de95f316ae8fd455a38672a60da5c7c6895cca9dbecd5d56a88c3c40979c6a673a047d986b5b41e1e84b528b7df5d905b9b1"
+    "md5=c285c0524fc05f27cd642591d951a48d"
+    "sha512=26be7b3b2d112718fd44f82de6296c58ec7c341b7261e984d5a762daa89cee4b6df61ce60e757482e5e0980da64555fa0d3e9b6d4bbe3437255ee837343995fe"
   ]
 }

--- a/js.esy.lock/overrides/opam__s__menhir_opam__c__20200211_opam_override/package.json
+++ b/js.esy.lock/overrides/opam__s__menhir_opam__c__20200211_opam_override/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@opam/fix": "*"
+  }
+}

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -81,15 +81,15 @@ let getExecutingDirectory = () =>
       | _ =>
         let candidatePath = Filename.dirname(Sys.argv[0]) ++ Filename.dir_sep;
 
-        if (Filename.isAbsolute(candidatePath)) {
-          candidatePath;
+        if (Filename.is_relative(candidatePath)) {
+          Internal.addTrailingSlash(Sys.getcwd()) ++ candidatePath;
         } else {
-          addTrailingSlash(Sys.getcwd()) ++ candidatePath;
+          candidatePath;
         };
       };
 
     /* Check if there is a trailing slash. If not, we need to add one. */
-    addTrailingSlash(dir);
+    Internal.addTrailingSlash(dir);
   };
 
 let executingDirectory = getExecutingDirectory();

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -41,6 +41,21 @@ let os = {
     );
 };
 
+module Internal = {
+  let addTrailingSlash = dir => {
+    let len = String.length(dir);
+    if (len == 0) {
+      dir;
+    } else {
+      switch (dir.[len - 1]) {
+      | '/' => dir
+      | '\\' => dir
+      | _ => dir ++ Filename.dir_sep
+      };
+    };
+  };
+};
+
 let getExecutingDirectory = () =>
   if (!isNative) {
     "";
@@ -63,20 +78,18 @@ let getExecutingDirectory = () =>
         | (Some(v), None) => String.sub(Sys.executable_name, 0, v)
         | _ => Sys.executable_name
         }
-      | _ => Filename.dirname(Sys.argv[0]) ++ Filename.dir_sep
+      | _ =>
+        let candidatePath = Filename.dirname(Sys.argv[0]) ++ Filename.dir_sep;
+
+        if (Filename.isAbsolute(candidatePath)) {
+          candidatePath;
+        } else {
+          addTrailingSlash(Sys.getcwd()) ++ candidatePath;
+        };
       };
 
     /* Check if there is a trailing slash. If not, we need to add one. */
-
-    let len = String.length(dir);
-    let ret =
-      switch (dir.[len - 1]) {
-      | '/' => dir
-      | '\\' => dir
-      | _ => dir ++ Filename.dir_sep
-      };
-
-    ret;
+    addTrailingSlash(dir);
   };
 
 let executingDirectory = getExecutingDirectory();

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -47,7 +47,7 @@
         "rebez@github:jchavarri/rebez#03fa3b7@d41d8cd9",
         "reason-skia@github:revery-ui/reason-skia#fec55ce@d41d8cd9",
         "reason-sdl2@2.10.3018@d41d8cd9",
-        "reason-harfbuzz@1.91.5007@d41d8cd9",
+        "reason-harfbuzz@1.91.5008@d41d8cd9",
         "reason-font-manager@2.1.1@d41d8cd9", "flex@1.2.3@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
         "@reason-native/console@0.0.3@d41d8cd9",
@@ -196,19 +196,19 @@
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "reason-harfbuzz@1.91.5007@d41d8cd9": {
-      "id": "reason-harfbuzz@1.91.5007@d41d8cd9",
+    "reason-harfbuzz@1.91.5008@d41d8cd9": {
+      "id": "reason-harfbuzz@1.91.5008@d41d8cd9",
       "name": "reason-harfbuzz",
-      "version": "1.91.5007",
+      "version": "1.91.5008",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5007.tgz#sha1:c27b3575badab09532e343166611e1cb1df10674"
+          "archive:https://registry.npmjs.org/reason-harfbuzz/-/reason-harfbuzz-1.91.5008.tgz#sha1:c0bccd880fe4aa7480d62d0da0c0480d316959f4"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "esy-harfbuzz@1.9.1005@d41d8cd9",
+        "ocaml@4.8.1000@d41d8cd9", "esy-harfbuzz@1.9.1006@d41d8cd9",
         "@opam/dune-configurator@opam:2.3.1@f275cf9a",
         "@opam/dune@opam:2.3.1@b10b59bf", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
@@ -320,14 +320,14 @@
       ],
       "devDependencies": []
     },
-    "esy-harfbuzz@1.9.1005@d41d8cd9": {
-      "id": "esy-harfbuzz@1.9.1005@d41d8cd9",
+    "esy-harfbuzz@1.9.1006@d41d8cd9": {
+      "id": "esy-harfbuzz@1.9.1006@d41d8cd9",
       "name": "esy-harfbuzz",
-      "version": "1.9.1005",
+      "version": "1.9.1006",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/esy-harfbuzz/-/esy-harfbuzz-1.9.1005.tgz#sha1:04651c73d33ce8004e61fde35a7549a7b9e908b6"
+          "archive:https://registry.npmjs.org/esy-harfbuzz/-/esy-harfbuzz-1.9.1006.tgz#sha1:d706f1562513ea0f7c2e454f8dd5d9cd54f94d87"
         ]
       },
       "overrides": [],
@@ -952,20 +952,20 @@
         "@opam/dune@opam:2.3.1@b10b59bf"
       ]
     },
-    "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80": {
-      "id": "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+    "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023": {
+      "id": "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
       "name": "@opam/ppx_tools_versioned",
-      "version": "opam:5.2.3",
+      "version": "opam:5.3.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/b1/b1455e5a4a1bcd9ddbfcf712ccbd4262#md5:b1455e5a4a1bcd9ddbfcf712ccbd4262",
-          "archive:https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.2.3.tar.gz#md5:b1455e5a4a1bcd9ddbfcf712ccbd4262"
+          "archive:https://opam.ocaml.org/cache/md5/c2/c285c0524fc05f27cd642591d951a48d#md5:c285c0524fc05f27cd642591d951a48d",
+          "archive:https://github.com/ocaml-ppx/ppx_tools_versioned/releases/download/5.3.0/ppx_tools_versioned-5.3.0.tbz#md5:c285c0524fc05f27cd642591d951a48d"
         ],
         "opam": {
           "name": "ppx_tools_versioned",
-          "version": "5.2.3",
-          "path": "test.esy.lock/opam/ppx_tools_versioned.5.2.3"
+          "version": "5.3.0",
+          "path": "test.esy.lock/opam/ppx_tools_versioned.5.3.0"
         }
       },
       "overrides": [],
@@ -1336,8 +1336,8 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.3.1@b10b59bf"
       ]
     },
-    "@opam/menhir@opam:20200211@90483d81": {
-      "id": "@opam/menhir@opam:20200211@90483d81",
+    "@opam/menhir@opam:20200211@26571604": {
+      "id": "@opam/menhir@opam:20200211@26571604",
       "name": "@opam/menhir",
       "version": "opam:20200211",
       "source": {
@@ -1352,11 +1352,17 @@
           "path": "test.esy.lock/opam/menhir.20200211"
         }
       },
-      "overrides": [],
+      "overrides": [
+        {
+          "opamoverride":
+            "test.esy.lock/overrides/opam__s__menhir_opam__c__20200211_opam_override"
+        }
+      ],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/menhirSdk@opam:20200211@1b43927c",
         "@opam/menhirLib@opam:20200211@99279102",
-        "@opam/dune@opam:2.3.1@b10b59bf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.3.1@b10b59bf",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/menhirSdk@opam:20200211@1b43927c",
@@ -1410,14 +1416,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+        "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.3.1@b10b59bf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
+        "@opam/ppx_tools_versioned@opam:5.3.0@2c0dc023",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/lwt@opam:4.5.0@677655b4", "@opam/dune@opam:2.3.1@b10b59bf"
       ]
@@ -1695,6 +1701,31 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/stdlib-shims@opam:0.1.0@d957c903",
         "@opam/seq@opam:base@d8d7de1d"
+      ]
+    },
+    "@opam/fix@opam:20200131@0ecd2f01": {
+      "id": "@opam/fix@opam:20200131@0ecd2f01",
+      "name": "@opam/fix",
+      "version": "opam:20200131",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/99/991ff031666c662eaab638d2e0f4ac1d#md5:991ff031666c662eaab638d2e0f4ac1d",
+          "archive:https://gitlab.inria.fr/fpottier/fix/repository/20200131/archive.tar.gz#md5:991ff031666c662eaab638d2e0f4ac1d"
+        ],
+        "opam": {
+          "name": "fix",
+          "version": "20200131",
+          "path": "test.esy.lock/opam/fix.20200131"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.3.1@b10b59bf",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:2.3.1@b10b59bf"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {
@@ -2172,7 +2203,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/menhir@opam:20200211@90483d81",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/menhir@opam:20200211@26571604",
         "@opam/jbuilder@opam:1.0+beta20.2@053ddcf2",
         "@opam/easy-format@opam:1.3.2@0484b3c4",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -2260,7 +2291,7 @@
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocaml-migrate-parsetree@opam:1.6.0@da2643e7",
         "@opam/merlin-extend@opam:0.5@a5dd7d4b",
-        "@opam/menhir@opam:20200211@90483d81",
+        "@opam/menhir@opam:20200211@26571604",
         "@opam/dune@opam:2.3.1@b10b59bf"
       ],
       "devDependencies": []

--- a/test.esy.lock/opam/fix.20200131/opam
+++ b/test.esy.lock/opam/fix.20200131/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/fix"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/fix.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "1.3" }
+]
+synopsis: "Facilities for memoization and fixed points"
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/fix/repository/20200131/archive.tar.gz"
+  checksum: [
+    "md5=991ff031666c662eaab638d2e0f4ac1d"
+    "sha512=01c45a1d90b02ec0939e968b185a6a373ac6117e2287b9a26d3db9d71e9569d086cea50da60710fcab5c2ed9d3b4c72b76839c0651e436f1fb39c77dc7c04b5e"
+  ]
+}

--- a/test.esy.lock/opam/ppx_tools_versioned.5.3.0/opam
+++ b/test.esy.lock/opam/ppx_tools_versioned.5.3.0/opam
@@ -17,14 +17,14 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.0"}
-  "ocaml-migrate-parsetree" {>= "1.4.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
 ]
 synopsis: "A variant of ppx_tools based on ocaml-migrate-parsetree"
 url {
   src:
-    "https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.2.3.tar.gz"
+    "https://github.com/ocaml-ppx/ppx_tools_versioned/releases/download/5.3.0/ppx_tools_versioned-5.3.0.tbz"
   checksum: [
-    "md5=b1455e5a4a1bcd9ddbfcf712ccbd4262"
-    "sha512=af20aa0031b9c638537bcdb52c75de95f316ae8fd455a38672a60da5c7c6895cca9dbecd5d56a88c3c40979c6a673a047d986b5b41e1e84b528b7df5d905b9b1"
+    "md5=c285c0524fc05f27cd642591d951a48d"
+    "sha512=26be7b3b2d112718fd44f82de6296c58ec7c341b7261e984d5a762daa89cee4b6df61ce60e757482e5e0980da64555fa0d3e9b6d4bbe3437255ee837343995fe"
   ]
 }

--- a/test.esy.lock/overrides/opam__s__menhir_opam__c__20200211_opam_override/package.json
+++ b/test.esy.lock/overrides/opam__s__menhir_opam__c__20200211_opam_override/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@opam/fix": "*"
+  }
+}


### PR DESCRIPTION
We use `Revery.Environment.executingDirectory` in a way that we assume is always an absolute path. 

However, it looks like there could be cases on Linux where this wasn't the case - this checks if the path is absolute, and if it isn't, applies the current working directory to get a fully absolute path.