### PR TITLE
Add windows, centos, archlinux in GHA CI

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -122,6 +122,7 @@ jobs:
         env:
           DOC_PATH: ${{ steps.print_docs_path.outputs.docs_path }}
       - name: Deploy docs
+        if: ${{ github.ref }} == "master"
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -129,6 +129,17 @@ jobs:
           CLEAN: true
           FOLDER: ${{ steps.print_docs_path.outputs.docs_path }}
 
+  build_docker:
+    name: Build inside a docker
+    runs-on: ubuntu-latest
+    strategy:
+      # If we have many bug we can test on all plateform
+      fail-fast: false
+      matrix:
+        os: [archlinux, centos]
+    steps:
+      - uses: actions/checkout@v2
+      - run: docker build -t ${{ matrix.os }} scripts/docker/${{ matrix.os }}
   build:
     name: Build
     runs-on: ${{ matrix.os }}
@@ -136,7 +147,7 @@ jobs:
       # If we have many bug we can test on all plateform
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [windows-2016, ubuntu-latest, macos-latest]
     steps:
       - uses: actions/setup-node@v1.4.2
         with:

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -121,8 +121,21 @@ jobs:
       - run: ls ./$DOC_PATH
         env:
           DOC_PATH: ${{ steps.print_docs_path.outputs.docs_path }}
+      - name: debug
+        run: |
+          echo ${{ github.event }}
+          echo ${{ github.workflow }}
+          echo ${{ github.actor }}
+          echo ${{ github.repository }}
+          echo ${{ github.event_name }}
+          echo ${{ github.sha }}
+          echo ${{ github.ref }}
+          echo ${{ github.head_ref }}
+          echo ${{ github.base_ref }}
+          echo master
+          echo refs/heads/master
       - name: Deploy docs
-        if: ${{ github.ref }} == "refs/heads/master"
+        if: ${{ github.ref }} == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -141,7 +141,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: docker build -t ${{ matrix.os }} scripts/docker/${{ matrix.os }}
-      - run: docker run --rm --volume $(pwd):/revery --volume ${{ steps.print_esy_cache.outputs.esy_cache }}:/esy/store ${{ matrix.os }} bash -c "cd /revery && esy install --prefix-path=/esy/store"
+      - name: Create esy store
+        run: mkdir ~/.esy
+      - run: docker run --rm --volume $(pwd):/revery --volume ~/.esy:/esy/store ${{ matrix.os }} bash -c "cd /revery && esy install --prefix-path=/esy/store"
+      - name: Print esy cache
+        id: print_esy_cache
+        run: node .github/workflows/print_esy_cache.js
       - name: Try to restore dependencies cache
         id: deps-cache
         uses: actions/cache@v1.1.2
@@ -152,7 +157,7 @@ jobs:
             ${{ matrix.os }}-
       - name: Build dependencies in release
         if: steps.deps-cache.outputs.cache-hit != 'true'
-        run: docker run --rm --volume $(pwd):/revery --volume ${{ steps.print_esy_cache.outputs.esy_cache }}:/esy/store ${{ matrix.os }} bash -c "cd /revery && esy build-dependencies --release --prefix-path=/esy/store"
+        run: docker run --rm --volume $(pwd):/revery --volume ~/.esy:/esy/store ${{ matrix.os }} bash -c "cd /revery && esy build-dependencies --release --prefix-path=/esy/store"
 
   build:
     name: Build

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -121,21 +121,8 @@ jobs:
       - run: ls ./$DOC_PATH
         env:
           DOC_PATH: ${{ steps.print_docs_path.outputs.docs_path }}
-      - name: debug
-        run: |
-          echo ${{ github.event }}
-          echo ${{ github.workflow }}
-          echo ${{ github.actor }}
-          echo ${{ github.repository }}
-          echo ${{ github.event_name }}
-          echo ${{ github.sha }}
-          echo ${{ github.ref }}
-          echo ${{ github.head_ref }}
-          echo ${{ github.base_ref }}
-          echo master
-          echo refs/heads/master
       - name: Deploy docs
