### PR TITLE
refactor(window): Update Window API to differentiate between scaled/unscaled sizes

### DIFF
--- a/.ci/esy-check-hygiene.yml
+++ b/.ci/esy-check-hygiene.yml
@@ -29,3 +29,5 @@ steps:
     displayName: esy format
   - script: git diff --exit-code
     displayName: 'check that formatting is correct. If this fails, run `esy format` and re-submit PR.'
+  - script: esy b dune build @check
+    displayName: 'esy b dune build @check'

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -297,12 +297,6 @@ let setSize = (~width: int, ~height: int, win: t) => {
   Internal.setRawSize(win, adjWidth, adjHeight);
 };
 
-let setUnscaledSize = (~width: int, ~height: int, win: t) => {
-  Log.tracef(m => m("setUnscaledSize - calling with: %ux%u", width, height));
-
-  Internal.setRawSize(win, width, height);
-};
-
 let setZoom = (w: t, zoom: float) => {
   w.metrics = {...w.metrics, zoom: max(zoom, 0.1)};
   w.areMetricsDirty = true;
@@ -665,8 +659,6 @@ let hide = w => {
 };
 
 let getSize = ({metrics, _}) => metrics.scaledSize;
-
-let getUnscaledSize = ({metrics, _}) => metrics.unscaledSize;
 
 let getPosition = window => {
   Sdl2.Window.getPosition(window.sdlWindow);

--- a/src/Core/Window.rei
+++ b/src/Core/Window.rei
@@ -43,10 +43,7 @@ let getDevicePixelRatio: t => float;
   [getSize(window)] returns a [size] describing the window dimensions, accounting for display scaling.
 */
 let getSize: t => size;
-/**
-  [getUnscaledSize(window)] is like [getSize], but ignores display scaling.
-*/
-let getUnscaledSize: t => size;
+
 let getFramebufferSize: t => size;
 
 /**
@@ -57,11 +54,6 @@ let getFramebufferSize: t => size;
   the behavior you want. To directly set the size, without considering display scaling, use [setUnscaledSize]
 */
 let setSize: (~width: int, ~height: int, t) => unit;
-
-/**
-  [setUnscaledSize(~width, ~height, window)] sets the window size, without accounting for display scaling.
-*/
-let setUnscaledSize: (~width: int, ~height: int, t) => unit;
 
 let getPosition: t => (int, int);
 let getScaleAndZoom: t => float;

--- a/src/Core/Window.rei
+++ b/src/Core/Window.rei
@@ -38,9 +38,31 @@ let onFileDropped: (t, fileDropEvent => unit) => unsubscribe;
 let canQuit: t => bool;
 
 let getDevicePixelRatio: t => float;
-let getFramebufferSize: t => size;
+
+/**
+  [getSize(window)] returns a [size] describing the window dimensions, accounting for display scaling.
+*/
 let getSize: t => size;
-let getRawSize: t => size;
+/**
+  [getUnscaledSize(window)] is like [getSize], but ignores display scaling.
+*/
+let getUnscaledSize: t => size;
+let getFramebufferSize: t => size;
+
+/**
+  [setSize(~width, ~height, window)] sets the window size, taking display scaling into account.
+
+  For example, for a Windows display with 200% scaling, [setSize(~width=400, ~height=300, window)],
+  will actually set the window to a height of 800 pixels wide by 600 pixels high. This is usually
+  the behavior you want. To directly set the size, without considering display scaling, use [setUnscaledSize]
+*/
+let setSize: (~width: int, ~height: int, t) => unit;
+
+/**
+  [setUnscaledSize(~width, ~height, window)] sets the window size, without accounting for display scaling.
+*/
+let setUnscaledSize: (~width: int, ~height: int, t) => unit;
+
 let getPosition: t => (int, int);
 let getScaleAndZoom: t => float;
 let getSdlWindow: t => Sdl2.Window.t;
@@ -71,6 +93,11 @@ let setVsync: (t, Vsync.t) => unit;
 let render: t => unit;
 let handleEvent: (Sdl2.Event.t, t) => unit;
 
+/**
+  [create(name, options)] creates a new Revery application window.
+
+  See [WindowCreateOptions] for a list of available options.
+*/
 let create: (string, WindowCreateOptions.t) => t;
 
 let takeScreenshot: (t, string) => unit;

--- a/src/Core/WindowCreateOptions.re
+++ b/src/Core/WindowCreateOptions.re
@@ -34,11 +34,11 @@ type t = {
     */
   y: [ | `Centered | `Absolute(int)],
   /**
-    [width] is the initial horizontal size of the [Window]
+    [width] is the initial horizontal size of the [Window], with display scaling applied.
     */
   width: int,
   /**
-    [height] is the initial vertical size of the [Window]
+    [height] is the initial vertical size of the [Window], with display scaling applied.
   */
   height: int,
   /**

--- a/src/UI/Render.re
+++ b/src/UI/Render.re
@@ -28,7 +28,7 @@ let render =
   );
 
   /* Layout */
-  let size = Window.getRawSize(window);
+  let size = Window.getUnscaledSize(window);
   let pixelRatio = Window.getDevicePixelRatio(window);
   let scaleAndZoomFactor = Window.getScaleAndZoom(window);
   let canvasScalingFactor = pixelRatio *. scaleAndZoomFactor;

--- a/src/UI/Render.re
+++ b/src/UI/Render.re
@@ -28,14 +28,16 @@ let render =
   );
 
   /* Layout */
-  let size = Window.getUnscaledSize(window);
+  let size = Window.getSize(window);
+
   let pixelRatio = Window.getDevicePixelRatio(window);
   let scaleAndZoomFactor = Window.getScaleAndZoom(window);
   let canvasScalingFactor = pixelRatio *. scaleAndZoomFactor;
+
+  let zoomFactor = Window.getZoom(window);
   let adjustedHeight =
-    float_of_int(size.height) /. scaleAndZoomFactor |> int_of_float;
-  let adjustedWidth =
-    float_of_int(size.width) /. scaleAndZoomFactor |> int_of_float;
+    float_of_int(size.height) /. zoomFactor |> int_of_float;
+  let adjustedWidth = float_of_int(size.width) /. zoomFactor |> int_of_float;
 
   RenderContainer.updateCanvas(window, renderContainer);
 


### PR DESCRIPTION
Motivated by https://github.com/onivim/oni2/pull/1752 - this addresses an inconsistency in the Revery `Window` API in talking about sizes - there are two window sizes that SDL gives us - the 'screen space' size, and the 'framebuffer' size. On top of that, we also account for display scaling (like frameworks like Electron handle). So that makes three 'spaces' for window sizes:

1) Screen space size
2) Screen space size, _scaled based on display settings_
3) Framebuffer pixel size (the size of the 'backbuffer' that we render to - this is in pixels can vary depending on the device pixel ratio of the screen. For example, retina displays would be some multiple of the screen space size).

For the purposes of window management, we only care about 1 & 2 - framebuffer size is important for rendering though.

We run into case 2 in Linux with `GDK_SCALE` applied, or zoomed display settings on Windows. When the `scaleFactor` is 1, cases 1/2 are equivalent.

The problem was, the API surface wasn't consistent in handling scaling - `create`, `getSize`, and `setSize` should all be consistent in the space they use - which they weren't. `create` would use coordinates in the 'display scaled' space (2), but getSize/getRawSize would get the dimensions in unscaled space (1) - and `setSize` would also retrieve dimensions in unscaled space. This is confusing and inconsistent, and caused problems in https://github.com/onivim/oni2/pull/1752, because we'd use `getSize` to read the window dimensions (without scaling applied), and then on startup we'd apply scaling to them, causing the window to grow in size, because each `create` would re-apply scaling.

__TODO:__
- [x] Test on Linux with `GDK_SCALE` set
- [x] Test on retina OSX display
- [x] Test on non-retina OSX display
- [x] Test on unscaled Windows display
- [x] Test on Windows display with display scaling
(test example app, example with zoom, Onivim 2 text rendering, Onivim 2 persistence round trip)