### PR TITLE
add password type inputs

### DIFF
--- a/examples/InputExample.re
+++ b/examples/InputExample.re
@@ -37,12 +37,12 @@ module Example = {
     first: string,
     second: string,
     third: string,
-    typePassword: bool,
+    isPassword: bool,
   };
 
   let%component make = () => {
-    let%hook ({first, typePassword, _}, setValue) =
-      Hooks.state({first: "", second: "", third: "", typePassword: false});
+    let%hook ({first, isPassword, _}, setValue) =
+      Hooks.state({first: "", second: "", third: "", isPassword: false});
 
     <View style=containerStyle>
       <View
@@ -86,19 +86,17 @@ module Example = {
               setValue(state => {...state, first: value})
             }
             value=first
-            typePassword
+            isPassword
           />
           <View style=controlsStyle>
             <Text style=textStyle text="Obscure Input" />
             <Checkbox
               checkedColor=Colors.green
               onChange={() =>
-                setValue(state =>
-                  {...state, typePassword: !state.typePassword}
-                )
+                setValue(state => {...state, isPassword: !state.isPassword})
               }
               style=Style.[border(~width=2, ~color=Colors.green)]
-              checked=typePassword
+              checked=isPassword
             />
           </View>
         </View>

--- a/examples/InputExample.re
+++ b/examples/InputExample.re
@@ -12,17 +12,37 @@ let containerStyle =
     alignItems(`Center),
     justifyContent(`Center),
     flexDirection(`Column),
-    backgroundColor(Colors.white),
+  ];
+
+let controlsStyle =
+  Style.[
+    margin(10),
+    flexDirection(`Row),
+    justifyContent(`Center),
+    alignItems(`Center),
+  ];
+
+let textStyle =
+  Style.[
+    color(Colors.white),
+    width(100),
+    fontFamily("Roboto-Regular.ttf"),
+    fontSize(16.),
+    margin(14),
+    textWrap(TextWrapping.NoWrap),
   ];
 
 module Example = {
   type inputFields = {
     first: string,
     second: string,
+    third: string,
+    typePassword: bool,
   };
 
   let%component make = () => {
-    let%hook ({first, _}, setValue) = Hooks.state({first: "", second: ""});
+    let%hook ({first, typePassword, _}, setValue) =
+      Hooks.state({first: "", second: "", third: "", typePassword: false});
 
     <View style=containerStyle>
       <View
@@ -53,6 +73,36 @@ module Example = {
           onClick={() => setValue(state => {...state, first: "New value"})}
         />
       </View>
+      <Padding padding=20>
+        <View
+          style=Style.[
+            flexDirection(`Row),
+            alignItems(`Center),
+            justifyContent(`Center),
+          ]>
+          <Input
+            placeholder="Insert text here"
+            onChange={(value, _) =>
+              setValue(state => {...state, first: value})
+            }
+            value=first
+            typePassword
+          />
+          <View style=controlsStyle>
+            <Text style=textStyle text="Obscure Input" />
+            <Checkbox
+              checkedColor=Colors.green
+              onChange={() =>
+                setValue(state =>
+                  {...state, typePassword: !state.typePassword}
+                )
+              }
+              style=Style.[border(~width=2, ~color=Colors.green)]
+              checked=typePassword
+            />
+          </View>
+        </View>
+      </Padding>
       <Padding padding=20>
         <BoxShadow
           boxShadow={Style.BoxShadow.make(

--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -106,10 +106,6 @@ let addCharacter = (word, char, index) => {
   (startStr ++ char ++ endStr, String.length(startStr) + 1);
 };
 
-let renderAsPassword = value => {
-  StringLabels.map(value, ~f=_ => '*');
-};
-
 let reducer = (action, state) =>
   switch (action) {
   | Focus => {...state, isFocused: true}
@@ -210,7 +206,7 @@ let%component make =
                 ~onChange=(_, _) => (),
                 ~value=?,
                 ~cursorPosition=?,
-                ~typePassword=false,
+                ~isPassword=false,
                 (),
               ) => {
   let%hook (state, dispatch) =
@@ -376,7 +372,7 @@ let%component make =
       ref={node => textRef := Some(node)}
       text={
         showPlaceholder
-          ? placeholder : typePassword ? renderAsPassword(value) : value
+          ? placeholder : isPassword ? String.map(_ => '*', value) : value
       }
       smoothing
       style={Styles.text(

--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -367,13 +367,19 @@ let%component make =
     </View>;
   };
 
+  let text =
+    if (showPlaceholder) {
+      placeholder;
+    } else if (isPassword) {
+      String.map(_ => '*', value);
+    } else {
+      value;
+    };
+
   let text = () =>
     <Text
       ref={node => textRef := Some(node)}
-      text={
-        showPlaceholder
-          ? placeholder : isPassword ? String.map(_ => '*', value) : value
-      }
+      text
       smoothing
       style={Styles.text(
         ~showPlaceholder,

--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -106,6 +106,10 @@ let addCharacter = (word, char, index) => {
   (startStr ++ char ++ endStr, String.length(startStr) + 1);
 };
 
+let renderAsPassword = value => {
+  StringLabels.map(value, ~f=_ => '*');
+};
+
 let reducer = (action, state) =>
   switch (action) {
   | Focus => {...state, isFocused: true}
@@ -206,6 +210,7 @@ let%component make =
                 ~onChange=(_, _) => (),
                 ~value=?,
                 ~cursorPosition=?,
+                ~typePassword=false,
                 (),
               ) => {
   let%hook (state, dispatch) =
@@ -369,7 +374,10 @@ let%component make =
   let text = () =>
     <Text
       ref={node => textRef := Some(node)}
-      text={showPlaceholder ? placeholder : value}
+      text={
+        showPlaceholder
+          ? placeholder : typePassword ? renderAsPassword(value) : value
+      }
       smoothing
       style={Styles.text(
         ~showPlaceholder,


### PR DESCRIPTION
This adds a boolean option to the input component to obscure the entered value on render:

![Screenshot from 2020-05-02 17-13-42](https://user-images.githubusercontent.com/927609/80868070-755a6f00-8c98-11ea-8fa5-2c6b22b9f962.png)


The name `typePassword` is based on the [input type of html element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password). I can change it if something like `obscureValue` makes more sense.