### PR TITLE
feat(window): bind Node mouseBehavior to SDL hit-tests

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -155,6 +155,11 @@ let examples = [
     render: _ => URLFileOpen.render(),
     source: "URLFileOpen.re",
   },
+  {
+    name: "Window: Hit Tests/Zones",
+    render: _ => HitTests.render(),
+    source: "HitTests.re",
+  },
 ];
 
 let getExampleByName = name =>

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -157,7 +157,7 @@ let examples = [
   },
   {
     name: "Window: Hit Tests/Zones",
-    render: _ => HitTests.render(),
+    render: w => HitTests.render(w),
     source: "HitTests.re",
   },
 ];
@@ -271,13 +271,15 @@ let init = app => {
   |> (ignore: Revery.App.unsubscribe => unit);
 
   let initialExample = ref("Animation");
+  let decorated = ref(true);
   Arg.parse(
     [
       ("--trace", Unit(() => Timber.App.setLevel(Timber.Level.trace)), ""),
+      ("--no-decoration", Unit(() => decorated := false), ""),
       ("--example", String(name => initialExample := name), ""),
     ],
     _ => (),
-    "There is only --trace and --example",
+    "There is only --trace, --example, and --no-decoration",
   );
   let initialExample = initialExample^;
 
@@ -298,6 +300,7 @@ let init = app => {
           ~maximized,
           ~titlebarStyle=Transparent,
           ~icon=Some("revery-icon.png"),
+          ~decorated=decorated^,
           (),
         ),
       app,

--- a/examples/HitTests.re
+++ b/examples/HitTests.re
@@ -1,0 +1,44 @@
+open Revery;
+open Revery.UI;
+
+module Styles = {
+  open Style;
+
+  let outer = [
+    position(`Absolute),
+    top(0),
+    bottom(0),
+    left(0),
+    right(0),
+    justifyContent(`Center),
+    alignItems(`Center),
+  ];
+
+  let draggable = [
+    width(100),
+    height(100),
+    backgroundColor(Colors.blue),
+    justifyContent(`Center),
+    alignItems(`Center),
+  ];
+
+  let text =
+    Style.[
+      color(Colors.white),
+      fontFamily("Roboto-Regular.ttf"),
+      fontSize(14.),
+    ];
+};
+
+let hitTests = () =>
+  <View style=Styles.outer>
+    <View style=Styles.draggable mouseBehavior=Draggable>
+      <Text
+        text="Drag window from here!"
+        style=Styles.text
+        mouseBehavior=Draggable
+      />
+    </View>
+  </View>;
+
+let render = () => <hitTests />;

--- a/examples/HitTests.re
+++ b/examples/HitTests.re
@@ -32,20 +32,18 @@ module Styles = {
 
 let hitTests = (~window, ()) =>
   <View style=Styles.outer>
-    {
-      Window.isDecorated(window) ?
-        <Text
-          text="Window decorations must not be enabled.\nRestart with --no-decoration"
-          style=Styles.text
-        /> :
-        <View style=Styles.draggable mouseBehavior=Draggable>
-          <Text
-            text="Drag window from here!"
-            style=Styles.text
-            mouseBehavior=Draggable
-          />
-        </View>
-    }
+    {Window.isDecorated(window)
+       ? <Text
+           text="Window decorations must not be enabled.\nRestart with --no-decoration"
+           style=Styles.text
+         />
+       : <View style=Styles.draggable mouseBehavior=Draggable>
+           <Text
+             text="Drag window from here!"
+             style=Styles.text
+             mouseBehavior=Draggable
+           />
+         </View>}
   </View>;
 
 let render = window => <hitTests window />;

--- a/examples/HitTests.re
+++ b/examples/HitTests.re
@@ -30,15 +30,22 @@ module Styles = {
     ];
 };
 
-let hitTests = () =>
+let hitTests = (~window, ()) =>
   <View style=Styles.outer>
-    <View style=Styles.draggable mouseBehavior=Draggable>
-      <Text
-        text="Drag window from here!"
-        style=Styles.text
-        mouseBehavior=Draggable
-      />
-    </View>
+    {
+      Window.isDecorated(window) ?
+        <Text
+          text="Window decorations must not be enabled.\nRestart with --no-decoration"
+          style=Styles.text
+        /> :
+        <View style=Styles.draggable mouseBehavior=Draggable>
+          <Text
+            text="Drag window from here!"
+            style=Styles.text
+            mouseBehavior=Draggable
+          />
+        </View>
+    }
   </View>;
 
-let render = () => <hitTests />;
+let render = window => <hitTests window />;

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -157,6 +157,7 @@ type t = {
   mutable isComposingText: bool,
   mutable dropState: option(list(string)),
   titlebarStyle: WindowStyles.titlebar,
+  isDecorated: bool,
   onBeforeRender: Event.t(unit),
   onAfterRender: Event.t(unit),
   onBeforeSwap: Event.t(unit),
@@ -284,6 +285,8 @@ let isDirty = (w: t) =>
   } else {
     w.requestedUnscaledSize != None;
   };
+
+let isDecorated = (w: t) => w.isDecorated;
 
 let getSdlWindow = (w: t) => w.sdlWindow;
 
@@ -553,6 +556,8 @@ let create = (name: string, options: WindowCreateOptions.t) => {
     dropState: None,
 
     forceScaleFactor: options.forceScaleFactor,
+
+    isDecorated: options.decorated,
 
     onBeforeRender: Event.create(),
     onAfterRender: Event.create(),

--- a/src/Core/Window.rei
+++ b/src/Core/Window.rei
@@ -65,6 +65,8 @@ let getBackgroundColor: t => Color.t;
 
 let isDirty: t => bool;
 
+let isDecorated: t => bool;
+
 let setInputRect: (t, int, int, int, int) => unit;
 let startTextInput: t => unit;
 let stopTextInput: t => unit;

--- a/src/Core/WindowCreateOptions.re
+++ b/src/Core/WindowCreateOptions.re
@@ -15,7 +15,7 @@ type t = {
   /**
     If [decorated] is true, the window will be framed with the OS-specific adorners.
     If false, the default chrome behavior on the OS will be disabled and (if you want
-    to maintain that funtionality) you must implement it yourself through the
+    to maintain that functionality) you must implement it yourself through the
     mouseBehavior attribute on Views
     */
   decorated: bool,

--- a/src/Core/WindowCreateOptions.re
+++ b/src/Core/WindowCreateOptions.re
@@ -14,6 +14,9 @@ type t = {
   maximized: bool,
   /**
     If [decorated] is true, the window will be framed with the OS-specific adorners.
+    If false, the default chrome behavior on the OS will be disabled and (if you want
+    to maintain that funtionality) you must implement it yourself through the
+    mouseBehavior attribute on Views
     */
   decorated: bool,
   /**

--- a/src/UI/HitTest.re
+++ b/src/UI/HitTest.re
@@ -7,7 +7,7 @@ let windowCallback = (node, window) =>
   Some(
     (sdlWindow, mouseX, mouseY) =>
       Sdl2.Window.(
-        if (sdlWindow == Window.getSdlWindow(window)) {
+        if (sdlWindow == Window.getSdlWindow(window) && node#hasRendered()) {
           let deepestNode =
             getTopMostNode(node, float(mouseX), float(mouseY));
           switch (deepestNode) {

--- a/src/UI/HitTest.re
+++ b/src/UI/HitTest.re
@@ -1,0 +1,21 @@
+module Window = Revery_Core.Window;
+open UiEvents;
+
+module Log = (val Revery_Core.Log.withNamespace("Revery.Ui.HitTest"));
+
+let windowCallback = (node, window) =>
+  Some(
+    (sdlWindow, mouseX, mouseY) =>
+      Sdl2.Window.(
+        if (sdlWindow == Window.getSdlWindow(window)) {
+          let deepestNode =
+            getTopMostNode(node, float(mouseX), float(mouseY));
+          switch (deepestNode) {
+          | Some(node) => node#getMouseBehavior()
+          | None => Normal
+          };
+        } else {
+          Normal;
+        }
+      ),
+  );

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -64,6 +64,7 @@ class node (()) = {
   val mutable _isLayoutDirty = true;
   val mutable _forcedMeasurements: option(Dimensions.t) = None;
   val mutable _hasHadNonZeroBlurRadius = false;
+  val mutable _mouseBehavior = Sdl2.Window.Normal;
   // !! WARNING !!
   // These values are not marked as [mutable], but they are mutated
   // via the C FFI for performance.
@@ -444,6 +445,8 @@ class node (()) = {
   pub blur = () => {
     _hasFocus = false;
   };
+  pub setMouseBehavior = behavior => _mouseBehavior = behavior;
+  pub getMouseBehavior = () => _mouseBehavior;
 };
 
 let iter = (f, node: node) => {

--- a/src/UI/Ui.re
+++ b/src/UI/Ui.re
@@ -20,7 +20,7 @@ let _activeWindow: ref(option(Window.t)) = ref(None);
 
 type renderFunction = React.element(React.reveryNode) => unit;
 
-type mouseBehvaior =
+type mouseBehavior =
   Sdl2.Window.hitTestResult =
     | Normal
     | Draggable

--- a/src/UI/Ui.re
+++ b/src/UI/Ui.re
@@ -49,10 +49,12 @@ let start = (window: Window.t, element: React.element(React.reveryNode)) => {
   let container = Container.create(rootNode);
   let ui = RenderContainer.create(window, rootNode, container, mouseCursor);
 
-  Sdl2.Window.setHitTest(
-    Window.getSdlWindow(window),
-    HitTest.windowCallback(rootNode, window),
-  );
+  if (!Window.isDecorated(window)) {
+    Sdl2.Window.setHitTest(
+      Window.getSdlWindow(window),
+      HitTest.windowCallback(rootNode, window),
+    );
+  };
 
   let _ignore = Window.onExposed(window, () => uiDirty := true);
 

--- a/src/UI/Ui.re
+++ b/src/UI/Ui.re
@@ -20,6 +20,19 @@ let _activeWindow: ref(option(Window.t)) = ref(None);
 
 type renderFunction = React.element(React.reveryNode) => unit;
 
+type mouseBehvaior =
+  Sdl2.Window.hitTestResult =
+    | Normal
+    | Draggable
+    | ResizeTopLeft
+    | ResizeTop
+    | ResizeTopRight
+    | ResizeRight
+    | ResizeBottomRight
+    | ResizeBottom
+    | ResizeBottomLeft
+    | ResizeLeft;
+
 let getActiveWindow = () => _activeWindow^;
 
 let start = (window: Window.t, element: React.element(React.reveryNode)) => {
@@ -35,6 +48,11 @@ let start = (window: Window.t, element: React.element(React.reveryNode)) => {
   let mouseCursor: Mouse.Cursor.t = Mouse.Cursor.make();
   let container = Container.create(rootNode);
   let ui = RenderContainer.create(window, rootNode, container, mouseCursor);
+
+  Sdl2.Window.setHitTest(
+    Window.getSdlWindow(window),
+    HitTest.windowCallback(rootNode, window),
+  );
 
   let _ignore = Window.onExposed(window, () => uiDirty := true);
 

--- a/src/UI/Ui.rei
+++ b/src/UI/Ui.rei
@@ -21,3 +21,16 @@ type renderFunction = React.element(React.reveryNode) => unit;
 let start: (Window.t, React.element(React.reveryNode)) => renderFunction;
 
 let getActiveWindow: unit => option(Window.t);
+
+type mouseBehvaior =
+  Sdl2.Window.hitTestResult =
+    | Normal
+    | Draggable
+    | ResizeTopLeft
+    | ResizeTop
+    | ResizeTopRight
+    | ResizeRight
+    | ResizeBottomRight
+    | ResizeBottom
+    | ResizeBottomLeft
+    | ResizeLeft;

--- a/src/UI/Ui.rei
+++ b/src/UI/Ui.rei
@@ -22,7 +22,7 @@ let start: (Window.t, React.element(React.reveryNode)) => renderFunction;
 
 let getActiveWindow: unit => option(Window.t);
 
-type mouseBehvaior =
+type mouseBehavior =
   Sdl2.Window.hitTestResult =
     | Normal
     | Draggable

--- a/src/UI/Ui.rei
+++ b/src/UI/Ui.rei
@@ -22,6 +22,13 @@ let start: (Window.t, React.element(React.reveryNode)) => renderFunction;
 
 let getActiveWindow: unit => option(Window.t);
 
+/** [mouseBehavior] is an alias for SDL2's hit-test results.
+       Each option is fairly self explanatory, but please note that
+       these only work if you set `decorated` to false on window
+       creation. This is unfortunately due to the fact that enabling
+       hit tests causes the default chrome behavior on Windows to no
+       longer work.
+   */
 type mouseBehavior =
   Sdl2.Window.hitTestResult =
     | Normal

--- a/src/UI_Primitives/Text.re
+++ b/src/UI_Primitives/Text.re
@@ -17,6 +17,7 @@ let%nativeComponent make =
                       ~text="",
                       ~smoothing=Revery_Font.Smoothing.default,
                       ~children=React.empty,
+                      ~mouseBehavior=Revery_UI.Normal,
                       (),
                       hooks,
                     ) => (
@@ -64,6 +65,7 @@ let%nativeComponent make =
       tn#setStyle(styles);
       tn#setText(text);
       tn#setSmoothing(smoothing);
+      tn#setMouseBehavior(mouseBehavior);
       node;
     },
     children,

--- a/src/UI_Primitives/View.re
+++ b/src/UI_Primitives/View.re
@@ -24,6 +24,7 @@ let%nativeComponent make =
                       ~onDimensionsChanged=?,
                       ~onBoundingBoxChanged=?,
                       ~onFileDropped=?,
+                      ~mouseBehavior=Revery_UI.Normal,
                       (),
                       hooks,
                     ) => (
@@ -85,6 +86,7 @@ let%nativeComponent make =
       node#setEvents(events);
       node#setStyle(styles);
       node#setTabIndex(tabindex);
+      node#setMouseBehavior(mouseBehavior);
       node;
     },
     children,


### PR DESCRIPTION
This adds an attribute to all nodes that changes their mouse
behavior based on SDL2's hit test results.

i.e.
```reason
<View
  mouseBehavior=Draggable
  ...
/>
```

GIF:
![revery-hit-tests-example](https://user-images.githubusercontent.com/4527949/82494900-4a558500-9ab8-11ea-97b3-dbe6ad782607.gif)

I want to make sure this works cross-platform before I merge it in. I've tested in on macOS and can test on Linux. @bryphe would you be able to test on Windows? That would be super helpful 😃.

- [x] Test on macOS
  - [x] `Draggable`
  - [ ] `Resize`
- [x] Test on Linux
  - [x] `Draggable`
  - [x] `Resize`
- [x] Test on Windows
  - [x] `Draggable`
  - [x] `Resize`

From what I can tell the `Resize` types don't work on macOS. I don't think this is evidence of something wrong either here or in `reason-sdl2`. I'll do some research to see if they're supposed to work.