### PR TITLE
feat(example): Add --force-device-scale-factor option to make it easier to test

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -277,11 +277,13 @@ let init = app => {
 
   let initialExample = ref("Animation");
   let decorated = ref(true);
+  let forceScaleFactor = ref(None);
   Arg.parse(
     [
       ("--trace", Unit(() => Timber.App.setLevel(Timber.Level.trace)), ""),
       ("--no-decoration", Unit(() => decorated := false), ""),
       ("--example", String(name => initialExample := name), ""),
+      ("--force-device-scale-factor", Float(scaleFactor => forceScaleFactor := Some(scaleFactor)), ""),
     ],
     _ => (),
     "There is only --trace, --example, and --no-decoration",
@@ -306,6 +308,7 @@ let init = app => {
           ~titlebarStyle=Transparent,
           ~icon=Some("revery-icon.png"),
           ~decorated=decorated^,
+          ~forceScaleFactor=forceScaleFactor^,
           (),
         ),
       app,

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -283,7 +283,11 @@ let init = app => {
       ("--trace", Unit(() => Timber.App.setLevel(Timber.Level.trace)), ""),
       ("--no-decoration", Unit(() => decorated := false), ""),
       ("--example", String(name => initialExample := name), ""),
-      ("--force-device-scale-factor", Float(scaleFactor => forceScaleFactor := Some(scaleFactor)), ""),
+      (
+        "--force-device-scale-factor",
+        Float(scaleFactor => forceScaleFactor := Some(scaleFactor)),
+        "",
+      ),
     ],
     _ => (),
     "There is only --trace, --example, and --no-decoration",

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -290,7 +290,7 @@ let init = app => {
       ),
     ],
     _ => (),
-    "There is only --trace, --example, and --no-decoration",
+    "There is only --trace, --example, --no-decoration, and --force-device-scale-factor",
   );
   let initialExample = initialExample^;
 


### PR DESCRIPTION
To make it easier to test cases like #869 - this adds a `--force-device-scale-factor` option, like: 
```
esy run --force-device-scale-factor=1.5
```
so that the example app can be run scaled.