-        if: ${{ github.ref }} == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -141,6 +141,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: docker build -t ${{ matrix.os }} scripts/docker/${{ matrix.os }}
+      - run: docker run --rm --volume $(pwd):/revery --volume ${{ steps.print_esy_cache.outputs.esy_cache }}:/esy/store ${{ matrix.os }} bash -c "cd /revery && esy install --prefix-path=/esy/store"
+      - name: Try to restore dependencies cache
+        id: deps-cache
+        uses: actions/cache@v1.1.2
+        with:
+          path: ${{ steps.print_esy_cache.outputs.esy_cache }}
+          key: ${{ matrix.os }}-${{ hashFiles('**/index.json') }}
+          restore-keys: |
+            ${{ matrix.os }}-
+      - name: Build dependencies in release
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        run: docker run --rm --volume $(pwd):/revery --volume ${{ steps.print_esy_cache.outputs.esy_cache }}:/esy/store ${{ matrix.os }} bash -c "cd /revery && esy build-dependencies --release --prefix-path=/esy/store"
+
   build:
     name: Build
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -155,9 +155,13 @@ jobs:
           key: ${{ matrix.os }}-${{ hashFiles('**/index.json') }}
           restore-keys: |
             ${{ matrix.os }}-
-      - name: Build dependencies in release
+      - name: Build release dependencies
         if: steps.deps-cache.outputs.cache-hit != 'true'
         run: docker run --rm --volume $(pwd):/revery --volume ~/.esy:/esy/store ${{ matrix.os }} bash -c "cd /revery && esy build-dependencies --release --prefix-path=/esy/store"
+      - name: Build project in release
+        run: docker run --rm --volume $(pwd):/revery --volume ~/.esy:/esy/store ${{ matrix.os }} bash -c "cd /revery && esy build --release --prefix-path=/esy/store"
+      - name: Build test/dev dependencies
+        run: docker run --rm --volume $(pwd):/revery --volume ~/.esy:/esy/store ${{ matrix.os }} bash -c "cd /revery && esy build-dependencies --prefix-path=/esy/store"
 
   build:
     name: Build

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -122,7 +122,7 @@ jobs:
         env:
           DOC_PATH: ${{ steps.print_docs_path.outputs.docs_path }}
       - name: Deploy docs
-        if: ${{ github.ref }} == "master"
+        if: ${{ github.ref }} == "refs/heads/master"
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -1,0 +1,14 @@
+FROM archlinux:latest
+
+RUN pacman -Syu --noconfirm
+
+RUN pacman -S --noconfirm base base-devel git npm
+
+RUN mkdir "${HOME}/.npm-packages"
+RUN npm config set prefix "${HOME}/.npm-packages"
+RUN echo export PATH=\"\$PATH:\${HOME}/.npm-packages/bin\" >> .bashrc
+RUN npm install -g esy
+
+RUN npm --version
+RUN git --version
+RUN esy --version

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -1,13 +1,15 @@
 FROM archlinux:latest
 
-RUN pacman -Syu --noconfirm
+ENV NPM_PATH=$HOME/.npm-packages
+ENV PATH=$NPM_PATH:$PATH
+RUN echo $NPM_PATH
 
+RUN pacman -Syu --noconfirm
 RUN pacman -S --noconfirm base base-devel git npm
 
-RUN mkdir "${HOME}/.npm-packages"
-RUN npm config set prefix "${HOME}/.npm-packages"
-RUN echo export PATH=\"\$PATH:\${HOME}/.npm-packages/bin\" >> .bashrc
-RUN source $HOME/.bashrc
+RUN mkdir $NPM_PATH
+RUN npm config set prefix $NPM_PATH
+
 RUN npm install -g esy
 
 RUN npm --version

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -8,6 +8,7 @@ ENV PATH=$PATH:/usr/bin/core_perl
 
 # workaround hack while ocaml-secondary-compiler@4.08.1 work well with gcc 10
 RUN mv /usr/bin/gcc /usr/bin/gcc-orig
-RUN echo -en "#!/usr/bin/sh\n/usr/bin/gcc-orig -fcommon \"$@\"" > /usr/bin/gcc
+RUN echo -en '#!/usr/bin/sh\n/usr/bin/gcc-orig -fcommon "$@"' > /usr/bin/gcc
+RUN chmod u+x /usr/bin/gcc
 
 RUN npm install --verbose --global --unsafe-perm=true esy@0.6.4

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -1,5 +1,6 @@
 FROM archlinux:latest
 
