### PR TITLE
feat(reason-skia): bind to `sk_typeface_open_stream` and `sk_stream_t`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ _esy/
 
 skia-c-example.png
 skia-font-manager-output.png
+Arial.ttf

--- a/examples/skia-font-manager-cli/SkiaFontManagerCli.re
+++ b/examples/skia-font-manager-cli/SkiaFontManagerCli.re
@@ -31,6 +31,15 @@ let draw = canvas => {
   | Some(typeface) =>
     Paint.setTypeface(fill, typeface);
     Canvas.drawText(canvas, "Arial (System)", 10., 20., fill);
+    let stream = Typeface.openStream(typeface);
+    let length = Stream.getLength(stream);
+    Printf.printf("Stream length: %d\n", length);
+    let data = Data.ofStream(stream, length);
+    let oc = open_out("Arial.ttf");
+    print_endline("Writing Arial Normal to Arial.ttf...");
+    Printf.fprintf(oc, "%s", Data.makeString(data));
+    print_endline("Written!");
+    close_out(oc);
   };
 
   let maybeTypeface =

--- a/examples/skia-font-manager-cli/SkiaFontManagerCli.re
+++ b/examples/skia-font-manager-cli/SkiaFontManagerCli.re
@@ -31,10 +31,10 @@ let draw = canvas => {
   | Some(typeface) =>
     Paint.setTypeface(fill, typeface);
     Canvas.drawText(canvas, "Arial (System)", 10., 20., fill);
-    let stream = Typeface.openStream(typeface);
+    let stream = Typeface.toStream(typeface);
     let length = Stream.getLength(stream);
     Printf.printf("Stream length: %d\n", length);
-    let data = Data.ofStream(stream, length);
+    let data = Data.makeFromStream(stream, length);
     let oc = open_out("Arial.ttf");
     print_endline("Writing Arial Normal to Arial.ttf...");
     Printf.fprintf(oc, "%s", Data.makeString(data));

--- a/src/reason-skia/Skia.re
+++ b/src/reason-skia/Skia.re
@@ -612,7 +612,7 @@ module Data = {
     maybeData;
   };
 
-  let ofStream = SkiaWrapped.Data.ofStream;
+  let makeFromStream = SkiaWrapped.Data.makeFromStream;
 };
 
 module Typeface = {
@@ -621,7 +621,7 @@ module Typeface = {
   let makeFromName = SkiaWrapped.Typeface.makeFromName;
   let makeFromFile = SkiaWrapped.Typeface.makeFromFile;
 
-  let openStream = typeface => {
+  let toStream = typeface => {
     let stream = SkiaWrapped.Typeface.openStream(typeface, None);
     Gc.finalise(SkiaWrapped.Stream.delete, stream);
     stream;

--- a/src/reason-skia/Skia.re
+++ b/src/reason-skia/Skia.re
@@ -479,13 +479,6 @@ module FontStyle = {
   let make = SkiaWrapped.FontStyle.make;
 };
 
-module Typeface = {
-  type t = SkiaWrapped.Typeface.t;
-
-  let makeFromName = SkiaWrapped.Typeface.makeFromName;
-  let makeFromFile = SkiaWrapped.Typeface.makeFromFile;
-};
-
 module FontManager = {
   type t = SkiaWrapped.FontManager.t;
 
@@ -593,6 +586,13 @@ module ColorSpace = {
   type t = SkiaWrapped.ColorSpace.t;
 };
 
+module Stream = {
+  type t = SkiaWrapped.Stream.t;
+
+  let hasLength = SkiaWrapped.Stream.hasLength;
+  let getLength = SkiaWrapped.Stream.getLength;
+};
+
 module Data = {
   type t = SkiaWrapped.Data.t;
 
@@ -610,6 +610,21 @@ module Data = {
     | None => ()
     };
     maybeData;
+  };
+
+  let ofStream = SkiaWrapped.Data.ofStream;
+};
+
+module Typeface = {
+  type t = SkiaWrapped.Typeface.t;
+
+  let makeFromName = SkiaWrapped.Typeface.makeFromName;
+  let makeFromFile = SkiaWrapped.Typeface.makeFromFile;
+
+  let openStream = typeface => {
+    let stream = SkiaWrapped.Typeface.openStream(typeface, None);
+    Gc.finalise(SkiaWrapped.Stream.delete, stream);
+    stream;
   };
 };
 

--- a/src/reason-skia/Skia.rei
+++ b/src/reason-skia/Skia.rei
@@ -29,11 +29,29 @@ module FontStyle: {
 module Hinting: {type t = SkiaWrapped.Hinting.t;};
 module TextEncoding: {type t = SkiaWrapped.TextEncoding.t;};
 
+module Stream: {
+  type t;
+
+  let hasLength: t => bool;
+  let getLength: t => int;
+};
+
+module Data: {
+  type t;
+
+  let makeFromFileName: string => option(t);
+
+  let makeString: t => string;
+
+  let ofStream: (Stream.t, int) => t;
+};
+
 module Typeface: {
   type t;
 
   let makeFromName: (string, FontStyle.t) => option(t);
   let makeFromFile: (string, int) => option(t);
+  let openStream: t => Stream.t;
 };
 
 module FontManager: {
@@ -364,14 +382,6 @@ module Path: {
     ) =>
     unit;
   let close: t => unit;
-};
-
-module Data: {
-  type t;
-
-  let makeFromFileName: string => option(t);
-
-  let makeString: t => string;
 };
 
 module ImageInfo: {

--- a/src/reason-skia/Skia.rei
+++ b/src/reason-skia/Skia.rei
@@ -43,7 +43,7 @@ module Data: {
 
   let makeString: t => string;
 
-  let ofStream: (Stream.t, int) => t;
+  let makeFromStream: (Stream.t, int) => t;
 };
 
 module Typeface: {
@@ -51,7 +51,7 @@ module Typeface: {
 
   let makeFromName: (string, FontStyle.t) => option(t);
   let makeFromFile: (string, int) => option(t);
-  let openStream: t => Stream.t;
+  let toStream: t => Stream.t;
 };
 
 module FontManager: {

--- a/src/reason-skia/wrapped/bindings/SkiaWrappedBindings.re
+++ b/src/reason-skia/wrapped/bindings/SkiaWrappedBindings.re
@@ -23,6 +23,35 @@ module M = (F: FOREIGN) => {
     let t = uint32_t;
   };
 
+  module Stream = {
+    type t = ptr(structure(SkiaTypes.Stream.t));
+    let t = ptr(SkiaTypes.Stream.t);
+
+    let hasLength = foreign("sk_stream_has_length", t @-> returning(bool));
+
+    let getLength = foreign("sk_stream_get_length", t @-> returning(int));
+
+    let delete = foreign("sk_stream_destroy", t @-> returning(void));
+  };
+
+  module Data = {
+    type t = ptr(structure(SkiaTypes.Data.t));
+    let t = ptr(SkiaTypes.Data.t);
+
+    let makeFromFileName =
+      foreign(
+        "sk_data_new_from_file",
+        string @-> returning(ptr_opt(SkiaTypes.Data.t)),
+      );
+    let delete = foreign("sk_data_unref", t @-> returning(void));
+
+    let getData = foreign("sk_data_get_data", t @-> returning(ptr(void)));
+    let getSize = foreign("sk_data_get_size", t @-> returning(size_t));
+
+    let ofStream =
+      foreign("sk_data_new_from_stream", Stream.t @-> int @-> returning(t));
+  };
+
   module FontStyle = {
     type t = ptr(structure(SkiaTypes.FontStyle.t));
     let t = ptr(SkiaTypes.FontStyle.t);
@@ -59,7 +88,11 @@ module M = (F: FOREIGN) => {
         "sk_typeface_create_from_file",
         string @-> int @-> returning(ptr_opt(SkiaTypes.Typeface.t)),
       );
-
+    let openStream =
+      foreign(
+        "sk_typeface_open_stream",
+        t @-> ptr_opt(int) @-> returning(Stream.t),
+      );
     let delete = foreign("sk_typeface_unref", t @-> returning(void));
   };
 
@@ -660,21 +693,6 @@ module M = (F: FOREIGN) => {
   module ColorSpace = {
     type t = ptr(structure(SkiaTypes.ColorSpace.t));
     let t = ptr(SkiaTypes.ColorSpace.t);
-  };
-
-  module Data = {
-    type t = ptr(structure(SkiaTypes.Data.t));
-    let t = ptr(SkiaTypes.Data.t);
-
-    let makeFromFileName =
-      foreign(
-        "sk_data_new_from_file",
-        string @-> returning(ptr_opt(SkiaTypes.Data.t)),
-      );
-    let delete = foreign("sk_data_unref", t @-> returning(void));
-
-    let getData = foreign("sk_data_get_data", t @-> returning(ptr(void)));
-    let getSize = foreign("sk_data_get_size", t @-> returning(size_t));
   };
 
   module ImageInfo = {

--- a/src/reason-skia/wrapped/bindings/SkiaWrappedBindings.re
+++ b/src/reason-skia/wrapped/bindings/SkiaWrappedBindings.re
@@ -48,7 +48,7 @@ module M = (F: FOREIGN) => {
     let getData = foreign("sk_data_get_data", t @-> returning(ptr(void)));
     let getSize = foreign("sk_data_get_size", t @-> returning(size_t));
 
-    let ofStream =
+    let makeFromStream =
       foreign("sk_data_new_from_stream", Stream.t @-> int @-> returning(t));
   };
 

--- a/src/reason-skia/wrapped/lib/raw_bindings.c
+++ b/src/reason-skia/wrapped/lib/raw_bindings.c
@@ -9,6 +9,9 @@
 #include "sk_matrix.h"
 #include "sk_paint.h"
 #include "sk_types.h"
+#include "sk_typeface.h"
+#include "sk_data.h"
+#include "sk_stream.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -241,3 +244,4 @@ CAMLprim value reason_skia_matrix_set_translate_byte(value vMatrix,
     return reason_skia_matrix_set_translate(vMatrix, Double_val(vTranslateX),
                                             Double_val(vTranslateY));
 }
+

--- a/src/reason-skia/wrapped/stubgen/stubgen.ml
+++ b/src/reason-skia/wrapped/stubgen/stubgen.ml
@@ -13,6 +13,7 @@ let prologue = "
 #include \"sk_rrect.h\"
 #include \"sk_matrix.h\"
 #include \"sk_typeface.h\"
+#include \"sk_stream.h\"
 "
 
 let () =

--- a/src/reason-skia/wrapped/types/SkiaWrappedTypes.re
+++ b/src/reason-skia/wrapped/types/SkiaWrappedTypes.re
@@ -75,6 +75,18 @@ module M = (T: TYPE) => {
       );
   };
 
+  module Data = {
+    type t;
+    let t: typ(structure(t)) = structure("sk_data_t");
+    let t = typedef(t, "sk_data_t");
+  };
+
+  module Stream = {
+    type t;
+    let t: typ(structure(t)) = structure("sk_stream_t");
+    let t = typedef(t, "sk_stream_t");
+  };
+
   module Typeface = {
     type t;
     let t: typ(structure(t)) = structure("sk_typeface_t");
@@ -354,12 +366,6 @@ module M = (T: TYPE) => {
         (Unpremul, "UNPREMUL_SK_ALPHATYPE"),
       ],
     );
-
-  module Data = {
-    type t;
-    let t: typ(structure(t)) = structure("sk_data_t");
-    let t = typedef(t, "sk_data_t");
-  };
 
   module ImageInfo = {
     type t;


### PR DESCRIPTION
This does a couple main things:
- Creates a `Stream` module
  - has `getLength` & `hasLength` functions
- Adds a `Data.ofStream` function (`sk_data_new_from_stream`)
- Adds a `Typeface.openStream` function (`sk_typeface_open_stream`)
- Writes the found Arial typeface to a file, `Arial.ttf` in the `SkiaFontManagerCli` example

This adds a small C error that Im not sure if there's a mechanism to fix within ctypes. The stream returned by `sk_typeface_open_stream` is an `sk_stream_asset_t` ([`SkStreamAsset`](https://api.skia.org/classSkStreamAsset.html)), which, in the C++/OOP world, is a subclass of `sk_stream_t` ([`SkStream`](https://api.skia.org/classSkStream.html)). However, since there's no notion of inheritance in C the compiler gives an incompatible pointer types warning. We have other semi-similar warnings but those are about type qualifiers like `const`. @bryphe let me know if you think this is something worth trying to fix and, if so, if you know any way to do so.