### PR TITLE
feat(reason-skia): bind to `FontMetrics` char width functions

### DIFF
--- a/examples/skia-font-manager-cli/SkiaFontManagerCli.re
+++ b/examples/skia-font-manager-cli/SkiaFontManagerCli.re
@@ -53,6 +53,48 @@ let draw = canvas => {
     Paint.setTypeface(fill, typeface);
     Canvas.drawText(canvas, "Times New Roman (System)", 10., 40., fill);
   };
+
+  let maybeTypeface =
+    FontManager.matchFamilyStyle(fontManager, "Consolas", style);
+  switch (maybeTypeface) {
+  | None =>
+    print_endline(
+      "Normal Consolas not found. Ensure your system has it available.",
+    )
+  | Some(typeface) =>
+    Paint.setTypeface(fill, typeface);
+    let metrics = FontMetrics.make();
+    let _ret: float = Paint.getFontMetrics(fill, metrics, 1.0);
+    print_endline("__Consolas__");
+    print_endline(
+      "-- Average character width: "
+      ++ string_of_float(FontMetrics.getAvgCharacterWidth(metrics)),
+    );
+    print_endline(
+      "-- Maximum character width: "
+      ++ string_of_float(FontMetrics.getMaxCharacterWidth(metrics)),
+    );
+  };
+
+  let filePath = Sys.getcwd() ++ "/examples/skia-cli/FiraCode-Regular.ttf";
+  print_endline("Loading font: " ++ filePath);
+  let maybeTypeface = Typeface.makeFromFile(filePath, 0);
+  switch (maybeTypeface) {
+  | None => failwith("Unable to load font: " ++ filePath)
+  | Some(typeface) =>
+    Paint.setTypeface(fill, typeface);
+    let metrics = FontMetrics.make();
+    let _ret: float = Paint.getFontMetrics(fill, metrics, 1.0);
+    print_endline("__Fira Code__");
+    print_endline(
+      "-- Average character width: "
+      ++ string_of_float(FontMetrics.getAvgCharacterWidth(metrics)),
+    );
+    print_endline(
+      "-- Maximum character width: "
+      ++ string_of_float(FontMetrics.getMaxCharacterWidth(metrics)),
+    );
+  };
 };
 
 let surface = makeSurface(640l, 480l);

--- a/src/reason-skia/Skia.re
+++ b/src/reason-skia/Skia.re
@@ -67,6 +67,8 @@ module FontMetrics = {
   let getBottom = SkiaWrapped.FontMetrics.getBottom;
   let getUnderlineThickness = SkiaWrapped.FontMetrics.getUnderlineThickness;
   let getUnderlinePosition = SkiaWrapped.FontMetrics.getUnderlinePosition;
+  let getAvgCharacterWidth = SkiaWrapped.FontMetrics.getAvgCharacterWidth;
+  let getMaxCharacterWidth = SkiaWrapped.FontMetrics.getMaxCharacterWidth;
 };
 
 module Hinting = {

--- a/src/reason-skia/Skia.rei
+++ b/src/reason-skia/Skia.rei
@@ -71,6 +71,8 @@ module FontMetrics: {
   let getBottom: t => float;
   let getUnderlinePosition: t => float;
   let getUnderlineThickness: t => float;
+  let getAvgCharacterWidth: t => float;
+  let getMaxCharacterWidth: t => float;
 };
 
 module ImageFilter: {

--- a/src/reason-skia/wrapped/bindings/SkiaWrappedBindings.re
+++ b/src/reason-skia/wrapped/bindings/SkiaWrappedBindings.re
@@ -130,6 +130,10 @@ module M = (F: FOREIGN) => {
       getf(!@metrics, SkiaTypes.FontMetrics.underlineThickness);
     let getUnderlinePosition = metrics =>
       getf(!@metrics, SkiaTypes.FontMetrics.underlinePosition);
+    let getMaxCharacterWidth = metrics =>
+      getf(!@metrics, SkiaTypes.FontMetrics.maxCharacterWidth);
+    let getAvgCharacterWidth = metrics =>
+      getf(!@metrics, SkiaTypes.FontMetrics.avgCharacterWidth);
   };
 
   module ImageFilter = {

--- a/src/reason-skia/wrapped/types/SkiaWrappedTypes.re
+++ b/src/reason-skia/wrapped/types/SkiaWrappedTypes.re
@@ -119,6 +119,8 @@ module M = (T: TYPE) => {
     let underlinePosition = field(t, "fUnderlinePosition", float);
     let strikeoutThickness = field(t, "fStrikeoutThickness", float);
     let strikeoutPosition = field(t, "fStrikeoutPosition", float);
+    let maxCharacterWidth = field(t, "fMaxCharWidth", float);
+    let avgCharacterWidth = field(t, "fAvgCharWidth", float);
     seal(t);
     let t = typedef(t, "sk_fontmetrics_t");
   };


### PR DESCRIPTION
This is a really small change that just adds two functions from `FontMetrics`: the average character width and the maximum character width. These functions make it easy to test if a loaded font is monospace through
```
FontMetrics.avgCharacterWidth(metrics) == FontMetrics.maxCharacaterWidth(metrics)
```

I tested this with Consolas and it worked. Fortunately it also worked with FiraCode (I was worried that maybe the ligatures would register strangely).