+ENV HOME=/root
 ENV NPM_PATH=$HOME/.npm-packages
 ENV PATH=$NPM_PATH:$PATH
 RUN echo $NPM_PATH

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -1,18 +1,6 @@
 FROM archlinux:latest
 
-ENV HOME=/root
-ENV NPM_PATH=$HOME/.npm-packages
-ENV PATH=$NPM_PATH:$PATH
-RUN echo $NPM_PATH
-
 RUN pacman -Syu --noconfirm
 RUN pacman -S --noconfirm base base-devel git npm
 
-RUN mkdir $NPM_PATH
-RUN npm config set prefix $NPM_PATH
-
-RUN npm install -g esy
-
-RUN npm --version
-RUN git --version
-RUN esy --version
+RUN npm install --verbose --global --unsafe-perm=true esy@0.6.4

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -4,6 +4,8 @@ RUN pacman -Syu --noconfirm
 RUN pacman -S --noconfirm base base-devel git npm perl
 #perl for shasum binary
 
+# Revery special deps
+RUN pacman -S --noconfirm libpng libxcursor libxi libxinerama libxrandr harfbuzz glu gtk3 fontconfig
 ENV PATH=$PATH:/usr/bin/core_perl
 
 # workaround hack while ocaml-secondary-compiler@4.08.1 work well with gcc 10

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -1,6 +1,6 @@
 FROM archlinux:latest
 
 RUN pacman -Syu --noconfirm
-RUN pacman -S --noconfirm base base-devel git npm
+RUN pacman -S --noconfirm base base-devel git npm shasum
 
 RUN npm install --verbose --global --unsafe-perm=true esy@0.6.4

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -7,6 +7,7 @@ RUN pacman -S --noconfirm base base-devel git npm
 RUN mkdir "${HOME}/.npm-packages"
 RUN npm config set prefix "${HOME}/.npm-packages"
 RUN echo export PATH=\"\$PATH:\${HOME}/.npm-packages/bin\" >> .bashrc
+RUN source .bashrc
 RUN npm install -g esy
 
 RUN npm --version

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -4,6 +4,6 @@ RUN pacman -Syu --noconfirm
 RUN pacman -S --noconfirm base base-devel git npm perl
 #perl for shasum binary
 
-ENV PATH=$(PATH):/usr/bin/core_perl/shasum
+ENV PATH=$PATH:/usr/bin/core_perl/shasum
 
 RUN npm install --verbose --global --unsafe-perm=true esy@0.6.4

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -7,7 +7,7 @@ RUN pacman -S --noconfirm base base-devel git npm
 RUN mkdir "${HOME}/.npm-packages"
 RUN npm config set prefix "${HOME}/.npm-packages"
 RUN echo export PATH=\"\$PATH:\${HOME}/.npm-packages/bin\" >> .bashrc
-RUN source .bashrc
+RUN source $HOME/.bashrc
 RUN npm install -g esy
 
 RUN npm --version

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -1,6 +1,9 @@
 FROM archlinux:latest
 
 RUN pacman -Syu --noconfirm
-RUN pacman -S --noconfirm base base-devel git npm shasum
+RUN pacman -S --noconfirm base base-devel git npm perl
+#perl for shasum binary
+
+ENV PATH=$(PATH):/usr/bin/core_perl/shasum
 
 RUN npm install --verbose --global --unsafe-perm=true esy@0.6.4

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -5,7 +5,7 @@ RUN pacman -S --noconfirm base base-devel git npm perl
 #perl for shasum binary
 
 # Revery special deps
-RUN pacman -S --noconfirm libpng libxcursor libxi libxinerama libxrandr harfbuzz glu gtk3 fontconfig
+RUN pacman -S --noconfirm libpng libxcursor libxi libxinerama libxrandr harfbuzz glu gtk3 fontconfig nasm
 ENV PATH=$PATH:/usr/bin/core_perl
 
 # workaround hack while ocaml-secondary-compiler@4.08.1 work well with gcc 10

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -5,7 +5,7 @@ RUN pacman -S --noconfirm base base-devel git npm perl
 #perl for shasum binary
 
 # Revery special deps
