### PR TITLE
feat(components): add `underline` prop to Text component

### DIFF
--- a/src/Font/FontMetrics.re
+++ b/src/Font/FontMetrics.re
@@ -3,7 +3,7 @@ type t = {
   lineHeight: float,
   ascent: float,
   descent: float,
-  underlinePos: float,
+  underlinePosition: float,
   underlineThickness: float,
 };
 
@@ -12,21 +12,21 @@ let empty = (size: float) => {
   lineHeight: size,
   ascent: 0.,
   descent: 0.,
-  underlinePos: 0.,
+  underlinePosition: 0.,
   underlineThickness: 0.,
 };
 
 let ofSkia = (size: float, lineHeight: float, metrics: Skia.FontMetrics.t) => {
   let ascent = Skia.FontMetrics.getAscent(metrics);
   let descent = Skia.FontMetrics.getDescent(metrics);
-  let underlinePos = Skia.FontMetrics.getUnderlinePosition(metrics);
+  let underlinePosition = Skia.FontMetrics.getUnderlinePosition(metrics);
   let underlineThickness = Skia.FontMetrics.getUnderlineThickness(metrics);
   {
     height: size,
     lineHeight,
     ascent,
     descent,
-    underlinePos,
+    underlinePosition,
     underlineThickness,
   };
 };

--- a/src/Font/FontMetrics.re
+++ b/src/Font/FontMetrics.re
@@ -3,6 +3,8 @@ type t = {
   lineHeight: float,
   ascent: float,
   descent: float,
+  underlinePos: float,
+  underlineThickness: float,
 };
 
 let empty = (size: float) => {
@@ -10,10 +12,21 @@ let empty = (size: float) => {
   lineHeight: size,
   ascent: 0.,
   descent: 0.,
+  underlinePos: 0.,
+  underlineThickness: 0.,
 };
 
 let ofSkia = (size: float, lineHeight: float, metrics: Skia.FontMetrics.t) => {
   let ascent = Skia.FontMetrics.getAscent(metrics);
   let descent = Skia.FontMetrics.getDescent(metrics);
-  {height: size, lineHeight, ascent, descent};
+  let underlinePos = Skia.FontMetrics.getUnderlinePosition(metrics);
+  let underlineThickness = Skia.FontMetrics.getUnderlineThickness(metrics);
+  {
+    height: size,
+    lineHeight,
+    ascent,
+    descent,
+    underlinePos,
+    underlineThickness,
+  };
 };

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -100,7 +100,7 @@ class textNode (text: string) = {
             canvas,
           );
           if (_underlined) {
-            let {underlinePos, underlineThickness, _}: FontMetrics.t =
+            let {underlinePosition, underlineThickness, _}: FontMetrics.t =
               FontCache.getMetrics(font, _fontSize);
 
             let width =
@@ -115,9 +115,9 @@ class textNode (text: string) = {
             let rect =
               Skia.Rect.makeLtrb(
                 0.,
-                baselineY +. underlinePos -. underlineThickness /. 2.,
+                baselineY +. underlinePosition -. underlineThickness /. 2.,
                 width,
-                baselineY +. underlinePos +. underlineThickness /. 2.,
+                baselineY +. underlinePosition +. underlineThickness /. 2.,
               );
             CanvasContext.drawRect(~rect, ~paint=_textPaint, canvas);
           };

--- a/src/UI_Components/ClickableText.re
+++ b/src/UI_Components/ClickableText.re
@@ -17,6 +17,7 @@ let%component make =
                 ~fontWeight=Weight.Normal,
                 ~italic=false,
                 ~monospaced=false,
+                ~underlined=false,
                 ~onClick=noop,
                 (),
               ) => {
@@ -33,6 +34,7 @@ let%component make =
       italic
       monospaced
       style={isHovered ? activeStyle : inactiveStyle}
+      underlined
     />
   </Clickable>;
 };

--- a/src/UI_Components/Link.re
+++ b/src/UI_Components/Link.re
@@ -12,6 +12,7 @@ let make =
       ~fontWeight=Weight.Normal,
       ~italic=false,
       ~monospaced=false,
+      ~underlined=true,
       (),
     ) => {
   let onClick = _ => Shell.openURL(href) |> ignore;
@@ -25,5 +26,6 @@ let make =
     fontWeight
     italic
     monospaced
+    underlined
   />;
 };

--- a/src/UI_Components/Markdown.re
+++ b/src/UI_Components/Markdown.re
@@ -202,6 +202,7 @@ let generateText = (text, styles, attrs, dispatch, state) => {
         fontFamily={styles.fontFamily}
         fontWeight
         italic={isItalicized(attrs)}
+        underlined=true
         monospaced={isMonospaced(attrs)}
       />
     </View>;

--- a/src/UI_Primitives/Text.re
+++ b/src/UI_Primitives/Text.re
@@ -20,6 +20,7 @@ let%nativeComponent make =
                       ~italic=false,
                       ~monospaced=false,
                       ~fontSize=14.,
+                      ~underlined=false,
                       ~text="",
                       ~smoothing=Smoothing.default,
                       ~children=React.empty,
@@ -77,6 +78,7 @@ let%nativeComponent make =
       tn#setItalicized(italic);
       tn#setMonospaced(monospaced);
       tn#setFontSize(fontSize);
+      tn#setUnderlined(underlined);
       node;
     },
     children,


### PR DESCRIPTION
This is another fairly simple addition. We get the underline info from Skia via FontMetrics and draw a rectangle from it.

Here's what the text looks like all underlined (before I added the property):
<img width="912" alt="Screen Shot 2020-06-08 at 8 53 54 AM" src="https://user-images.githubusercontent.com/4527949/84033992-b3b60e80-a967-11ea-964d-57dc66fe02a3.png">

I also added it to the components that use `Text`, like `ClickableText` and `Link`. I made `Link`s underlined by default and `ClickableText`s not.