### PR TITLE
More feature detection

### DIFF
--- a/src/Native/Revery_Native.c
+++ b/src/Native/Revery_Native.c
@@ -8,23 +8,24 @@
 
 #define UNUSED(x) (void)(x)
 
-#ifdef WIN32
+#include "config.h"
+#ifdef USE_WIN32
 #include "ReveryWin32.h"
 #include <combaseapi.h>
 #include <windows.h>
-#elif __APPLE__
+#elif USE_COCOA
 #include "ReveryCocoa.h"
 #import "ReveryAppDelegate.h"
-#else
+#elif USE_GTK
 #include "ReveryGtk.h"
 #endif
 
 CAMLprim value revery_initializeApp() {
-#ifdef __APPLE__
+#ifdef USE_COCOA
     SDLAppDelegate *sdlDelegate = [NSApp delegate];
     ReveryAppDelegate *delegate = [ReveryAppDelegate newWithSDLDelegate:sdlDelegate];
     [NSApp setDelegate:delegate];
-#elif WIN32
+#elif USE_WIN32
     HRESULT hr = CoInitialize(NULL);
     if (hr != S_OK) {
         fprintf(stderr, "WARNING: COM initialization failed.");
@@ -34,7 +35,7 @@ CAMLprim value revery_initializeApp() {
 }
 
 CAMLprim value revery_uninitializeApp() {
-#ifdef WIN32
+#ifdef USE_WIN32
     CoUninitialize();
 #endif
     return Val_unit;
@@ -44,7 +45,7 @@ CAMLprim value revery_uninitializeApp() {
 CAMLprim value revery_initializeWindow(value vWin) {
     CAMLparam1(vWin);
     void *win = (void *)vWin;
-#ifdef WIN32
+#ifdef USE_WIN32
     /* This flag often gets unset when the window decoration is removed.
        This Chromium comment is the source of this fix:
        https://chromium.googlesource.com/chromium/src.git/+/46.0.2478.0/chrome/browser/ui/views/apps/chrome_native_app_window_views_win.cc#71

--- a/src/Native/cocoa/ReveryAppDelegate.c
+++ b/src/Native/cocoa/ReveryAppDelegate.c
@@ -1,4 +1,5 @@
-#ifdef __APPLE__
+#include "config.h"
+#ifdef USE_COCOA
 #import "ReveryAppDelegate.h"
 #import <Cocoa/Cocoa.h>
 

--- a/src/Native/cocoa/ReveryAppDelegate.h
+++ b/src/Native/cocoa/ReveryAppDelegate.h
@@ -1,4 +1,5 @@
-#ifdef __APPLE__
+#include "config.h"
+#ifdef USE_COCOA
 #import <Cocoa/Cocoa.h>
 #import "SDLAppDelegate.h"
 

--- a/src/Native/cocoa/ReveryAppDelegate_func.c
+++ b/src/Native/cocoa/ReveryAppDelegate_func.c
@@ -1,4 +1,5 @@
-#ifdef __APPLE__
+#include "config.h"
+#ifdef USE_COCOA
 #include "ReveryAppDelegate_func.h"
 
 #include <caml/callback.h>

--- a/src/Native/cocoa/ReveryAppDelegate_func.h
+++ b/src/Native/cocoa/ReveryAppDelegate_func.h
@@ -1,4 +1,5 @@
-#ifdef __APPLE__
+#include "config.h"
+#ifdef USE_COCOA
 #ifndef ReveryAppDelegate_func_h
 #define ReveryAppDelegate_func_h
 

--- a/src/Native/cocoa/ReveryProgressBar.c
+++ b/src/Native/cocoa/ReveryProgressBar.c
@@ -1,4 +1,5 @@
-#ifdef __APPLE__
+#include "config.h"
+#ifdef USE_COCOA
 #import <Cocoa/Cocoa.h>
 #import "ReveryProgressBar.h"
 

--- a/src/Native/cocoa/SDLAppDelegate.h
+++ b/src/Native/cocoa/SDLAppDelegate.h
@@ -1,4 +1,5 @@
-#ifdef __APPLE__
+#include "config.h"
+#ifdef USE_COCOA
 #import <Cocoa/Cocoa.h>
 
 @interface SDLAppDelegate

--- a/src/Native/config/discover.re
+++ b/src/Native/config/discover.re
@@ -1,9 +1,11 @@
-module Configurator = Configurator.V1;
+open Configurator.V1;
+open C_define;
+open Flags;
 
 type os =
-  | Windows
+  | Linux
   | Mac
-  | Linux;
+  | Windows;
 
 let detect_system_header = {|
   #if __APPLE__
@@ -24,11 +26,7 @@ let get_os = t => {
     file;
   };
   let platform =
-    Configurator.C_define.import(
-      t,
-      ~includes=[header],
-      [("PLATFORM_NAME", String)],
-    );
+    C_define.import(t, ~includes=[header], [("PLATFORM_NAME", String)]);
   switch (platform) {
   | [(_, String("linux"))] => Linux
   | [(_, String("mac"))] => Mac
@@ -37,26 +35,52 @@ let get_os = t => {
   };
 };
 
+type feature =
+  | GTK
+  | COCOA
+  | WIN32;
+
+let gen_config_header = (conf, features) => {
+  let includes = value =>
+    List.exists((==)(value), features)
+      ? Value.Int(1) : Value.Switch(false);
+  gen_header_file(
+    conf,
+    [
+      ("USE_GTK", includes(GTK)),
+      ("USE_COCOA", includes(COCOA)),
+      ("USE_WIN32", includes(WIN32)),
+    ],
+  );
+};
+
 type config = {
+  features: list(feature),
   libs: list(string),
   cflags: list(string),
   flags: list(string),
 };
 
 let get_mac_config = () => {
+  features: [COCOA],
   cflags: ["-I", ".", "-x", "objective-c"],
   libs: [],
   flags: [],
 };
 
 let get_linux_config = c => {
-  let default = {libs: [], cflags: [], flags: []};
-  switch (Configurator.Pkg_config.get(c)) {
+  let default = {features: [], libs: [], cflags: [], flags: []};
+  switch (Pkg_config.get(c)) {
   | None => default
   | Some(pc) =>
-    switch (Configurator.Pkg_config.query(pc, ~package="gtk+-3.0")) {
+    switch (Pkg_config.query(pc, ~package="gtk+-3.0")) {
     | None => default
-    | Some(conf) => {libs: conf.libs, cflags: conf.cflags, flags: []}
+    | Some(conf) => {
+        features: [GTK],
+        libs: conf.libs,
+        cflags: conf.cflags,
+        flags: [],
+      }
     }
   };
 };
@@ -65,21 +89,22 @@ let ccopt = s => ["-ccopt", s];
 let cclib = s => ["-cclib", s];
 
 let get_win32_config = () => {
+  features: [WIN32],
   cflags: [],
   libs: [],
   flags: [] @ cclib("-luuid") @ cclib("-lole32"),
 };
 
-Configurator.main(~name="discover", conf => {
-  let os = get_os(conf);
+main(~name="discover", t => {
+  let os = get_os(t);
   let conf =
     switch (os) {
     | Mac => get_mac_config()
-    | Linux => get_linux_config(conf)
+    | Linux => get_linux_config(t)
     | Windows => get_win32_config()
     };
-
-  Configurator.Flags.write_sexp("flags.sexp", conf.flags);
-  Configurator.Flags.write_sexp("c_flags.sexp", conf.cflags);
-  Configurator.Flags.write_sexp("c_library_flags.sexp", conf.libs);
+  gen_config_header(~fname="config.h", t, conf.features);
+  write_sexp("flags.sexp", conf.flags);
+  write_sexp("c_flags.sexp", conf.cflags);
+  write_sexp("c_library_flags.sexp", conf.libs);
 });

--- a/src/Native/dialog.c
+++ b/src/Native/dialog.c
@@ -9,20 +9,17 @@
 
 #include <string.h>
 
-#ifdef WIN32
+#include "config.h"
+#ifdef USE_WIN32
 #include "ReveryWin32.h"
-#elif __APPLE__
+#elif USE_COCOA
 #include "ReveryCocoa.h"
-#else
+#elif USE_GTK
 #include "ReveryGtk.h"
 #endif
 
 CAMLprim value revery_alertSupported() {
-#ifdef WIN32
-    return Val_true;
-#elif __APPLE__
-    return Val_true;
-#elif __linux__
+#if defined(USE_WIN32) || defined(USE_COCOA) || defined(USE_GTK)
     return Val_true;
 #else
     return Val_false;
@@ -34,11 +31,11 @@ CAMLprim value revery_alert(value vWindow, value vMessage) {
     const char *szMessage = String_val(vMessage);
     void *pWin = (void *)vWindow;
 
-#ifdef WIN32
+#ifdef USE_WIN32
     revery_alert_win32(pWin, szMessage);
-#elif __APPLE__
+#elif USE_COCOA
     revery_alert_cocoa(pWin, szMessage);
-#elif __linux__
+#elif USE_GTK
     revery_alert_gtk(pWin, szMessage);
 #else
     printf("WARNING - Not implemented: alert");
@@ -102,11 +99,11 @@ CAMLprim value revery_alertOpenFiles_native(
 
     char **fileList = NULL;
 
-#ifdef __APPLE__
+#ifdef USE_COCOA
     fileList = revery_open_files_cocoa(
                    startDirectory, fileTypes, fileTypesSize, allowMultiple, canChooseFiles,
                    canChooseDirectories, showHidden, buttonText, title);
-#elif __linux__
+#elif USE_GTK
     fileList = revery_open_files_gtk(
                    startDirectory, fileTypes, fileTypesSize, allowMultiple, canChooseFiles,
                    canChooseDirectories, showHidden, buttonText, title);

--- a/src/Native/dialog_cocoa.c
+++ b/src/Native/dialog_cocoa.c
@@ -1,4 +1,5 @@
-#ifdef __APPLE__
+#include "config.h"
+#ifdef USE_COCOA
 #include <stdio.h>
 
 #import <Cocoa/Cocoa.h>

--- a/src/Native/dialog_gtk.c
+++ b/src/Native/dialog_gtk.c
@@ -1,4 +1,5 @@
-#ifdef __linux__
+#include "config.h"
+#ifdef USE_GTK
 #include <gtk/gtk.h>
 #include <string.h>
 

--- a/src/Native/dialog_win32.c
+++ b/src/Native/dialog_win32.c
@@ -1,4 +1,5 @@
-#ifdef WIN32
+#include "config.h"
+#ifdef USE_WIN32
 
 #include <stdio.h>
 

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -21,6 +21,6 @@
 (copy_files cocoa/*)
 
 (rule
-(targets flags.sexp c_flags.sexp c_library_flags.sexp)
+(targets config.h flags.sexp c_flags.sexp c_library_flags.sexp)
 (deps (:discover config/discover.exe))
 (action (run %{discover})))

--- a/src/Native/icon.c
+++ b/src/Native/icon.c
@@ -8,20 +8,21 @@
 
 #include "caml_values.h"
 
-#ifdef WIN32
+#include "config.h"
+#ifdef USE_WIN32
 #include "ReveryWin32.h"
-#elif __APPLE__
+#elif USE_COCOA
 #include "ReveryCocoa.h"
-#else
+#elif USE_GTK
 #include "ReveryGtk.h"
 #endif
 
 CAMLprim value revery_getIconHandle() {
     CAMLparam0();
     void *ret;
-#ifdef __APPLE__
+#ifdef USE_COCOA
     ret = revery_getIconHandle_cocoa();
-#elif WIN32
+#elif USE_WIN32
     ret = revery_getIconHandle_win32();
 #else
     fprintf(stderr, "WARNING: %s is not implemented on this platform.", __func__);
@@ -42,20 +43,20 @@ CAMLprim value revery_setIconProgress(value vWin, value vIconHandle,
     */
     // If vProgress "is long", it has no type arguments, and is therefore indeterminate
     if (Is_long(vProgress)) {
-#ifdef __APPLE__
+#ifdef USE_COCOA
         (void)win;
         revery_setIconProgressIndeterminate_cocoa(ih);
-#elif WIN32
+#elif USE_WIN32
         revery_setIconProgressIndeterminate_win32(win, ih);
 #else
         fprintf(stderr, "WARNING: %s is not implemented on this platform.", __func__);
 #endif
     } else if (Is_block(vProgress)) {  // If vProgress "is block", it has a type argument and must be determinate
         float progress = Double_val(Field(vProgress, 0));
-#ifdef __APPLE__
+#ifdef USE_COCOA
         (void)win;
         revery_setIconProgress_cocoa(ih, progress);
-#elif WIN32
+#elif USE_WIN32
         revery_setIconProgress_win32(win, ih, progress);
 #else
         fprintf(stderr, "WARNING: %s is not implemented on this platform.", __func__);
@@ -73,10 +74,10 @@ CAMLprim value revery_hideIconProgress(value vWin, value vIconHandle) {
     void *win = (void *)vWin;
     void *ih = (void *)vIconHandle;
 
-#ifdef __APPLE__
+#ifdef USE_COCOA
     (void)win;
     revery_hideIconProgress_cocoa(ih);
-#elif WIN32
+#elif USE_WIN32
     revery_hideIconProgress_win32(win, ih);
 #else
     (void)win;

--- a/src/Native/icon_cocoa.c
+++ b/src/Native/icon_cocoa.c
@@ -1,4 +1,5 @@
-#ifdef __APPLE__
+#include "config.h"
+#ifdef USE_COCOA
 #include <stdio.h>
 
 #import <Cocoa/Cocoa.h>

--- a/src/Native/icon_win32.c
+++ b/src/Native/icon_win32.c
@@ -1,4 +1,5 @@
-#ifdef WIN32
+#include "config.h"
+#ifdef USE_WIN32
 
 #include <windows.h>
 #include <shobjidl.h>

--- a/src/Native/locale.c
+++ b/src/Native/locale.c
@@ -8,11 +8,12 @@
 
 #include "caml_values.h"
 
-#ifdef WIN32
+#include "config.h"
+#ifdef USE_WIN32
 #include "ReveryWin32.h"
-#elif __APPLE__
+#elif USE_COCOA
 #include "ReveryCocoa.h"
-#else
+#elif USE_GTK
 #include "ReveryGtk.h"
 #include <locale.h>
 #endif
@@ -22,10 +23,10 @@ CAMLprim value revery_getUserLocale() {
     CAMLlocal1(camlRet);
     char *ret;
     int shouldFree;
-#ifdef __APPLE__
+#ifdef USE_COCOA
     ret = revery_getUserLocale_cocoa();
     shouldFree = 0;
-#elif WIN32
+#elif USE_WIN32
     ret = revery_getUserLocale_win32();
     shouldFree = 1;
 #else

--- a/src/Native/locale_cocoa.c
+++ b/src/Native/locale_cocoa.c
@@ -1,4 +1,5 @@
-#ifdef __APPLE__
+#include "config.h"
+#ifdef USE_COCOA
 #include <stdio.h>
 
 #import <Cocoa/Cocoa.h>

--- a/src/Native/notification.c
+++ b/src/Native/notification.c
@@ -9,11 +9,12 @@
 
 #define UNUSED(x) (void)(x)
 
-#ifdef WIN32
+#include "config.h"
+#ifdef USE_WIN32
 #include "ReveryWin32.h"
-#elif __APPLE__
+#elif USE_COCOA
 #include "ReveryCocoa.h"
-#else
+#elif USE_GTK
 #include "ReveryGtk.h"
 #endif
 
@@ -28,7 +29,7 @@ CAMLprim value revery_dispatchNotification(value vNotificationT) {
     body = String_val(Field(vNotificationT, 1));
     value onClickCaml = Field(vNotificationT, 2);
     mute = Int_val(Field(vNotificationT, 3));
-#ifdef __APPLE__
+#ifdef USE_COCOA
     revery_dispatchNotification_cocoa(title, body, onClickCaml, mute);
     UNUSED(title);
     UNUSED(body);
@@ -57,7 +58,7 @@ CAMLprim value revery_scheduleNotificationFromNow(value vSeconds, value vNotific
     onClickCaml = Field(vNotificationT, 2);
     mute = Int_val(Field(vNotificationT, 3));
     seconds = Int_val(vSeconds);
-#ifdef __APPLE__
+#ifdef USE_COCOA
     revery_scheduleNotificationFromNow_cocoa(title, body, onClickCaml, mute, seconds);
     UNUSED(title);
     UNUSED(body);

--- a/src/Native/notification_cocoa.c
+++ b/src/Native/notification_cocoa.c
@@ -1,4 +1,5 @@
-#ifdef __APPLE__
+#include "config.h"
+#ifdef USE_COCOA
 #import "cocoa/ReveryAppDelegate.h"
 #import <Cocoa/Cocoa.h>
 

--- a/src/Native/shell.c
+++ b/src/Native/shell.c
@@ -9,11 +9,12 @@
 
 #define UNUSED(x) (void)(x)
 
-#ifdef WIN32
+#include "config.h"
+#ifdef USE_WIN32
 #include "ReveryWin32.h"
-#elif __APPLE__
+#elif USE_COCOA
 #include "ReveryCocoa.h"
-#else
+#elif USE_GTK
 #include "ReveryGtk.h"
 #endif
 
@@ -22,11 +23,11 @@ CAMLprim value revery_openURL(value vURL) {
 
     const char *url_string = String_val(vURL);
     int success = 0;
-#ifdef __APPLE__
+#ifdef USE_COCOA
     success = revery_openURL_cocoa(url_string);
-#elif __linux__
+#elif USE_GTK
     success = revery_openURL_gtk(url_string);
-#elif WIN32
+#elif USE_WIN32
     success = revery_openURL_win32(url_string);
 #else
     fprintf(stderr, "WARNING: %s is not implemented on this platform.\n", __func__);
@@ -41,11 +42,11 @@ CAMLprim value revery_openFile(value vPath) {
 
     const char *path_string = String_val(vPath);
     int success = 0;
-#ifdef __APPLE__
+#ifdef USE_COCOA
     success = revery_openFile_cocoa(path_string);
-#elif __linux__
+#elif USE_GTK
     success = revery_openFile_gtk(path_string);
-#elif WIN32
+#elif USE_WIN32
     // The Win32 implementation of the URL opener also works for file paths
     success = revery_openURL_win32(path_string);
 #else

--- a/src/Native/shell_cocoa.c
+++ b/src/Native/shell_cocoa.c
@@ -1,4 +1,5 @@
-#ifdef __APPLE__
+#include "config.h"
+#ifdef USE_COCOA
 #import <Cocoa/Cocoa.h>
 
 int revery_openURL_cocoa(const char *url_string) {

--- a/src/Native/shell_gtk.c
+++ b/src/Native/shell_gtk.c
@@ -1,4 +1,5 @@
-#ifdef __linux__
+#include "config.h"
+#ifdef USE_GTK
 #include <gtk/gtk.h>
 
 /*  gtk_show_uri is technically deprecated, but it has the most support

--- a/src/Native/shell_win32.c
+++ b/src/Native/shell_win32.c
@@ -1,4 +1,5 @@
-#ifdef WIN32
+#include "config.h"
+#ifdef USE_WIN32
 
 #include <windows.h>
 #include <shellapi.h>


### PR DESCRIPTION
## Problem

We currently use `__APPLE__` and `__linux__` to detect if the system uses Cocoa or GTK, that's a problem on iOS and Android as they don't have Cocoa and GTK

## Solution

Using a config header generated at `discover.re` makes it more portable, so when adding a new platform only the platform dependent code of this specific new platform, will need to change.
Another alternative would be to use `-D` on the command line, but that is harder to replicate and the editor integration is worse.

This is the last platform independent change to get Android and iOS on Revery. The next ones should be Android and iOS respectively.