### PR TITLE
chore(ci): Fix up triggers to reduce backlogs of builds in azure pipeline queue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,21 @@
 # https://aka.ms/yaml
 
 name: $(Build.SourceVersion)
+
+# Master build triggers
+trigger: 
+- master
+
+# PR Triggers
+pr:
+  autoCancel: true
+  branches:
+    include: 
+    - master
+  paths:
+    exclude: 
+    - README.md
+
 jobs:
 - job: Linux
   timeoutInMinutes: 0


### PR DESCRIPTION
This sets up triggers to auto-cancel PR builds when a new commit has been pushed