### PR TITLE
fix(components): Migrate Link & ClickableText to new font-styling API

### DIFF
--- a/src/UI_Components/ClickableText.re
+++ b/src/UI_Components/ClickableText.re
@@ -1,18 +1,39 @@
 open Revery_UI;
 open Revery_Core;
 open Revery_UI_Primitives;
+open Revery_Font;
 
 module Hooks = Revery_UI_Hooks;
 
 let noop = () => ();
 
-let%component make = (~text, ~inactiveStyle, ~activeStyle, ~onClick=noop, ()) => {
+let%component make =
+              (
+                ~text,
+                ~inactiveStyle,
+                ~activeStyle,
+                ~fontSize=14.,
+                ~fontFamily=Family.default,
+                ~fontWeight=Weight.Normal,
+                ~italicized=false,
+                ~monospaced=false,
+                ~onClick=noop,
+                (),
+              ) => {
   let%hook (isHovered, onMouseEnter, onMouseLeave) = Hooks.hover();
 
   let outerStyle = Style.[cursor(MouseCursors.pointer)];
   let onMouseUp = _ => onClick();
 
   <View style=outerStyle onMouseUp onMouseEnter onMouseLeave>
-    <Text text style={isHovered ? activeStyle : inactiveStyle} />
+    <Text
+      text
+      fontFamily
+      fontSize
+      fontWeight
+      italicized
+      monospaced
+      style={isHovered ? activeStyle : inactiveStyle}
+    />
   </View>;
 };

--- a/src/UI_Components/Link.re
+++ b/src/UI_Components/Link.re
@@ -1,6 +1,28 @@
 open Revery_Native;
+open Revery_Font;
 
-let make = (~text, ~inactiveStyle, ~activeStyle, ~href, ()) => {
+let make =
+    (
+      ~text,
+      ~inactiveStyle,
+      ~activeStyle,
+      ~href,
+      ~fontSize=14.,
+      ~fontFamily=Family.default,
+      ~fontWeight=Weight.Normal,
+      ~italicized=false,
+      ~monospaced=false,
+      (),
+    ) => {
   let onClick = _ => Shell.openURL(href) |> ignore;
-  <ClickableText text inactiveStyle activeStyle onClick />;
+  <ClickableText
+    text
+    inactiveStyle
+    activeStyle
+    onClick
+    fontSize
+    fontWeight
+    italicized
+    monospaced
+  />;
 };

--- a/src/UI_Components/Link.re
+++ b/src/UI_Components/Link.re
@@ -21,6 +21,7 @@ let make =
     activeStyle
     onClick
     fontSize
+    fontFamily
     fontWeight
     italicized
     monospaced


### PR DESCRIPTION
This was an oversight on my part 😳. Since a lot is no longer determined by `Style`, `Link` and `ClickableText` require new parameters to style the rendered text.