### PR TITLE
fix(test/#843): Fix windows output for test cases

### DIFF
--- a/test/TestRunner.re
+++ b/test/TestRunner.re
@@ -1,3 +1,10 @@
+// On Windows, because this is linked against the '-mwindows' flag
+// (for a GUI app), we need to manually allocate a console.
+if (Sys.win32) {
+  let _: int = Sdl2.Platform.win32AttachConsole();
+  Pastel.setMode(Pastel.Disabled);
+};
+
 Revery_Core_Test.TestFramework.cli();
 Revery_Math_Test.TestFramework.cli();
 Revery_UI_Test.TestFramework.cli();

--- a/test/TestRunner.re
+++ b/test/TestRunner.re
@@ -2,7 +2,7 @@
 // (for a GUI app), we need to manually allocate a console.
 if (Sys.win32) {
   let _: int = Sdl2.Platform.win32AttachConsole();
-  // Unfortunately, the colors aren't showing up correctly with the 
+  // Unfortunately, the colors aren't showing up correctly with the
   // attached console - so I'll disable them for now.
   Pastel.setMode(Pastel.Disabled);
 };

--- a/test/TestRunner.re
+++ b/test/TestRunner.re
@@ -2,6 +2,8 @@
 // (for a GUI app), we need to manually allocate a console.
 if (Sys.win32) {
   let _: int = Sdl2.Platform.win32AttachConsole();
+  // Unfortunately, the colors aren't showing up correctly with the 
+  // attached console - so I'll disable them for now.
   Pastel.setMode(Pastel.Disabled);
 };
 


### PR DESCRIPTION
__Issue:__ `esy @test run` stopped producing output on all the windows devices I tried.

__Defect:__ Linking in `reason-sdl2` brings in the `-mwindows` flag, which causes the application to not allocate or attach console.

__Fix:__ Explicitly attach a console for the test runner.

Fixes #843  - I guess we both hit this at the same time, @Et7f3 !