### PR TITLE
feat(font-manager): fallback when Font is not found

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -363,4 +363,17 @@ let init = app => {
   ();
 };
 
+Revery.Font.Discovery.callback_font_not_found :=
+  (
+    (~weight, ~width, ~italic, ~mono, family) => {
+      path: Environment.getAssetPath("Roboto-Bold.ttf"),
+      postscriptName: "Roboto-Bold",
+      family: "Roboto",
+      weight: Normal,
+      width: Normal,
+      italic: false,
+      monospace: false,
+    }
+  );
+
 App.start(init);

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -363,17 +363,17 @@ let init = app => {
   ();
 };
 
-Revery.Font.Discovery.callback_font_not_found :=
-  (
-    (~weight, ~width, ~italic, ~mono, family) => {
-      path: Environment.getAssetPath("Roboto-Bold.ttf"),
-      postscriptName: "Roboto-Bold",
-      family: "Roboto",
-      weight: Normal,
-      width: Normal,
-      italic: false,
-      monospace: false,
-    }
-  );
+Revery.Font.Discovery.setFallbackResolver(
+  (~weight as _, ~width as _, ~mono as _, ~italic as _, _) =>
+  {
+    path: Environment.getAssetPath("Roboto-Bold.ttf"),
+    postscriptName: "Roboto-Bold",
+    family: "Roboto",
+    weight: Normal,
+    width: Normal,
+    italic: false,
+    monospace: false,
+  }
+);
 
 App.start(init);

--- a/examples/FontsExample.re
+++ b/examples/FontsExample.re
@@ -35,13 +35,11 @@ module FontComponent = {
       };
 
     let resolvedFont =
-      Some(
-        Font.Discovery.find(
-          ~weight=state.bold ? Font.Weight.Bold : Font.Weight.Normal,
-          ~mono=state.mono,
-          ~italic=state.italic,
-          state.family,
-        ),
+      Font.Discovery.find(
+        ~weight=state.bold ? Font.Weight.Bold : Font.Weight.Normal,
+        ~mono=state.mono,
+        ~italic=state.italic,
+        state.family,
       );
 
     switch (resolvedFont) {

--- a/src/Font/Discovery.re
+++ b/src/Font/Discovery.re
@@ -4,6 +4,11 @@
 */
 open FontManager;
 
+let callback_font_not_found =
+  ref((~weight, ~width, ~italic, ~mono, family) =>
+    raise(FontManager.Font_not_found)
+  );
+
 let find =
     (
       ~weight=FontWeight.Bold,
@@ -12,6 +17,19 @@ let find =
       ~italic=false,
       family,
     ) =>
-  FontManager.findFontExn(~weight, ~width, ~mono, ~italic, ~family, ());
+  FontManager.findFont(~weight, ~width, ~mono, ~italic, ~family, ());
+
+let findExn =
+    (
+      ~weight=FontWeight.Bold,
+      ~width=FontWidth.Undefined,
+      ~mono=false,
+      ~italic=false,
+      family,
+    ) =>
+  switch (FontManager.findFont(~weight, ~width, ~mono, ~italic, ~family, ())) {
+  | Some(fd) => fd
+  | None => callback_font_not_found^(~weight, ~width, ~mono, ~italic, family)
+  };
 
 let toString = FontManager.FontDescriptor.show;

--- a/src/Font/Discovery.re
+++ b/src/Font/Discovery.re
@@ -4,11 +4,11 @@
 */
 open FontManager;
 
-let callback_font_not_found =
-  ref((~weight, ~width, ~italic, ~mono, family) =>
+let callbackFontNotFound =
+  ref((~weight as _, ~width as _, ~mono as _, ~italic as _, _) =>
     raise(FontManager.Font_not_found)
   );
-
+let setFallbackResolver = newCallback => callbackFontNotFound := newCallback;
 let find =
     (
       ~weight=FontWeight.Bold,
@@ -29,7 +29,7 @@ let findExn =
     ) =>
   switch (FontManager.findFont(~weight, ~width, ~mono, ~italic, ~family, ())) {
   | Some(fd) => fd
-  | None => callback_font_not_found^(~weight, ~width, ~mono, ~italic, family)
+  | None => callbackFontNotFound^(~weight, ~width, ~mono, ~italic, family)
   };
 
 let toString = FontManager.FontDescriptor.show;

--- a/src/Font/FontFamily.re
+++ b/src/Font/FontFamily.re
@@ -41,7 +41,7 @@ let system = (familyName): t =>
       FontFamilyCache.promote(fontDescr, cache);
       fd.path;
     | None =>
-      let fd = Discovery.find(~weight, ~mono, ~italic, familyName);
+      let fd = Discovery.findExn(~weight, ~mono, ~italic, familyName);
       FontFamilyCache.add(fontDescr, fd, cache);
       FontFamilyCache.trim(cache);
       fd.path;

--- a/src/Font/Revery_Font.re
+++ b/src/Font/Revery_Font.re
@@ -26,6 +26,11 @@ let shape = FontCache.shape;
 
 module Discovery = {
   type t = FontManager.FontDescriptor.t;
+
+  let callback_font_not_found = Discovery.callback_font_not_found;
+
+  /** raises Font_not_found if couldn't find any font */
   let find = Discovery.find;
+  let findExn = Discovery.findExn;
   let toString = Discovery.toString;
 };

--- a/src/Font/Revery_Font.re
+++ b/src/Font/Revery_Font.re
@@ -27,7 +27,7 @@ let shape = FontCache.shape;
 module Discovery = {
   type t = FontManager.FontDescriptor.t;
 
-  let callback_font_not_found = Discovery.callback_font_not_found;
+  let setFallbackResolver = Discovery.setFallbackResolver;
 
   /** raises Font_not_found if couldn't find any font */
   let find = Discovery.find;


### PR DESCRIPTION
## Why?

After #918 instead of the applications crashing when a font is not found it throws a `Font_not_found` , but there is some platforms like Android who will never have a font because it's using a `dummy` font-manager, so we need a way to handle that.

## Solution

This is not a great API, but shouldn't be a problem considering that this kinda of choice should be handled on an application level. We can mark it as unstable or deprecated.

Still proposed it, because it's a nice to have even if it's not great and we can use it to develop a proper implementation to replace it later.