### PR TITLE
Pass font info to input text

### DIFF
--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -187,6 +187,7 @@ let%component make =
                 ~italic=false,
                 ~monospaced=false,
                 ~fontSize=14.0,
+                ~underlined=false,
                 ~placeholderColor=Styles.defaultPlaceholderColor,
                 ~cursorColor=Styles.defaultCursorColor,
                 ~autofocus=false,
@@ -401,6 +402,12 @@ let%component make =
     <Text
       ref={node => textRef := Some(node)}
       text
+      fontFamily
+      fontWeight
+      italic
+      monospaced
+      fontSize
+      underlined
       smoothing
       style={Styles.text(
         ~showPlaceholder,


### PR DESCRIPTION
This fixes `Input` allowing it to work correctly when all the new font stuff is set.

This was causing other bugs as well because the cursor positioning was done based on the actual font while the text being displayed was using a different font.