### PR TITLE
Bugfix - Font Smoothing: Use subpixel text as default

### DIFF
--- a/src/Font/Smoothing.re
+++ b/src/Font/Smoothing.re
@@ -1,5 +1,3 @@
-open Revery_Core;
-
 type t =
   | None
   | Antialiased

--- a/src/Font/Smoothing.re
+++ b/src/Font/Smoothing.re
@@ -5,14 +5,11 @@ type t =
   | Antialiased
   | SubpixelAntialiased;
 
-let default =
-  switch (Environment.os) {
-  | Windows => SubpixelAntialiased
-  // On OSX, default to non-subpixel for Retina displays.
-  // On Linux, subpixel does not reliably set subpixel rendering,
-  // so default to false and make it opt-in
-  | _ => Antialiased
-  };
+// Default to subpixel-antialiased, as it has the most reliable
+// scaling characteristics - see Onivim 2 bugs:
+// - https://github.com/onivim/oni2/issues/1475
+// - https://github.com/onivim/oni2/issues/1592
+let default = SubpixelAntialiased;
 
 let setPaint = (~smoothing: t, paint: Skia.Paint.t) => {
   switch (smoothing) {


### PR DESCRIPTION
__Issue:__ There were several issues reported with Onivim, where the text / cursor wouldn't match up, ie:
https://github.com/onivim/oni2/issues/1475
https://github.com/onivim/oni2/issues/1592

(And I know @CrossR has to help lots of people troubleshoot / tell them to switch their font settings to `subpixel-antialiased`).

__Defect:__ From my investigation - it seems that in the case of a scaled display (ie, using `--force-device-scale-factor`, or an inferred scale, like `GDK_SCALE`) could cause the text metrics to be calculated incorrectly (at least, out of sync with how they are rendered).

The main issue is that text sizes may scale non-linearly - so, if a font has a measured width of `7.5px` at `14px` line height, there's no guarantee that the same font at a `28px` line height will have a width of `15px`.

Some notes here about how scaling: https://groups.google.com/d/msg/skia-discuss/0P6S8gkx3n8/c4PVzRc2AgAJ

In particular, we should look at / log the hinting settings too - especially relevant on Linux.

__Fix:__ Change the default text smoothing to subpixel-antialiased, so that font rendering works correctly out-of-box when scaled.

I noted here that 'subpixel does not reliably set subpixel rendering' - but I believe this was actually erroneous (I haven't seen issues on any Linux build I've tested recently) - I think there were issues when I first brought Skia in, but it was due to measuring w/o the same smoothing settings as rendering (subpixel text changes the glyph sizes).