### PR TITLE
fix(macOS/fonts): change default macOS font to Arial

### DIFF
--- a/src/Font/FontFamily.re
+++ b/src/Font/FontFamily.re
@@ -78,7 +78,6 @@ let system = (familyName): t =>
 let default =
   switch (Revery_Core.Environment.os) {
   | Linux => system("Liberation Sans")
-  | Mac => system("System Font")
   | _ => system("Arial")
   };
 


### PR DESCRIPTION
This is a temporary fix to address #894. On macOS, Arial is bundled as separate files so this is a good font to use until #894 is fixed.