### PR TITLE
Stop separately tracking focus for Input

### DIFF
--- a/src/UI/Focus.re
+++ b/src/UI/Focus.re
@@ -29,15 +29,15 @@ let focus = (node: Node.node) => {
   focused := Some({handler: node#handleEvent, id: node#getInternalId()});
 };
 
+let isFocused = (node: Node.node) =>
+  switch (focused^) {
+  | Some({id, _}) => node#getInternalId() === id
+  | None => false
+  };
+
 /* TODO perform checks if a node can be focused ? */
 let dispatch = (node: Node.node) =>
-  switch (focused^) {
-  | Some({id, _}) =>
-    if (node#getInternalId() === id) {
-      ();
-    } else {
-      loseFocus();
-      focus(node);
-    }
-  | None => focus(node)
+  if (!isFocused(node)) {
+    loseFocus();
+    focus(node);
   };

--- a/src/UI/Focus.re
+++ b/src/UI/Focus.re
@@ -23,7 +23,7 @@ let loseFocus = () => {
   // If there is an active window, with text input active, turn off text input
 };
 
-let focus = (node: Node.node) => {
+let focusWithoutBlur = (node: Node.node) => {
   Log.trace("focus()");
   node#handleEvent(Focus);
   focused := Some({handler: node#handleEvent, id: node#getInternalId()});
@@ -31,13 +31,13 @@ let focus = (node: Node.node) => {
 
 let isFocused = (node: Node.node) =>
   switch (focused^) {
-  | Some({id, _}) => node#getInternalId() === id
+  | Some({id, _}) => node#getInternalId() == id
   | None => false
   };
 
 /* TODO perform checks if a node can be focused ? */
-let dispatch = (node: Node.node) =>
+let focus = (node: Node.node) =>
   if (!isFocused(node)) {
     loseFocus();
-    focus(node);
+    focusWithoutBlur(node);
   };

--- a/src/UI/Focus.re
+++ b/src/UI/Focus.re
@@ -10,8 +10,6 @@ let focused = ref(None);
 
 module Log = (val Log.withNamespace("Revery.UI.Focus"));
 
-let getFocused = () => focused^;
-
 /* Should happen when user clicks anywhere where no focusable node exists */
 let loseFocus = () => {
   Log.trace("loseFocus()");
@@ -39,4 +37,10 @@ let focus = (node: Node.node) =>
     Log.trace("focus()");
     node#handleEvent(Focus);
     focused := Some({handler: node#handleEvent, id: node#getInternalId()});
+  };
+
+let dispatch = event =>
+  switch (focused^) {
+  | Some({handler, _}) => handler(event)
+  | None => ()
   };

--- a/src/UI/Focus.re
+++ b/src/UI/Focus.re
@@ -6,7 +6,7 @@ type active = {
   id: int,
 };
 type focused = ref(option(active));
-let focused = ref(None);
+let focused: focused = ref(None);
 
 module Log = (val Log.withNamespace("Revery.UI.Focus"));
 

--- a/src/UI/Focus.re
+++ b/src/UI/Focus.re
@@ -10,6 +10,8 @@ let focused = ref(None);
 
 module Log = (val Log.withNamespace("Revery.UI.Focus"));
 
+let getFocused = () => focused^;
+
 /* Should happen when user clicks anywhere where no focusable node exists */
 let loseFocus = () => {
   Log.trace("loseFocus()");
@@ -23,12 +25,6 @@ let loseFocus = () => {
   // If there is an active window, with text input active, turn off text input
 };
 
-let focusWithoutBlur = (node: Node.node) => {
-  Log.trace("focus()");
-  node#handleEvent(Focus);
-  focused := Some({handler: node#handleEvent, id: node#getInternalId()});
-};
-
 let isFocused = (node: Node.node) =>
   switch (focused^) {
   | Some({id, _}) => node#getInternalId() == id
@@ -39,5 +35,8 @@ let isFocused = (node: Node.node) =>
 let focus = (node: Node.node) =>
   if (!isFocused(node)) {
     loseFocus();
-    focusWithoutBlur(node);
+
+    Log.trace("focus()");
+    node#handleEvent(Focus);
+    focused := Some({handler: node#handleEvent, id: node#getInternalId()});
   };

--- a/src/UI/Focus.rei
+++ b/src/UI/Focus.rei
@@ -1,15 +1,9 @@
 open NodeEvents;
 
-type active = {
-  handler: event => unit,
-  id: int,
-};
-type focused = ref(option(active));
-
-let getFocused: unit => option(active);
-
 let loseFocus: unit => unit;
 
 let isFocused: Node.node => bool;
 
 let focus: Node.node => unit;
+
+let dispatch: event => unit;

--- a/src/UI/Focus.rei
+++ b/src/UI/Focus.rei
@@ -1,0 +1,15 @@
+open NodeEvents;
+
+type active = {
+  handler: event => unit,
+  id: int,
+};
+type focused = ref(option(active));
+
+let getFocused: unit => option(active);
+
+let loseFocus: unit => unit;
+
+let isFocused: Node.node => bool;
+
+let focus: Node.node => unit;

--- a/src/UI/Keyboard.re
+++ b/src/UI/Keyboard.re
@@ -2,7 +2,7 @@ open Revery_Core;
 open NodeEvents;
 
 let dispatch = (event: Revery_Core.Events.internalKeyboardEvent) => {
-  let focused = Focus.focused^;
+  let focused = Focus.getFocused();
 
   switch (focused) {
   | None => ()

--- a/src/UI/Keyboard.re
+++ b/src/UI/Keyboard.re
@@ -2,39 +2,33 @@ open Revery_Core;
 open NodeEvents;
 
 let dispatch = (event: Revery_Core.Events.internalKeyboardEvent) => {
-  let focused = Focus.getFocused();
-
-  switch (focused) {
-  | None => ()
-  | Some({handler, _}) =>
-    switch (event) {
-    | InternalTextEditEvent({text, start, length}) =>
-      handler(TextEdit({text, start, length}))
-    | InternalTextInputEvent(e) => handler(TextInput({text: e.text}))
-    | InternalKeyUpEvent(e) =>
-      handler(
-        KeyUp({
-          keycode: e.keycode,
-          scancode: e.scancode,
-          repeat: e.repeat,
-          keymod: e.keymod,
-          ctrlKey: Key.Keymod.isControlDown(e.keymod),
-          altKey: Key.Keymod.isAltDown(e.keymod),
-          shiftKey: Key.Keymod.isShiftDown(e.keymod),
-        }),
-      )
-    | InternalKeyDownEvent(e) =>
-      handler(
-        KeyDown({
-          keycode: e.keycode,
-          scancode: e.scancode,
-          repeat: e.repeat,
-          keymod: e.keymod,
-          ctrlKey: Key.Keymod.isControlDown(e.keymod),
-          altKey: Key.Keymod.isAltDown(e.keymod),
-          shiftKey: Key.Keymod.isShiftDown(e.keymod),
-        }),
-      )
-    }
+  switch (event) {
+  | InternalTextEditEvent({text, start, length}) =>
+    Focus.dispatch(TextEdit({text, start, length}))
+  | InternalTextInputEvent(e) => Focus.dispatch(TextInput({text: e.text}))
+  | InternalKeyUpEvent(e) =>
+    Focus.dispatch(
+      KeyUp({
+        keycode: e.keycode,
+        scancode: e.scancode,
+        repeat: e.repeat,
+        keymod: e.keymod,
+        ctrlKey: Key.Keymod.isControlDown(e.keymod),
+        altKey: Key.Keymod.isAltDown(e.keymod),
+        shiftKey: Key.Keymod.isShiftDown(e.keymod),
+      }),
+    )
+  | InternalKeyDownEvent(e) =>
+    Focus.dispatch(
+      KeyDown({
+        keycode: e.keycode,
+        scancode: e.scancode,
+        repeat: e.repeat,
+        keymod: e.keymod,
+        ctrlKey: Key.Keymod.isControlDown(e.keymod),
+        altKey: Key.Keymod.isAltDown(e.keymod),
+        shiftKey: Key.Keymod.isShiftDown(e.keymod),
+      }),
+    )
   };
 };

--- a/src/UI/Keyboard.re
+++ b/src/UI/Keyboard.re
@@ -1,34 +1,36 @@
 open Revery_Core;
 open NodeEvents;
 
-let dispatch = (event: Revery_Core.Events.internalKeyboardEvent) => {
+let internalToExternalEvent =
+    (event: Revery_Core.Events.internalKeyboardEvent) =>
   switch (event) {
   | InternalTextEditEvent({text, start, length}) =>
-    Focus.dispatch(TextEdit({text, start, length}))
-  | InternalTextInputEvent(e) => Focus.dispatch(TextInput({text: e.text}))
+    TextEdit({text, start, length})
+  | InternalTextInputEvent(e) => TextInput({text: e.text})
   | InternalKeyUpEvent(e) =>
-    Focus.dispatch(
-      KeyUp({
-        keycode: e.keycode,
-        scancode: e.scancode,
-        repeat: e.repeat,
-        keymod: e.keymod,
-        ctrlKey: Key.Keymod.isControlDown(e.keymod),
-        altKey: Key.Keymod.isAltDown(e.keymod),
-        shiftKey: Key.Keymod.isShiftDown(e.keymod),
-      }),
-    )
+    KeyUp({
+      keycode: e.keycode,
+      scancode: e.scancode,
+      repeat: e.repeat,
+      keymod: e.keymod,
+      ctrlKey: Key.Keymod.isControlDown(e.keymod),
+      altKey: Key.Keymod.isAltDown(e.keymod),
+      shiftKey: Key.Keymod.isShiftDown(e.keymod),
+    })
   | InternalKeyDownEvent(e) =>
-    Focus.dispatch(
-      KeyDown({
-        keycode: e.keycode,
-        scancode: e.scancode,
-        repeat: e.repeat,
-        keymod: e.keymod,
-        ctrlKey: Key.Keymod.isControlDown(e.keymod),
-        altKey: Key.Keymod.isAltDown(e.keymod),
-        shiftKey: Key.Keymod.isShiftDown(e.keymod),
-      }),
-    )
+    KeyUp({
+      keycode: e.keycode,
+      scancode: e.scancode,
+      repeat: e.repeat,
+      keymod: e.keymod,
+      ctrlKey: Key.Keymod.isControlDown(e.keymod),
+      altKey: Key.Keymod.isAltDown(e.keymod),
+      shiftKey: Key.Keymod.isShiftDown(e.keymod),
+    })
   };
+
+let dispatch = (event: Revery_Core.Events.internalKeyboardEvent) => {
+  let eventToSend = internalToExternalEvent(event);
+
+  Focus.dispatch(eventToSend);
 };

--- a/src/UI/Mouse.re
+++ b/src/UI/Mouse.re
@@ -287,7 +287,7 @@ let dispatch =
 
     if (isMouseDownEv(eventToSend)) {
       switch (getFirstFocusable(node, mouseX, mouseY)) {
-      | Some(node) => Focus.dispatch(node)
+      | Some(node) => Focus.focus(node)
       | None => Focus.loseFocus()
       };
     };

--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -52,9 +52,6 @@ type state = {
   cursorPosition: int,
 };
 
-type action =
-  | TextInput(string, int);
-
 let getStringParts = (index, str) => {
   switch (index) {
   | 0 => ("", str)

--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -103,11 +103,6 @@ let addCharacter = (word, char, index) => {
   (startStr ++ char ++ endStr, String.length(startStr) + 1);
 };
 
-let reducer = (action, state) =>
-  switch (action) {
-  | TextInput(value, cursorPosition) => {value, cursorPosition}
-  };
-
 module Constants = {
   let defaultHeight = 50;
   let defaultWidth = 200;
@@ -204,14 +199,11 @@ let%component make =
                 ~isPassword=false,
                 (),
               ) => {
-  let%hook (state, dispatch) =
-    Hooks.reducer(
-      ~initialState={
-        value: Option.value(value, ~default=""),
-        cursorPosition: Option.value(cursorPosition, ~default=0),
-      },
-      reducer,
-    );
+  let%hook (state, setState) =
+    Hooks.state({
+      value: Option.value(value, ~default=""),
+      cursorPosition: Option.value(cursorPosition, ~default=0),
+    });
   let%hook textRef = Hooks.ref(None);
   let%hook scrollOffset = Hooks.ref(0);
 
@@ -291,7 +283,7 @@ let%component make =
   // Refactor when https://github.com/briskml/brisk-reconciler/issues/54 has been fixed
   let update = (value, cursorPosition) => {
     onChange(value, cursorPosition);
-    dispatch(TextInput(value, cursorPosition));
+    setState(_ => {value, cursorPosition});
   };
 
   let handleTextInput = (event: NodeEvents.textInputEventParams) => {

--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -55,7 +55,7 @@ type state = {
 type action =
   | TextInput(string, int);
 
-let reducer = (action, state) =>
+let reducer = (action, _state) =>
   switch (action) {
   | TextInput(value, cursorPosition) => {value, cursorPosition}
   };


### PR DESCRIPTION
I renamed `dispatch` to `focus` and `focus` to `focusWithoutBlur`.

(I accidentally screwed up the other pull request.)

I ran `esy format` and it didn't change anything, but hopefully it's happy now. I also am not sure what the unused variable mentioned is.