### PR TITLE
fix(events): fix mouse positions not scaling correctly

### DIFF
--- a/src/UI/HitTest.re
+++ b/src/UI/HitTest.re
@@ -8,8 +8,13 @@ let windowCallback = (node, window) =>
     (sdlWindow, mouseX, mouseY) =>
       Sdl2.Window.(
         if (sdlWindow == Window.getSdlWindow(window) && node#hasRendered()) {
+          let scaleAndZoomFactor = Window.getScaleAndZoom(window);
           let deepestNode =
-            getTopMostNode(node, float(mouseX), float(mouseY));
+            getTopMostNode(
+              node,
+              float(mouseX) /. scaleAndZoomFactor,
+              float(mouseY) /. scaleAndZoomFactor,
+            );
           switch (deepestNode) {
           | Some(node) => node#getMouseBehavior()
           | None => Normal

--- a/src/UI/Ui.re
+++ b/src/UI/Ui.re
@@ -124,10 +124,11 @@ let start = (window: Window.t, element: React.element(React.reveryNode)) => {
       window,
       f => {
         Log.trace("File dropped");
+        let scaleAndZoomFactor = Window.getScaleAndZoom(window);
         let evt =
           Revery_Core.Events.InternalFileDropped({
-            mouseX: f.mouseX,
-            mouseY: f.mouseY,
+            mouseX: f.mouseX /. scaleAndZoomFactor,
+            mouseY: f.mouseY /. scaleAndZoomFactor,
             paths: f.paths,
           });
         FileDrop.dispatch(evt, rootNode);


### PR DESCRIPTION
This totally flew under the radar because I'm on a Mac and (I assume) @bryphe and I have our scaling set to 1.0 on Windows, but I didn't scale the mouse coordinates properly on the HitTest params and FileDrop events.

@CrossR noticed this in onivim/oni2#1801, and I think this fixes that.

@CrossR, if you could resolve Revery in your local Oni `package.json` to the latest commit here and see if that fixes the issue, that would be super helpful!

Sorry this was overlooked in the first place! Luckily it doesnt seem to be _too_ hard a fix!