### PR TITLE
feat(canvas): add concat (matrix)

### DIFF
--- a/examples/CanvasExample.re
+++ b/examples/CanvasExample.re
@@ -24,6 +24,10 @@ module Sample = {
       <Canvas
         style=outerBox
         render={canvasContext => {
+          let transform = Skia.Matrix.make();
+          Skia.Matrix.setIdentity(transform);
+          CanvasContext.concat(transform, canvasContext);
+
           let paint = Skia.Paint.make();
           Skia.Paint.setColor(
             paint,

--- a/src/Draw/CanvasContext.re
+++ b/src/Draw/CanvasContext.re
@@ -199,6 +199,10 @@ let setMatrix = (v: t, mat: Skia.Matrix.t) => {
   };
 };
 
+let concat = (transform, context) => {
+  Canvas.concat(context.canvas, transform);
+};
+
 let clipRect =
     (v: t, ~clipOp: clipOp=Intersect, ~antiAlias=false, rect: Skia.Rect.t) => {
   Canvas.clipRect(v.canvas, rect, clipOp, antiAlias);


### PR DESCRIPTION
This adds `CanvasContext.concat`, enabling transforms to be applied in the canvas rendering function without overriding any other transform that might have been applied.