### PR TITLE
fix(linux): Disable X11 compositor suppression (enable compositing)

### DIFF
--- a/src/reason-sdl2/sdl2_wrapper.cpp
+++ b/src/reason-sdl2/sdl2_wrapper.cpp
@@ -1299,6 +1299,9 @@ CAMLprim value resdl_SDL_CreateWindow(value vName, value vX, value vY,
   // ie, on my CentOS 6 box, with latest Intel drivers - only 2.1 is supported.
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+
+  // Disable compositing suppression - https://github.com/onivim/oni2/issues/2003
+  SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0");
 #endif
   SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
   SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);


### PR DESCRIPTION
Related: https://github.com/onivim/oni2/issues/2003

Revery apps, and Onivim 2, disable KDE compositing. This is because SDL disables compositing by default - this default makes sense for games that run full-screen. For a tool, or a windowed app like Revery / Onivim 2, it's problematic and unexpected to disable compositing.

This sets the `SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR` to `0` so that we disable this behavior.