### PR TITLE
fix accidentally converting keydown to keyup

### DIFF
--- a/src/UI/Keyboard.re
+++ b/src/UI/Keyboard.re
@@ -18,7 +18,7 @@ let internalToExternalEvent =
       shiftKey: Key.Keymod.isShiftDown(e.keymod),
     })
   | InternalKeyDownEvent(e) =>
-    KeyUp({
+    KeyDown({
       keycode: e.keycode,
       scancode: e.scancode,
       repeat: e.repeat,


### PR DESCRIPTION
This introduced an accidental change converting KeyDown events into KeyUp events. That lead to Inputs not calling their `onKeyDown` handler anymore.

https://github.com/revery-ui/revery/commit/e5f363a1ac1d2b3a91f30ce936efa18478fedb1a#diff-dca70cf54f7954dcef8dd3e027ccb53eR21

This fixes it.