### PR TITLE
feat: Android

### DIFF
--- a/bench.json
+++ b/bench.json
@@ -4,7 +4,7 @@
       "run": "esy '@bench' x ReveryBench"
   },
   "override": {
-      "build": ["dune build -p font-manager,harfbuzz,skia,sdl2,Revery,ReveryBench -j4"],
+      "build": ["dune build -p harfbuzz,skia,sdl2,Revery,ReveryBench -j4"],
       "install": [
           "esy-installer ReveryBench.install"
       ]

--- a/doc.json
+++ b/doc.json
@@ -5,7 +5,7 @@
     "print": "esy '@doc' echo #{self.target_dir}/default/_doc/_html"
   },
   "override": {
-      "build": ["dune build @doc -p font-manager,harfbuzz,skia,sdl2,Revery -j4"],
+      "build": ["dune build @doc -p harfbuzz,skia,sdl2,Revery -j4"],
       "dependencies": {
 	  "@opam/odoc": "*",
 	  "http-server": "*"

--- a/examples.json
+++ b/examples.json
@@ -5,7 +5,7 @@
       "run-harfbuzz": "esy @examples x bash -c run-harfbuzz.sh #{os}"
   },
   "override": {
-      "build": ["dune build -p font-manager,harfbuzz,skia,sdl2,Revery,ReveryExamples -j4"],
+      "build": ["dune build -p harfbuzz,skia,sdl2,Revery,ReveryExamples -j4"],
       "install": [
           "esy-installer harfbuzz.install",
           "esy-installer skia.install",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     },
     "build": "dune build -p harfbuzz,skia,sdl2,Revery",
     "install": [
-      "esy-installer font-manager.install",
       "esy-installer harfbuzz.install",
       "esy-installer skia.install",
       "esy-installer sdl2.install",

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -27,7 +27,7 @@ let os = {
   webGL
     ? Browser
     : (
-      switch (Revery_Native.Environemnt.get_os()) {
+      switch (Revery_Native.Environment.get_os()) {
       | `Android => Android
       | `Linux => Linux
       | `Mac => Mac

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -16,9 +16,10 @@ let sleep = (t: Time.t) =>
 external yield: unit => unit = "caml_thread_yield";
 
 type os =
-  | Windows
-  | Mac
+  | Android
   | Linux
+  | Mac
+  | Windows
   | Browser
   | Unknown;
 
@@ -26,17 +27,12 @@ let os = {
   webGL
     ? Browser
     : (
-      switch (Sys.os_type) {
-      | "Win32" => Windows
-      | _ =>
-        let ic = Unix.open_process_in("uname");
-        let uname = input_line(ic);
-        let _ = close_in(ic);
-        switch (uname) {
-        | "Darwin" => Mac
-        | "Linux" => Linux
-        | _ => Unknown
-        };
+      switch (Revery_Native.Environemnt.get_os()) {
+      | `Android => Android
+      | `Linux => Linux
+      | `Mac => Mac
+      | `Windows => Windows
+      | _ => Unknown
       }
     );
 };

--- a/src/Core/Environment.rei
+++ b/src/Core/Environment.rei
@@ -47,9 +47,10 @@ let getAssetPath: string => string;
 let getTempDirectory: unit => string;
 
 type os =
-  | Windows
-  | Mac
+  | Android
   | Linux
+  | Mac
+  | Windows
   | Browser
   | Unknown;
 

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -97,6 +97,21 @@ module WindowMetrics: {
             | None => 1.0
             };
           }
+        // On Android we can mostly trust the getDPI and the base DPI is 160
+        // ddpi indicates the scale factor choosen by the manufacturer
+        // hdpi is the real horizontal dpi, vdpi is the real vertical dpi, they can be different
+        // also any non integer scaleFactor is valid as it's choosen by the manufecturer
+        | Android =>
+          let display = Sdl2.Window.getDisplay(sdlWindow);
+          let dpi = Sdl2.Display.getDPI(display);
+          let scaleFactor = dpi.ddpi /. 160.0;
+          Log.tracef(m =>
+            m(
+              "_getScaleFactor - Android - inferring from DPI: %f",
+              scaleFactor,
+            )
+          );
+          scaleFactor;
         | _ => 1.0
         }
       };

--- a/src/Native/Environment.re
+++ b/src/Native/Environment.re
@@ -1,0 +1,9 @@
+external get_os: unit => string = "revery_getOperatingSystem";
+let get_os = () =>
+  switch (get_os()) {
+  | "android" => `Android
+  | "linux" => `Linux
+  | "mac" => `Mac
+  | "windows" => `Windows
+  | _ => `Unknown
+  };

--- a/src/Native/Revery_Native.re
+++ b/src/Native/Revery_Native.re
@@ -1,4 +1,5 @@
 module Dialog = Dialog;
+module Environemnt = Environment;
 module Icon = Icon;
 module Notification = Notification;
 module Shell = Shell;

--- a/src/Native/Revery_Native.re
+++ b/src/Native/Revery_Native.re
@@ -1,5 +1,5 @@
 module Dialog = Dialog;
-module Environemnt = Environment;
+module Environment = Environment;
 module Icon = Icon;
 module Notification = Notification;
 module Shell = Shell;

--- a/src/Native/dialog.c
+++ b/src/Native/dialog.c
@@ -7,6 +7,8 @@
 
 #include "caml_values.h"
 
+#define UNUSED(x) (void)(x)
+
 #include <string.h>
 
 #include "config.h"
@@ -39,6 +41,8 @@ CAMLprim value revery_alert(value vWindow, value vMessage) {
     revery_alert_gtk(pWin, szMessage);
 #else
     printf("WARNING - Not implemented: alert");
+    UNUSED(szMessage);
+    UNUSED(pWin);
 #endif
     return Val_unit;
 }

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -8,6 +8,7 @@
         Revery_Native
         dialog dialog_cocoa dialog_win32 dialog_gtk
         notification notification_cocoa
+        environment
         icon icon_cocoa icon_win32
         shell shell_cocoa shell_gtk shell_win32
         locale locale_cocoa locale_win32

--- a/src/Native/environment.c
+++ b/src/Native/environment.c
@@ -1,0 +1,18 @@
+#include <caml/alloc.h>
+#include <caml/callback.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <caml/alloc.h>
+#include <caml/callback.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+
+#include "config.h"
+
+CAMLprim value revery_getOperatingSystem() {
+  CAMLparam0();
+  CAMLreturn(caml_copy_string(PLATFORM_NAME));
+}

--- a/src/Native/environment.c
+++ b/src/Native/environment.c
@@ -13,6 +13,6 @@
 #include "config.h"
 
 CAMLprim value revery_getOperatingSystem() {
-  CAMLparam0();
-  CAMLreturn(caml_copy_string(PLATFORM_NAME));
+    CAMLparam0();
+    CAMLreturn(caml_copy_string(PLATFORM_NAME));
 }

--- a/src/Native/locale.c
+++ b/src/Native/locale.c
@@ -15,6 +15,9 @@
 #include "ReveryCocoa.h"
 #elif USE_GTK
 #include "ReveryGtk.h"
+#endif
+
+#ifdef __linux__
 #include <locale.h>
 #endif
 

--- a/src/Native/shell.c
+++ b/src/Native/shell.c
@@ -52,7 +52,7 @@ CAMLprim value revery_openFile(value vPath) {
 #else
     fprintf(stderr, "WARNING: %s is not implemented on this platform.\n", __func__);
     success = 0;
-    UNUSED(url_string);
+    UNUSED(path_string);
 #endif
     CAMLreturn(Val_bool(success));
 }

--- a/src/reason-skia/config/discover.re
+++ b/src/reason-skia/config/discover.re
@@ -6,15 +6,20 @@ let getenv = name =>
   };
 
 type os =
-  | Windows
+  | Android
+  | Linux
   | Mac
-  | Linux;
+  | Windows;
 
 let detect_system_header = {|
   #if __APPLE__
     #define PLATFORM_NAME "mac"
   #elif __linux__
-    #define PLATFORM_NAME "linux"
+    #if __ANDROID__
+      #define PLATFORM_NAME "android"
+    #else
+      #define PLATFORM_NAME "linux"
+    #endif
   #elif WIN32
     #define PLATFORM_NAME "windows"
   #endif
@@ -35,6 +40,7 @@ let get_os = t => {
       [("PLATFORM_NAME", String)],
     );
   switch (platform) {
+  | [(_, String("android"))] => Android
   | [(_, String("linux"))] => Linux
   | [(_, String("mac"))] => Mac
   | [(_, String("windows"))] => Windows
@@ -47,6 +53,27 @@ let cclib = s => ["-cclib", s];
 let framework = s => ["-framework", s];
 let flags = os =>
   switch (os) {
+  | Android =>
+    []
+    @ ["-verbose"]
+    @ cclib("-lfreetype")
+    @ cclib("-lz")
+    @ cclib("-lskia")
+    @ cclib("-lSDL2")
+    @ cclib("-lGLESv2")
+    @ cclib("-lGLESv1_CM")
+    @ cclib("-lm")
+    @ cclib("-llog")
+    @ cclib("-landroid")
+    @ ccopt("-L" ++ getenv("FREETYPE2_LIB_PATH"))
+    @ ccopt("-L" ++ getenv("SDL2_LIB_PATH"))
+    @ ccopt("-L" ++ getenv("SKIA_LIB_PATH"))
+    @ ccopt("-L" ++ getenv("JPEG_LIB_PATH"))
+    @ ccopt("-I" ++ getenv("FREETYPE2_INCLUDE_PATH"))
+    @ ccopt("-I" ++ getenv("SKIA_INCLUDE_PATH"))
+    @ cclib("-ljpeg")
+    @ ccopt("-I/usr/include")
+    @ ccopt("-lstdc++")
   | Linux =>
     []
     @ ["-verbose"]
@@ -76,11 +103,23 @@ let flags = os =>
 
 let cflags = os =>
   switch (os) {
-  | Mac =>
+  | Android =>
     []
+    @ ["-lSDL2"]
+    @ ["-lGLESv2"]
+    @ ["-lGLESv1_CM"]
+    @ ["-lm"]
+    @ ["-llog"]
+    @ ["-landroid"]
+    @ ["-lskia"]
     @ ["-I" ++ getenv("SDL2_INCLUDE_PATH")]
     @ ["-I" ++ getenv("SKIA_INCLUDE_PATH")]
     @ ["-I" ++ getenv("SKIA_INCLUDE_PATH") ++ "/c"]
+    @ ["-L" ++ getenv("SKIA_LIB_PATH")]
+    @ ["-L" ++ getenv("SDL2_LIB_PATH")]
+    @ ["-L" ++ getenv("JPEG_LIB_PATH")]
+    @ ["-lstdc++"]
+    @ ["-ljpeg"]
   | Linux =>
     []
     @ ["-lSDL2"]
@@ -93,6 +132,11 @@ let cflags = os =>
     @ ["-L" ++ getenv("JPEG_LIB_PATH")]
     @ ["-lstdc++"]
     @ ["-ljpeg"]
+  | Mac =>
+    []
+    @ ["-I" ++ getenv("SDL2_INCLUDE_PATH")]
+    @ ["-I" ++ getenv("SKIA_INCLUDE_PATH")]
+    @ ["-I" ++ getenv("SKIA_INCLUDE_PATH") ++ "/c"]
   | Windows =>
     []
     @ ["-std=c++1y"]
@@ -103,6 +147,42 @@ let cflags = os =>
 
 let libs = os =>
   switch (os) {
+  | Android =>
+    []
+    @ [
+      "-lSDL2",
+      "-lGLESv2",
+      "-lGLESv1_CM",
+      "-lm",
+      "-llog",
+      "-landroid",
+      "-lskia",
+      "-lfreetype",
+      "-lz",
+      "-L" ++ getenv("JPEG_LIB_PATH"),
+      "-ljpeg",
+      "-lstdc++",
+      "-L" ++ getenv("SDL2_LIB_PATH"),
+      "-L" ++ getenv("SKIA_LIB_PATH"),
+      "-L" ++ getenv("FREETYPE2_LIB_PATH"),
+    ]
+  | Linux =>
+    []
+    @ [
+      "-lSDL2",
+      "-lskia",
+      "-lfreetype",
+      "-lfontconfig",
+      "-lz",
+      "-lbz2",
+      "-L" ++ getenv("JPEG_LIB_PATH"),
+      "-ljpeg",
+      "-lpthread",
+      "-lstdc++",
+      "-L" ++ getenv("SDL2_LIB_PATH"),
+      "-L" ++ getenv("SKIA_LIB_PATH"),
+      "-L" ++ getenv("FREETYPE2_LIB_PATH"),
+    ]
   | Mac =>
     []
     @ ["-L" ++ getenv("JPEG_LIB_PATH")]
@@ -127,23 +207,6 @@ let libs = os =>
     @ ["-lskia"]
     @ ["-lstdc++"]
     @ [getenv("JPEG_LIB_PATH") ++ "/libturbojpeg.a"]
-  | Linux =>
-    []
-    @ [
-      "-lSDL2",
-      "-lskia",
-      "-lfreetype",
-      "-lfontconfig",
-      "-lz",
-      "-lbz2",
-      "-L" ++ getenv("JPEG_LIB_PATH"),
-      "-ljpeg",
-      "-lpthread",
-      "-lstdc++",
-      "-L" ++ getenv("SDL2_LIB_PATH"),
-      "-L" ++ getenv("SKIA_LIB_PATH"),
-      "-L" ++ getenv("FREETYPE2_LIB_PATH"),
-    ]
   | Windows =>
     []
     @ ["-luser32"]

--- a/test.json
+++ b/test.json
@@ -4,7 +4,7 @@
       "run": "esy '@test' x ReveryTestRunner"
   },
   "override": {
-      "build": ["dune build -p font-manager,harfbuzz,skia,sdl2,Revery,ReveryTest -j4"],
+      "build": ["dune build -p harfbuzz,skia,sdl2,Revery,ReveryTest -j4"],
       "dependencies": {
         "@reason-native/rely": "*"
       },


### PR DESCRIPTION
There is quite some duplicated code happening, related to system detection, probably in the near future I would like to change how we do that.

## Changes

- Get the OS during runtime using the value from `config.h`
- Add Android specific flags to reason-sdl2 and reason-skia
- Add special handle for Android scale factor

## How to test

Currently esy doesn't provide the needed tools, so we need some hacks, they're provided at [reason-mobile](https://github.com/EduardoRFS/reason-mobile)