### PR TITLE
Switch scrollOffset to Hooks.ref

### DIFF
--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -219,7 +219,7 @@ let%component make =
       reducer,
     );
   let%hook textRef = Hooks.ref(None);
-  let%hook (scrollOffset, _setScrollOffset) = Hooks.state(ref(0));
+  let%hook scrollOffset = Hooks.ref(0);
 
   let textAttrs = {
     fontFamily: Selector.select(style, FontFamily, "Roboto-Regular.ttf"),


### PR DESCRIPTION
Perhaps there is a reason why `scrollOffset` was using `Hooks.state(ref(0))`, but as far as I could tell, it was unnecessary. I switched it to `Hooks.ref(0)`