### PR TITLE
fix(primitives): canvas matrix operations did not work as expected

### DIFF
--- a/examples/CanvasExample.re
+++ b/examples/CanvasExample.re
@@ -24,6 +24,10 @@ module Sample = {
       <Canvas
         style=outerBox
         render={canvasContext => {
+          let transform = Skia.Matrix.make();
+          Skia.Matrix.setIdentity(transform);
+          CanvasContext.setMatrix(canvasContext, transform);
+
           let paint = Skia.Paint.make();
           Skia.Paint.setColor(
             paint,

--- a/src/UI/CanvasNode.re
+++ b/src/UI/CanvasNode.re
@@ -28,6 +28,7 @@ class canvasNode (()) = {
     | Some(r) =>
       let _ret: int = CanvasContext.save(canvas);
       CanvasContext.setMatrix(canvas, world);
+      CanvasContext.setRootTransform(world, canvas);
       Overflow.render(canvas, LayoutTypes.Hidden, dimensions, () => {
         // canvas save
         // canvas set transform


### PR DESCRIPTION
Using `CanvasContext.setMatrix` in a canvas rendering function produced unexpected transformations. I believe this is because the root transform was not being set on the canvas context, and so any matrix operation would override the transform of the element itself. But because of all the mutation going on here I'm not sure whether doing this may have other side-effects.