### PR TITLE
feat(window): add restore function

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -160,6 +160,11 @@ let examples = [
     render: w => HitTests.render(w),
     source: "HitTests.re",
   },
+  {
+    name: "Window: Control",
+    render: w => WindowControl.render(w),
+    source: "WindowControl.re",
+  },
 ];
 
 let getExampleByName = name =>

--- a/examples/WindowControl.re
+++ b/examples/WindowControl.re
@@ -27,8 +27,9 @@ let winControl = (~window as w, ()) =>
   <View style=Styles.outer>
     <Row>
       <Button title="Maximize!" onClick={_ => Window.maximize(w)} />
-      <Button title="Restore!" onClick={_ => Window.restore(w)} />
+      <Button title="Minimize!" onClick={_ => Window.minimize(w)} />
     </Row>
+    <Button title="Restore!" onClick={_ => Window.restore(w)} />
   </View>;
 
 let render = window => <winControl window />;

--- a/examples/WindowControl.re
+++ b/examples/WindowControl.re
@@ -1,0 +1,34 @@
+open Revery;
+open Revery.UI;
+open Revery.UI.Components;
+
+module Styles = {
+  open Style;
+
+  let outer = [
+    position(`Absolute),
+    top(0),
+    bottom(0),
+    left(0),
+    right(0),
+    justifyContent(`Center),
+    alignItems(`Center),
+  ];
+
+  let text =
+    Style.[
+      color(Colors.white),
+      fontFamily("Roboto-Regular.ttf"),
+      fontSize(14.),
+    ];
+};
+
+let winControl = (~window as w, ()) =>
+  <View style=Styles.outer>
+    <Row>
+      <Button title="Maximize!" onClick={_ => Window.maximize(w)} />
+      <Button title="Restore!" onClick={_ => Window.restore(w)} />
+    </Row>
+  </View>;
+
+let render = window => <winControl window />;

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -696,6 +696,10 @@ let isFullscreen = (w: t) => {
   Sdl2.Window.isFullscreen(w.sdlWindow);
 };
 
+let restore = (w: t) => {
+  Sdl2.Window.restore(w.sdlWindow);
+};
+
 let minimize = (w: t) => {
   Sdl2.Window.minimize(w.sdlWindow);
 };

--- a/src/Core/Window.rei
+++ b/src/Core/Window.rei
@@ -78,6 +78,7 @@ let show: t => unit;
 let maximize: t => unit;
 let isMaximized: t => bool;
 let isFullscreen: t => bool;
+let restore: t => unit;
 let minimize: t => unit;
 
 let setBackgroundColor: (t, Color.t) => unit;


### PR DESCRIPTION
This is necessary for Onivim2's custom titlebar on Windows.

I added a quick little example to show it working:
![image](https://user-images.githubusercontent.com/4527949/82575267-3a8c7e00-9b56-11ea-9159-ad7e5b1d885b.png)

Everything works as it should on macOS at least. Since I'm only using SDL2's built-in methods I think it's safe to assume that means it works everywhere.