### PR TITLE
Reduce deps

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -75,6 +75,7 @@ jobs:
               });
 
   doc:
+    needs: lint
     name: Push docs to GitHub's Pages
     runs-on: macos-latest
     steps:
@@ -131,6 +132,7 @@ jobs:
           FOLDER: ${{ steps.print_docs_path.outputs.docs_path }}
 
   build_docker:
+    needs: [doc, lint]
     name: Build inside a docker
     runs-on: ubuntu-latest
     strategy:
@@ -164,6 +166,7 @@ jobs:
         run: docker run --rm --volume $(pwd):/revery --volume ~/.esy:/esy/store ${{ matrix.os }} bash -c "cd /revery && esy build-dependencies --prefix-path=/esy/store"
 
   build:
+    needs: [doc, lint]
     name: Build
     runs-on: ${{ matrix.os }}
     strategy:

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@glennsl/timber": "^1.2.0"
   },
   "resolutions": {
+    "rench": "revery-ui/rench#efa53a609ad98b035b0621cbcfe48e415545fa3e",
     "@opam/dune": "2.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Just notice we pull atm 2 esy-cmake, and in release mode: refmterr, rely, reperf (those should be devDeps.)

reperf@1.5.0:
- [ ] refmterr

rench@1.9.1: https://github.com/revery-ui/rench/pull/37
- [x] refmterr
- [x] rely

Fix one of two:
@revery/esy-cmake@0.3.5001:
- [ ] esy-libjpeg-turbo

esy-cmake@0.3.5:
- [ ] esy-harfbuzz
- [ ] esy-freetype2
- [ ] esy-astyle