### PR TITLE
Fix lockdir update, and reporter

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -26,6 +26,7 @@ jobs:
           esy install -P bench
           esy install -P doc
           esy install -P js
+          git diff --exit-code --cached || (git add *lock; git commit -m "Update lockdir, ")
           #  git add *lock
       - name: Print esy cache
         id: print_esy_cache
@@ -43,7 +44,7 @@ jobs:
         run: |
           esy build dune build @check
           git status
-          git diff --exit-code --cached || (git add *opam; git commit -m "opam, ")
+          git diff --exit-code --cached || ([[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && (git commit -am "opam, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')opam, "))
           git status
           git log -2
       - name: format sources files

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -49,7 +49,9 @@ jobs:
           esy format || ([[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && git commit -am "format, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')format, ")
       - name: Push if it is not up to date
         run: |
-          git branch -r --contains $(git log -1 --pretty=format:'%H') || git push origin HEAD:$GITHUB_REF
+          # git branch -r --contains $(git log -1 --pretty=format:'%H') || 
+          # if last commit is from the bot then push.
+          [[ "$(git log -1 --pretty=format:'%an')" == "Github Runner" ]] && git push origin HEAD:$GITHUB_REF
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Display status should be clean

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -35,20 +35,18 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ steps.print_esy_cache.outputs.esy_cache }}
-          key: macOS-latest-4.08-${{ hashFiles('**/index.json') }}
+          key: macos-latest-4.08-${{ hashFiles('**/index.json') }}
       - name: Build dependencies
         if: steps.deps-cache-macos.outputs.cache-hit != 'true'
         run: esy build-dependencies --release
       - name: Generate opam files
         run: |
           esy build dune build @check
-          git add *opam
-          git diff --exit-code --cached || git commit -m "opam, "
+          git diff --exit-code --cached || (git add *opam; git commit -m "opam, ")
       - name: format sources files
         run: |
           esy format
-          git add -u
-          git diff --exit-code --cached || [[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && git commit -m "format, " || git commit --amend -m $(git log -1 --pretty=format:'%s')"format, "
+          git diff --exit-code --cached || [[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && git commit -am "format, " || git commit --amend -am $(git log -1 --pretty=format:'%s')"format, "
       - name: Push if it is not up to date
         run: |
           git status
@@ -87,7 +85,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ steps.print_esy_cache.outputs.esy_cache }}
-          key: macOS-latest-4.08-${{ hashFiles('doc.esy.lock/index.json') }}
+          key: macos-latest-4.08-${{ hashFiles('doc.esy.lock/index.json') }}
       - name: Install doc dependencies
         if: steps.deps-cache-macos.outputs.cache-hit != 'true'
         run: esy @doc build-dependencies --release

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -46,8 +46,7 @@ jobs:
           git diff --exit-code --cached || ([[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && git commit -am "opam, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')opam, ")
       - name: format sources files
         run: |
-          esy format
-          git diff --exit-code --cached || ([[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && git commit -am "format, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')format, ")
+          esy format || ([[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && git commit -am "format, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')format, ")
       - name: Push if it is not up to date
         run: |
           git branch -r --contains $(git log -1 --pretty=format:'%H') || git push origin HEAD:$GITHUB_REF

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -44,16 +44,22 @@ jobs:
           esy build dune build @check
           git status
           git diff --exit-code --cached || (git add *opam; git commit -m "opam, ")
+          git status
+          git log -2
       - name: format sources files
         run: |
           esy format
           git status
           git diff --exit-code --cached || [[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && (git commit -am "format, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')format, ")
+          git status
+          git log -2
       - name: Push if it is not up to date
         run: |
           git status
           git log -2
           git branch  -r --contains $(git log  -1 --pretty=format:'%H') || git push origin HEAD:$GITHUB_REF
+          git status
+          git log -2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Display status should be clean

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -18,6 +18,8 @@ jobs:
           git remote set-url --push origin https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY
           git config user.name "Github Runner"
           git config user.email "runner@runner.github.com"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update lockdir
         run: |
           # git rm -rf esy.lock test.esy.lock bench.esy.lock doc.esy.lock js.esy.lock
@@ -52,8 +54,6 @@ jobs:
           # git branch -r --contains $(git log -1 --pretty=format:'%H') || 
           # if last commit is from the bot then push.
           [[ "$(git log -1 --pretty=format:'%an')" == "Github Runner" ]] && git push origin HEAD:$GITHUB_REF
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Display status should be clean
         if: always()
         run: |

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           esy format || ([[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && git commit -am "format, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')format, ")
       - name: Push if it is not up to date
+        if: github.event_name != 'pull_request'
         run: |
           # if last commit is from the bot then push.
           [[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] || git push origin HEAD:$GITHUB_REF
@@ -58,7 +59,7 @@ jobs:
           git log -2
           git diff
       - uses: actions/github-script@0.3.0
-        if: github.event == 'pull_request'
+        if: github.event_name == 'pull_request'
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -43,28 +43,22 @@ jobs:
       - name: Generate opam files
         run: |
           esy build dune build @check
-          git status
           git diff --exit-code --cached || ([[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && (git commit -am "opam, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')opam, "))
-          git status
-          git log -2
       - name: format sources files
         run: |
           esy format
-          git status
           git diff --exit-code --cached || ([[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && (git commit -am "format, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')format, "))
-          git status
-          git log -2
       - name: Push if it is not up to date
         run: |
-          git status
-          git log -2
           git branch -r --contains $(git log -1 --pretty=format:'%H') || git push origin HEAD:$GITHUB_REF
-          git status
-          git log -2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Display status should be clean
-        run: git status
+        if: always()
+        run: |
+          git status
+          git log -2
+          git diff
       - uses: actions/github-script@0.3.0
         if: github.event == 'pull_request'
         with:

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -15,13 +15,13 @@ jobs:
         run: npm install -g esy
       - name: Update lockdir
         run: |
-          git rm -rf esy.lock test.esy.lock bench.esy.lock doc.esy.lock js.esy.lock
+          # git rm -rf esy.lock test.esy.lock bench.esy.lock doc.esy.lock js.esy.lock
           esy install
-          esy install -P test || true
-          esy install -P bench || true
-          esy install -P doc || true
-          esy install -P js || true
-          git add *lock
+          esy install -P test
+          esy install -P bench
+          esy install -P doc
+          esy install -P js
+          #  git add *lock
       - name: Print esy cache
         id: print_esy_cache
         run: node .github/workflows/print_esy_cache.js
@@ -38,7 +38,7 @@ jobs:
         run: |
           esy build dune build @check
           git add *opam
-      - name: format sources files
+      - name: format sources files 
         run: |
           esy format
           git add -u

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -13,6 +13,11 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install esy
         run: npm install -g esy
+      - name: Setup Git to push back
+        run: |
+          git remote set-url --push origin https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY
+          git config user.name "Github Runner"
+          git config user.email "runner@runner.github.com"
       - name: Update lockdir
         run: |
           # git rm -rf esy.lock test.esy.lock bench.esy.lock doc.esy.lock js.esy.lock
@@ -38,21 +43,17 @@ jobs:
         run: |
           esy build dune build @check
           git add *opam
-      - name: format sources files 
+          git diff --exit-code --cached || git commit -m "opam, "
+      - name: format sources files
         run: |
           esy format
           git add -u
-      - name: Check that lock directory are up-to-date.
-        run: git diff --exit-code --cached
-      - name: Push if it is not
-        if: failure()
+          git diff --exit-code --cached || [[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && git commit -m "format, " || git commit --amend -m $(git log -1 --pretty=format:'%s')"format, "
+      - name: Push if it is not up to date
         run: |
-          git remote set-url --push origin https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY
-          git config user.name "Github Runner"
-          git config user.email "runner@runner.github.com"
-          git commit -am "Update lockdir"
           git status
-          git push origin HEAD:$GITHUB_REF
+          git log -2
+          git branch  -r --contains $(git log  -1 --pretty=format:'%H') || git push origin HEAD:$GITHUB_REF
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Display status should be clean

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Push if it is not up to date
         run: |
           # if last commit is from the bot then push.
-          [[ "$(git log -1 --pretty=format:'%an')" == "Github Runner" ]] && git push origin HEAD:$GITHUB_REF
+          [[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] || git push origin HEAD:$GITHUB_REF
       - name: Display status should be clean
         if: always()
         run: |

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           esy format
           git status
+          git diff --exit-code --cached; echo $?
           git diff --exit-code --cached || [[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && (git commit -am "format, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')format, ")
           git status
           git log -2

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    name: Lint lockdir, autoformat
+    name: Lint lockdir, generate opam files, autoformat
     runs-on: macos-latest
     steps:
       - uses: actions/setup-node@v1
@@ -43,11 +43,11 @@ jobs:
       - name: Generate opam files
         run: |
           esy build dune build @check
-          git diff --exit-code --cached || ([[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && (git commit -am "opam, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')opam, "))
+          git diff --exit-code --cached || ([[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && git commit -am "opam, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')opam, ")
       - name: format sources files
         run: |
           esy format
-          git diff --exit-code --cached || ([[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && (git commit -am "format, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')format, "))
+          git diff --exit-code --cached || ([[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && git commit -am "format, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')format, ")
       - name: Push if it is not up to date
         run: |
           git branch -r --contains $(git log -1 --pretty=format:'%H') || git push origin HEAD:$GITHUB_REF

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           esy format
           git status
-          git diff --exit-code --cached || [[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && git commit -am "format, " || git commit --amend -am $(git log -1 --pretty=format:'%s')"format, "
+          git diff --exit-code --cached || [[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && (git commit -am "format, " || git commit --amend -am $(git log -1 --pretty=format:'%s')"format, ")
       - name: Push if it is not up to date
         run: |
           git status

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -50,24 +50,22 @@ jobs:
         run: |
           esy format
           git status
-          git diff --exit-code --cached; echo $?
-          git diff --exit-code --cached || [[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && (git commit -am "format, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')format, ")
+          git diff --exit-code --cached || ([[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && (git commit -am "format, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')format, "))
           git status
           git log -2
       - name: Push if it is not up to date
         run: |
           git status
           git log -2
-          git branch  -r --contains $(git log  -1 --pretty=format:'%H') || git push origin HEAD:$GITHUB_REF
+          git branch -r --contains $(git log -1 --pretty=format:'%H') || git push origin HEAD:$GITHUB_REF
           git status
           git log -2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Display status should be clean
         run: git status
-        if: success()
       - uses: actions/github-script@0.3.0
-        if: failure() && github.event == 'pull_request'
+        if: github.event == 'pull_request'
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -22,14 +22,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update lockdir
         run: |
-          # git rm -rf esy.lock test.esy.lock bench.esy.lock doc.esy.lock js.esy.lock
           esy install
           esy install -P test
           esy install -P bench
           esy install -P doc
           esy install -P js
           git diff --exit-code --cached || (git add *lock; git commit -m "Update lockdir, ")
-          #  git add *lock
       - name: Print esy cache
         id: print_esy_cache
         run: node .github/workflows/print_esy_cache.js
@@ -51,7 +49,6 @@ jobs:
           esy format || ([[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && git commit -am "format, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')format, ")
       - name: Push if it is not up to date
         run: |
-          # git branch -r --contains $(git log -1 --pretty=format:'%H') || 
           # if last commit is from the bot then push.
           [[ "$(git log -1 --pretty=format:'%an')" == "Github Runner" ]] && git push origin HEAD:$GITHUB_REF
       - name: Display status should be clean

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           esy format
           git status
-          git diff --exit-code --cached || [[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && (git commit -am "format, " || git commit --amend -am $(git log -1 --pretty=format:'%s')"format, ")
+          git diff --exit-code --cached || [[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && (git commit -am "format, " || git commit --amend -am "$(git log -1 --pretty=format:'%s')format, ")
       - name: Push if it is not up to date
         run: |
           git status

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -63,7 +63,8 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.issues.createComment({...context.issue, body: `I have updated your lock dirs and formatted the code. Please @${context.actor} pull the last commit before pushing any more changes.`});
+            if (require("child_process").execSync("git log -1 --pretty=format:'%an'") == "Github Runner")
+              github.issues.createComment({...context.issue, body: `I have updated your lock dirs and formatted the code. Please @${context.actor} pull the last commit before pushing any more changes.`});
 
   doc:
     name: Push docs to GitHub's Pages

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -35,17 +35,19 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ steps.print_esy_cache.outputs.esy_cache }}
-          key: macos-latest-4.08-${{ hashFiles('**/index.json') }}
+          key: macos-latest-${{ hashFiles('**/index.json') }}
       - name: Build dependencies
         if: steps.deps-cache-macos.outputs.cache-hit != 'true'
         run: esy build-dependencies --release
       - name: Generate opam files
         run: |
           esy build dune build @check
+          git status
           git diff --exit-code --cached || (git add *opam; git commit -m "opam, ")
       - name: format sources files
         run: |
           esy format
+          git status
           git diff --exit-code --cached || [[ "$(git log -1 --pretty=format:'%an')" != "Github Runner" ]] && git commit -am "format, " || git commit --amend -am $(git log -1 --pretty=format:'%s')"format, "
       - name: Push if it is not up to date
         run: |

--- a/doc.json
+++ b/doc.json
@@ -12,6 +12,6 @@
 	},
 	  "devDependencies": {
 	    "ocaml": ">=4.6.0 <4.9.0"
-	  }
+	  
   }
 }

--- a/doc.json
+++ b/doc.json
@@ -12,6 +12,6 @@
 	},
 	  "devDependencies": {
 	    "ocaml": ">=4.6.0 <4.9.0"
-	  
+	  }
   }
 }

--- a/doc.json
+++ b/doc.json
@@ -10,8 +10,8 @@
 	  "@opam/odoc": "*",
 	  "http-server": "*"
 	},
-	  "devDependencies": {
+	"devDependencies": {
 	    "ocaml": ">=4.6.0 <4.9.0"
-	  }
+	 
   }
 }

--- a/doc.json
+++ b/doc.json
@@ -12,6 +12,6 @@
 	},
 	"devDependencies": {
 	    "ocaml": ">=4.6.0 <4.9.0"
-	 
+	}
   }
 }

--- a/src/Revery.re
+++ b/src/Revery.re
@@ -13,7 +13,7 @@ module Math = Revery_Math;
 module Native = Revery_Native;
 
 module UI = {
-include Revery_UI;
+  include Revery_UI;
   include Revery_UI_Primitives;
 
   /*

--- a/src/Revery.re
+++ b/src/Revery.re
@@ -28,4 +28,4 @@ module Platform = {
   include Platform;
 };
 
-module Utility = Revery_Utility
+module Utility = Revery_Utility;

--- a/src/Revery.re
+++ b/src/Revery.re
@@ -28,4 +28,4 @@ module Platform = {
   include Platform;
 };
 
-module Utility = Revery_Utility;
+module Utility = Revery_Utility

--- a/src/Revery.re
+++ b/src/Revery.re
@@ -13,7 +13,7 @@ module Math = Revery_Math;
 module Native = Revery_Native;
 
 module UI = {
-  include Revery_UI;
+include Revery_UI;
   include Revery_UI_Primitives;
 
   /*


### PR DESCRIPTION
Ok so now lockdir update should be more resilient to package.json non-valid.

the issue before we removed all the lockdir to ensure we have a clean lockdir and we could detect newer dependencies that will break our build. So if a commit without a lockdir is pushed the CI was out. I have opted for a soft `esy install` I will bring the old behaviour back with the new @revery-bot after.