### PR TITLE
fix(Windows): ensure WS_CAPTION is set on undecorated windows

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -48,7 +48,7 @@ let quit = (~askNicely=false, ~code=0, app: t) => {
   };
 
   if (Hashtbl.length(app.windows) == 0 || !askNicely) {
-    Revery_Native.uninit();
+    Revery_Native.uninitApp();
 
     // Verify [quit] wasn't called recursively from a beforeQuit handler
     if (!app.isQuitting) {
@@ -253,7 +253,7 @@ let start = init => {
   let dispatchFileOpen = Event.dispatch(appInstance.onFileOpen);
   Callback.register("revery_dispatchFileOpen", dispatchFileOpen);
 
-  Revery_Native.init();
+  Revery_Native.initApp();
 
   let appLoop = () => {
     _flushEvents();

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -628,6 +628,8 @@ let create = (name: string, options: WindowCreateOptions.t) => {
 
   Internal.updateMetrics(window);
 
+  Revery_Native.initWindow(sdlWindow);
+
   window;
 };
 

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -600,10 +600,6 @@ let create = (name: string, options: WindowCreateOptions.t) => {
   setSize(~width, ~height, window);
   setVsync(window, options.vsync);
 
-  if (options.maximized) {
-    Sdl2.Window.maximize(sdlWindow);
-  };
-
   if (!options.decorated) {
     Sdl2.Window.setBordered(sdlWindow, false);
   };
@@ -621,14 +617,18 @@ let create = (name: string, options: WindowCreateOptions.t) => {
   | Transparent => Internal.setTitlebarTransparent(sdlWindow)
   };
 
+  Revery_Native.initWindow(sdlWindow);
+
+  if (options.maximized) {
+    Sdl2.Window.maximize(sdlWindow);
+  };
+
   // onivim/oni2#791
   // Set a minimum size for the window
   // TODO: Make configurable
   Sdl2.Window.setMinimumSize(sdlWindow, 200, 100);
 
   Internal.updateMetrics(window);
-
-  Revery_Native.initWindow(sdlWindow);
 
   window;
 };

--- a/src/Native/Initialization.re
+++ b/src/Native/Initialization.re
@@ -1,3 +1,5 @@
-external init: unit => unit = "revery_initialize";
+external initApp: unit => unit = "revery_initializeApp";
+external uninitApp: unit => unit = "revery_uninitializeApp";
 
-external uninit: unit => unit = "revery_uninitialize";
+external _initWindow: Sdl2.Window.nativeWindow => unit = "revery_initializeWindow";
+let initWindow = (w: Sdl2.Window.t) => _initWindow(w |> Sdl2.Window.getNativeWindow);

--- a/src/Native/Revery_Native.c
+++ b/src/Native/Revery_Native.c
@@ -11,6 +11,7 @@
 #ifdef WIN32
 #include "ReveryWin32.h"
 #include <combaseapi.h>
+#include <windows.h>
 #elif __APPLE__
 #include "ReveryCocoa.h"
 #import "ReveryAppDelegate.h"
@@ -18,7 +19,7 @@
 #include "ReveryGtk.h"
 #endif
 
-CAMLprim value revery_initialize() {
+CAMLprim value revery_initializeApp() {
 #ifdef __APPLE__
     SDLAppDelegate *sdlDelegate = [NSApp delegate];
     ReveryAppDelegate *delegate = [ReveryAppDelegate newWithSDLDelegate:sdlDelegate];
@@ -32,9 +33,23 @@ CAMLprim value revery_initialize() {
     return Val_unit;
 }
 
-CAMLprim value revery_uninitialize() {
+CAMLprim value revery_uninitializeApp() {
 #ifdef WIN32
     CoUninitialize();
 #endif
     return Val_unit;
+}
+
+
+CAMLprim value revery_initializeWindow(value vWin) {
+    CAMLparam1(vWin);
+    void *win = (void *)vWin;
+#ifdef WIN32
+    HWND window = (HWND)win;
+    int current_style = GetWindowLong(window, GWL_STYLE);
+    SetWindowLong(window, GWL_STYLE, current_style | WS_CAPTION);
+#else
+    UNUSED(win);
+#endif
+    CAMLreturn(Val_unit);
 }


### PR DESCRIPTION
People in the Oni Discord were noting that an undecorated Window was covering the taskbar on Windows. Luckily, I found that Chrome had that same problem: https://chromium.googlesource.com/chromium/src.git/+/46.0.2478.0/chrome/browser/ui/views/apps/chrome_native_app_window_views_win.cc#71

This fixes that by adding an `Revery_Native.initWindow` function that sets the flag after all the SDL modifications are done. 

This also renames `Revery_Native`'s `init` to `initApp` to avoid confusion.