### PR TITLE
fix(markdown): Fix wrong font families in code blocks

### DIFF
--- a/src/UI_Components/Markdown.re
+++ b/src/UI_Components/Markdown.re
@@ -211,7 +211,7 @@ let generateText = (text, styles, attrs, dispatch, state) => {
       <Text
         text
         fontSize
-        fontFamily={styles.fontFamily}
+        fontFamily={styles.codeFontFamily}
         fontWeight
         style=Style.[
           textWrap(TextWrapping.WrapIgnoreWhitespace),
@@ -445,7 +445,7 @@ and generateCodeBlock =
                       textWrap(TextWrapping.WrapIgnoreWhitespace),
                       color(block.color),
                     ]
-                    fontFamily={styles.fontFamily}
+                    fontFamily={styles.codeFontFamily}
                     fontWeight={block.bold ? Weight.Bold : Weight.Normal}
                     monospaced=true
                     fontSize

--- a/src/UI_Components/Markdown.rei
+++ b/src/UI_Components/Markdown.rei
@@ -1,7 +1,7 @@
 module SyntaxHighlight: {
   type highlight;
   type t = (~language: string, list(string)) => list(list(highlight));
-  
+
   let default: t;
 
   let makeHighlight:

--- a/src/UI_Components/Markdown.rei
+++ b/src/UI_Components/Markdown.rei
@@ -1,6 +1,8 @@
 module SyntaxHighlight: {
   type highlight;
   type t = (~language: string, list(string)) => list(list(highlight));
+  
+  let default: t;
 
   let makeHighlight:
     (


### PR DESCRIPTION
When I was originally testing this it was picking up my system monospaced fonts so I didnt notice the font props were incorrect. However any path based font is going to be incorrect.

My bad 🤦‍♂️.