-RUN pacman -S --noconfirm libpng libxcursor libxi libxinerama libxrandr harfbuzz glu gtk3 fontconfig nasm python2
+RUN pacman -S --noconfirm libpng libxcursor libxi libxinerama libxrandr harfbuzz glu gtk3 fontconfig nasm python2 clang
 ENV PATH=$PATH:/usr/bin/core_perl
 
 # workaround hack while ocaml-secondary-compiler@4.08.1 work well with gcc 10

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -4,6 +4,6 @@ RUN pacman -Syu --noconfirm
 RUN pacman -S --noconfirm base base-devel git npm perl
 #perl for shasum binary
 
-ENV PATH=$PATH:/usr/bin/core_perl/shasum
+ENV PATH=$PATH:/usr/bin/core_perl
 
 RUN npm install --verbose --global --unsafe-perm=true esy@0.6.4

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -5,7 +5,7 @@ RUN pacman -S --noconfirm base base-devel git npm perl
 #perl for shasum binary
 
 # Revery special deps
-RUN pacman -S --noconfirm libpng libxcursor libxi libxinerama libxrandr harfbuzz glu gtk3 fontconfig nasm
+RUN pacman -S --noconfirm libpng libxcursor libxi libxinerama libxrandr harfbuzz glu gtk3 fontconfig nasm python2
 ENV PATH=$PATH:/usr/bin/core_perl
 
 # workaround hack while ocaml-secondary-compiler@4.08.1 work well with gcc 10

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -6,4 +6,8 @@ RUN pacman -S --noconfirm base base-devel git npm perl
 
 ENV PATH=$PATH:/usr/bin/core_perl
 
+# workaround hack while ocaml-secondary-compiler@4.08.1 work well with gcc 10
+RUN mv /usr/bin/gcc /usr/bin/gcc-orig
+RUN echo -en "#!/usr/bin/sh\n/usr/bin/gcc-orig -fcommon \"$@\"" > /usr/bin/gcc
+
 RUN npm install --verbose --global --unsafe-perm=true esy@0.6.4

--- a/scripts/docker/archlinux/Dockerfile
+++ b/scripts/docker/archlinux/Dockerfile
@@ -8,6 +8,9 @@ RUN pacman -S --noconfirm base base-devel git npm perl
 RUN pacman -S --noconfirm libpng libxcursor libxi libxinerama libxrandr harfbuzz glu gtk3 fontconfig nasm python2 clang
 ENV PATH=$PATH:/usr/bin/core_perl
 
+# workaround for esy-skia that need `python` binary
+RUN cp /usr/bin/python2 /usr/bin/python
+
 # workaround hack while ocaml-secondary-compiler@4.08.1 work well with gcc 10
 RUN mv /usr/bin/gcc /usr/bin/gcc-orig
 RUN echo -en '#!/usr/bin/sh\n/usr/bin/gcc-orig -fcommon "$@"' > /usr/bin/gcc

--- a/scripts/docker/centos/Dockerfile
+++ b/scripts/docker/centos/Dockerfile
@@ -21,7 +21,7 @@ RUN yum -y install /usr/lib64/libasan.so.0.0.0
 RUN node -v
 RUN npm -v
 
-RUN npm install --global --unsafe-perm=true esy@0.6.2
+RUN npm install --global --unsafe-perm=true esy@0.6.4
 
 RUN yum -y install nasm
 RUN yum -y install https://repo.ius.io/ius-release-el7.rpm


### PR DESCRIPTION
Windows is added so we know we don't break major OS.
Centos is added to have parity with azure pipeline.
ArchLinux is added because it is a rolling release.

This PR also fix push docs from other non-master.
This PR also cache store from docker :) We can't see it because it isn't merged.

You can check it build here: https://github.com/revery-ui/revery/runs/732801762?check_suite_focus=true because without cache it is too much slow.

With this the build matrix get high. If we plan on adding build for IOS we might get another build: so we have to decide strategy ? Does it is fine that we wait a bit. Today we have 3 active PR so I have to kill some CI run. I haven't really this before so what do you think ?