### PR TITLE
Update table of contents of docs

### DIFF
--- a/src/index.mld
+++ b/src/index.mld
@@ -18,7 +18,7 @@ Framework for fast, native code, cross-platform GUI applications.
                 {li {{:#ComponentModel} Component Model}}
                 {li
                     {ul
-                        {li {{:#BasicComponentModel} Basic Components}}
+                        {li {{:#BasicFunctionalComponent} Basic Components}}
                         {li {{:#HooksComponent} Components with Hooks}}
                     }
                 }
@@ -28,30 +28,48 @@ Framework for fast, native code, cross-platform GUI applications.
   {li
     {ul
                 {li {{:../Revery/Revery_Core/App/index.html} App}}
+                {li {{:../Revery/Revery_Core/Color/index.html} Color}}
                 {li {{:../Revery/Revery_Core/Colors/index.html} Colors}}
                 {li {{:../Revery/Revery_Core/Environment/index.html} Environment}}
+                {li {{:../Revery/Revery_Core/Event/index.html} Event}}
+                {li {{:../Revery/Revery_Core/Events/index.html} Events}}
+                {li {{:../Revery/Revery_Core/Internal/index.html} Internal}}
                 {li {{:../Revery/Revery_Core/Key/index.html} Key}}
-                {li {{:../Revery/Revery_Core/Monitor/index.html} Monitor}}
+                {li {{:../Revery/Revery_Core/Log/index.html} Log}}
                 {li {{:../Revery/Revery_Core/MouseButton/index.html} MouseButton}}
                 {li {{:../Revery/Revery_Core/MouseCursors/index.html} MouseCursors}}
+                {li {{:../Revery/Revery_Core/Performance/index.html} Performance}}
+                {li {{:../Revery/Revery_Core/TextOverflow/index.html} TextOverflow}}
+                {li {{:../Revery/Revery_Core/TextWrapping/index.html} TextWrapping}}
                 {li {{:../Revery/Revery_Core/Tick/index.html} Tick}}
                 {li {{:../Revery/Revery_Core/Time/index.html} Time}}
+                {li {{:../Revery/Revery_Core/UniqueId/index.html} UniqueId}}
+                {li {{:../Revery/Revery_Core/Vsync/index.html} Vsync}}
                 {li {{:../Revery/Revery_Core/Window/index.html} Window}}
                 {li {{:../Revery/Revery_Core/WindowCreateOptions/index.html} WindowCreateOptions}}
+                {li {{:../Revery/Revery_Core/WindowStyles/index.html} WindowStyles}}
             }
     }
   {li Components}
   {li
     {ul
                 {li {{:../Revery/Revery_UI_Components/Button/index.html} Button}}
+                {li {{:../Revery/Revery_UI_Components/Center/index.html} Center}}
                 {li {{:../Revery/Revery_UI_Components/Checkbox/index.html} Checkbox}}
                 {li {{:../Revery/Revery_UI_Components/Clickable/index.html} Clickable}}
                 {li {{:../Revery/Revery_UI_Components/ClipContainer/index.html} ClipContainer}}
+                {li {{:../Revery/Revery_UI_Components/Column/index.html} Column}}
                 {li {{:../Revery/Revery_UI_Components/Container/index.html} Container}}
                 {li {{:../Revery/Revery_UI_Components/Dropdown/index.html} Dropdown}}
+                {li {{:../Revery/Revery_UI_Components/DropdownInt/index.html} DropdownInt}}
+                {li {{:../Revery/Revery_UI_Components/DropdownString/index.html} DropdownString}}
+                {li {{:../Revery/Revery_UI_Components/ExpandContainer/index.html} ExpandContainer}}
                 {li {{:../Revery/Revery_UI_Components/Input/index.html} Input}}
                 {li {{:../Revery/Revery_UI_Components/Positioned/index.html} Positioned}}
                 {li {{:../Revery/Revery_UI_Components/RadioButtons/index.html} RadioButtons}}
+                {li {{:../Revery/Revery_UI_Components/RadioButtonsInt/index.html} RadioButtonsInt}}
+                {li {{:../Revery/Revery_UI_Components/RadioButtonsString/index.html} RadioButtonsString}}
+                {li {{:../Revery/Revery_UI_Components/Row/index.html} Row}}
                 {li {{:../Revery/Revery_UI_Components/ScrollView/index.html} ScrollView}}
                 {li {{:../Revery/Revery_UI_Components/Slider/index.html} Slider}}
                 {li {{:../Revery/Revery_UI_Components/Stack/index.html} Stack}}
@@ -59,29 +77,81 @@ Framework for fast, native code, cross-platform GUI applications.
                 {li {{:../Revery/Revery_UI_Components/Tree/index.html} Tree}}
             }
     }
+  {li Draw}
+  {li
+    {ul
+                {li {{:../Revery/Revery_Draw/CanvasContext/index.html} CanvasContext}}
+                {li {{:../Revery/Revery_Draw/DebugDraw/index.html} DebugDraw}}
+                {li {{:../Revery/Revery_Draw/ImageResizeMode/index.html} ImageResizeMode}}
+                {li {{:../Revery/Revery_Draw/Text/index.html} Text}}
+            }
+    }
+  {li Fonts}
+  {li
+    {ul
+                {li {{:../Revery/Revery_Font/Discovery/index.html} Discovery}}
+                {li {{:../Revery/Revery_Font/FontCache/index.html} FontCache}}
+                {li {{:../Revery/Revery_Font/FontMetrics/index.html} FontMetrics}}
+                {li {{:../Revery/Revery_Font/FontRenderer/index.html} FontRenderer}}
+                {li {{:../Revery/Revery_Font/ShapeResult/index.html} ShapeResult}}
+                {li {{:../Revery/Revery_Font/Smoothing/index.html} Smoothing}}
+            }
+    }
   {li Hooks}
   {li
     {ul
-                {li {{:../Revery/Revery_UI_Hooks__/Animation/index.html} animation}}
                 {li {{:../Revery/Revery_UI_Hooks__/Effect/index.html} effect}}
                 {li {{:../Revery/Revery_UI_Hooks__/Reducer/index.html} reducer}}
                 {li {{:../Revery/Revery_UI_Hooks__/Ref/index.html} ref}}
+                {li {{:../Revery/Revery_UI_Hooks__/Spring/index.html} spring}}
                 {li {{:../Revery/Revery_UI_Hooks__/State/index.html} state}}
                 {li {{:../Revery/Revery_UI_Hooks__/Tick/index.html} tick}}
-                {li {{:../Revery/Revery_UI_Hooks__/Transition/index.html} transition}}
+                {li {{:../Revery/Revery_UI_Hooks__/Timer/index.html} timer}}
+            }
     }
-  }
   {li Math}
   {li
     {ul
+                {li {{:../Revery/Revery_Math/Angle/index.html} Angle}}
                 {li {{:../Revery/Revery_Math/BoundingBox2d/index.html} BoundingBox2d}}
-                {li {{:../Revery/Revery_Math/Rectangle/index.html} Rectangle}}
+            }
     }
-  }
-  {li Platform}
+  {li Native}
   {li
     {ul
-                {li {{:../Revery/Revery/Platform/index.html} Dialog}}
+                {li {{:../Revery/Revery_Native/Dialog/index.html} Dialog}}
+                {li {{:../Revery/Revery_Native/Icon/index.html} Icon}}
+                {li {{:../Revery/Revery_Native/Notification/index.html} Notification}}
+            }
+    }
+  {li UI}
+  {li
+    {ul
+                {li {{:../Revery/Revery_UI/Animation/index.html} Animation}}
+                {li {{:../Revery/Revery_UI/Container/index.html} Container}}
+                {li {{:../Revery/Revery_UI/Dimensions/index.html} Dimensions}}
+                {li {{:../Revery/Revery_UI/Easing/index.html} Easing}}
+                {li {{:../Revery/Revery_UI/Focus/index.html} Focus}}
+                {li {{:../Revery/Revery_UI/ImageResizeMode/index.html} ImageResizeMode}}
+                {li {{:../Revery/Revery_UI/Keyboard/index.html} Keyboard}}
+                {li {{:../Revery/Revery_UI/Layout/index.html} Layout}}
+                {li {{:../Revery/Revery_UI/Mouse/index.html} Mouse}}
+                {li {{:../Revery/Revery_UI/NodeDrawContext/index.html} NodeDrawContext}}
+                {li {{:../Revery/Revery_UI/NodeEvents/index.html} NodeEvents}}
+                {li {{:../Revery/Revery_UI/Offset/index.html} Offset}}
+                {li {{:../Revery/Revery_UI/React/index.html} React}}
+                {li {{:../Revery/Revery_UI/Selector/index.html} Selector}}
+                {li {{:../Revery/Revery_UI/Spring/index.html} Spring}}
+                {li {{:../Revery/Revery_UI/Style/index.html} Style}}
+                {li {{:../Revery/Revery_UI/Transform/index.html} Transform}}
+                {li {{:../Revery/Revery_UI/UiEvents/index.html} UiEvents}}
+            }
+    }
+  {li Utility}
+  {li
+    {ul
+                {li {{:../Revery/Revery_Utility/HeadlessWindow/index.html} HeadlessWindow}}
+            }
     }
   }
 }
@@ -89,13 +159,13 @@ Framework for fast, native code, cross-platform GUI applications.
 </nav>
 %}
 
-{2:overview Overview}
+{2:Overview Overview}
 
 Revery is a framework for building cross-platform GUI applications. Revery provides a React-like, functional approach for modeling UI, as well as scaffolding for managing the application lifecycle.
 
 Revery started as the foundation of {{:https://v2.onivim.io} Onivim 2}, but was factored out into a general toolkit for {{:https://reasonml.github.io} ReasonML} user interfaces.
 
-{2:quickstart Quickstart}
+{2:Quickstart Quickstart}
 
 There are two ways to get started:
 {ul


### PR DESCRIPTION
This PR updates the table of contents of the docs to link to all current modules. I also fixed a few broken links/anchors.

I think this closes: #650, and #810 

In case it's useful to anyone this is the script (`generate-toc`) I used to generate it:

```ruby
#!/usr/bin/env ruby

require 'pathname'

MODULES = {
  'API' => 'Revery_Core',
  'Components' => 'Revery_UI_Components',
  'Draw' => 'Revery_Draw',
  'Fonts' => 'Revery_Font',
  'Hooks' => 'Revery_UI_Hooks__',
  'Math' => 'Revery_Math',
  'Native' => 'Revery_Native',
  'UI' => 'Revery_UI',
  'Utility' => 'Revery_Utility',
}
base_path = ARGV.shift

if base_path.nil?
  warn 'Usage generate-nav _esy/doc/store/b/revery-xxxxxxxx/default/_doc/_html/Revery'
  exit 2
end

base_path = Pathname(base_path)

SubModule = Struct.new(:name, :href)

MODULES.each do |mod, path|
  mod_path = base_path + path

  puts "  {li #{mod}}"
  puts "  {li\n    {ul"

  sub_modules = []
  mod_path.each_child(false) do |child|
    candidate = base_path + path + child + 'index.html'
    if candidate.file?
      href = Pathname('../Revery') + path + child + 'index.html'
      name = mod == 'Hooks' ? child.to_s.downcase : child.to_s
      sub_modules << SubModule.new(name, href)
    end
  end

  # sort
  sub_modules.sort_by!(&:name)

  sub_modules.each do |mod|
    puts "                {li {{:#{mod.href}} #{mod.name}}}"
  end

  puts "            }"
  puts "    }"
end
```