### PR TITLE
refactor(examples): move examples to ReveryExamples package

### DIFF
--- a/examples.json
+++ b/examples.json
@@ -1,6 +1,7 @@
 {
   "source": "./package.json",
   "scripts": {
+      "run": "esy x Examples"
   },
   "override": {
       "build": ["dune build -p font-manager,harfbuzz,skia,Revery,ReveryExamples -j4"],

--- a/examples/dune
+++ b/examples/dune
@@ -2,7 +2,7 @@
  (names Examples)
  (preprocess
   (pps brisk-reconciler.ppx lwt_ppx))
- (package Revery)
+ (package ReveryExamples)
  (public_names Examples)
  (libraries ExampleStubs skia str Revery Revery_Lwt flex timber))
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "esy b dune runtest",
     "format": "esy #{os == 'windows' ? 'b' : ''} bash .ci/format.sh #{os}",
-    "run": "esy x Examples"
+    "run": "esy @examples x Examples"
   },
   "homepage": "https://github.com/bryphe/revery#readme",
   "esy": {


### PR DESCRIPTION
This moves the examples from the Revery package to the ReveryExamples package.

This has two advantages:
- Revery no longer builds the examples as part of the library. It doesn't really make sense for a consumer to build all the examples when they wont use them. Unless I'm missing something, this seems like a positive.
- The examples can use the Revery library as an external consumer. This will help to get separate bytecode and native builds working for the examples.