### PR TITLE
sdl2 better feature and system detection

### DIFF
--- a/bench.json
+++ b/bench.json
@@ -4,7 +4,7 @@
       "run": "esy '@bench' x ReveryBench"
   },
   "override": {
-      "build": ["dune build -p font-manager,harfbuzz,skia,Revery,ReveryBench -j4"],
+      "build": ["dune build -p font-manager,harfbuzz,skia,sdl2,Revery,ReveryBench -j4"],
       "install": [
           "esy-installer ReveryBench.install"
       ]

--- a/doc.json
+++ b/doc.json
@@ -5,7 +5,7 @@
     "print": "esy '@doc' echo #{self.target_dir}/default/_doc/_html"
   },
   "override": {
-      "build": ["dune build @doc -p font-manager,harfbuzz,skia,Revery -j4"],
+      "build": ["dune build @doc -p font-manager,harfbuzz,skia,sdl2,Revery -j4"],
       "dependencies": {
 	  "@opam/odoc": "*",
 	  "http-server": "*"

--- a/examples.json
+++ b/examples.json
@@ -4,7 +4,7 @@
       "run": "esy x Examples"
   },
   "override": {
-      "build": ["dune build -p font-manager,harfbuzz,skia,Revery,ReveryExamples -j4"],
+      "build": ["dune build -p font-manager,harfbuzz,skia,sdl2,Revery,ReveryExamples -j4"],
       "install": [
           "esy-installer harfbuzz.install",
           "esy-installer skia.install",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,12 @@
         "scope": "global"
       }
     },
-    "build": [
-      "dune build -p font-manager,harfbuzz,skia,Revery -j4"
-    ],
+    "build": "dune build -p font-manager,harfbuzz,skia,sdl2,Revery",
     "install": [
       "esy-installer font-manager.install",
       "esy-installer harfbuzz.install",
       "esy-installer skia.install",
+      "esy-installer sdl2.install",
       "esy-installer Revery.install",
       "bash -c \"#{os == 'windows' ? 'cp /usr/x86_64-w64-mingw32/sys-root/mingw/bin/*.dll \\'$cur__bin\\'': ':'}\"",
       "bash -c \"cp #{esy-skia.bin}/skia.dll \\'$cur__bin\\' #{os == 'windows' ? '' : '2>/dev/null || true'}\"",
@@ -72,4 +71,3 @@
     "@opam/ocaml-lsp-server": "ocaml/ocaml-lsp:ocaml-lsp-server.opam#38bd51a15c98b4f6ff841e5c914a8cdacee15ea6"
   }
 }
-

--- a/sdl2.opam
+++ b/sdl2.opam
@@ -1,0 +1,7 @@
+opam-version: "1.2"
+version: "dev"
+maintainer: "bryphe@outlook.com"
+author: ["Bryan Phelps"]
+build: [
+
+]

--- a/src/reason-sdl2/dune
+++ b/src/reason-sdl2/dune
@@ -1,6 +1,6 @@
 (library
     (name sdl2)
-    (public_name Revery.sdl2)
+    (public_name sdl2)
     (library_flags (:include flags.sexp))
     (c_library_flags (:include c_library_flags.sexp))
     (c_flags (:include c_flags.sexp))

--- a/test.json
+++ b/test.json
@@ -4,7 +4,7 @@
       "run": "esy '@test' x ReveryTestRunner"
   },
   "override": {
-      "build": ["dune build -p font-manager,harfbuzz,skia,Revery,ReveryTest -j4"],
+      "build": ["dune build -p font-manager,harfbuzz,skia,sdl2,Revery,ReveryTest -j4"],
       "dependencies": {
         "@reason-native/rely": "*"
       },


### PR DESCRIPTION
## Why?

By removing the use of `uname` we can cross compile from Linux to Mac / Window and from Mac to Linux / Windows. It's a neat tooling for development as compiling from a powerful Linux computer is a lot faster than compiling on Windows(especially for me).

Also used the `SDL_config.h` to detect features available, this should also fix **wayland** and it's half of the problem regarding iOS and Android.

## Why not full feature detection?

Feature detection for this specific case is quite hard, I plan to have it, but in the futuru, also there is some options with are inherently system based. So this is a middle ground for now but may change in the future.