### PR TITLE
feat(native): support iOS

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -302,3 +302,4 @@ let start = init => {
 
   Sdl2.renderLoop(appLoop);
 };
+let start = init => Sdl2.main(() => start(init));

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -17,6 +17,7 @@ external yield: unit => unit = "caml_thread_yield";
 
 type os =
   | Android
+  | IOS
   | Linux
   | Mac
   | Windows
@@ -29,6 +30,7 @@ let os = {
     : (
       switch (Revery_Native.Environment.get_os()) {
       | `Android => Android
+      | `IOS => IOS
       | `Linux => Linux
       | `Mac => Mac
       | `Windows => Windows

--- a/src/Core/Environment.rei
+++ b/src/Core/Environment.rei
@@ -48,6 +48,7 @@ let getTempDirectory: unit => string;
 
 type os =
   | Android
+  | IOS
   | Linux
   | Mac
   | Windows

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -65,8 +65,9 @@ module WindowMetrics: {
       // Otherwise, the way we figure out the scale factor depends on the platform
       | None =>
         switch (Environment.os) {
-        // Mac is easy... there isn't any scaling factor.  The window is automatically
+        // Mac and iOS is easy... there isn't any scaling factor.  The window is automatically
         // proportioned for us. The scaling is handled by the ratio of size / framebufferSize.
+        | IOS
         | Mac => 1.0
         // On Windows, we need to try a Win32 API to get the scale factor
         | Windows =>

--- a/src/Draw/CanvasContext.re
+++ b/src/Draw/CanvasContext.re
@@ -44,9 +44,11 @@ let create = (window: Revery_Core.Window.t) => {
     None;
   | Some(glContext) =>
     Log.debug("Skia context created successfully.");
+    let framebufferId = Sdl2.Gl.getFramebufferBinding();
+    Log.debug(Printf.sprintf("Framebuffer binding %d.", framebufferId));
     let framebufferInfo =
       Gr.Gl.FramebufferInfo.make(
-        Unsigned.UInt.of_int(0),
+        Unsigned.UInt.of_int(framebufferId),
         Unsigned.UInt.of_int(0x8058),
       );
 

--- a/src/Native/Environment.re
+++ b/src/Native/Environment.re
@@ -2,6 +2,7 @@ external get_os: unit => string = "revery_getOperatingSystem";
 let get_os = () =>
   switch (get_os()) {
   | "android" => `Android
+  | "ios" => `IOS
   | "linux" => `Linux
   | "mac" => `Mac
   | "windows" => `Windows

--- a/src/Native/locale.c
+++ b/src/Native/locale.c
@@ -17,7 +17,7 @@
 #include "ReveryGtk.h"
 #endif
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include <locale.h>
 #endif
 

--- a/src/reason-sdl2/sdl2.re
+++ b/src/reason-sdl2/sdl2.re
@@ -238,6 +238,8 @@ module Gl = {
     | Renderer
     | Version
     | ShadingLanguageVersion;
+  type glInt =
+    | FramebufferBinding;
 
   external setup: Window.t => context = "resdl_SDL_GL_Setup";
   external makeCurrent: (Window.t, context) => unit =
@@ -248,6 +250,8 @@ module Gl = {
   external setSwapInterval: int => unit = "resdl_SDL_GL_SetSwapInterval";
 
   external getString: glString => string = "resdl_SDL_GL_GetString";
+  external getFramebufferBinding: unit => int =
+    "resdl_SDL_GL_GetFramebufferBinding";
 };
 
 external delay: int => unit = "resdl_SDL_Delay";

--- a/src/reason-sdl2/sdl2.re
+++ b/src/reason-sdl2/sdl2.re
@@ -252,6 +252,8 @@ module Gl = {
 
 external delay: int => unit = "resdl_SDL_Delay";
 external init: unit => int = "resdl_SDL_Init";
+external main: (int, array(string), unit => unit) => unit = "resdl_SDL_main";
+let main = cb => main(Array.length(Sys.argv), Sys.argv, cb);
 
 module TextInput = {
   [@noalloc] external start: unit => unit = "resdl_SDL_StartTextInput";
@@ -799,6 +801,8 @@ module Version = {
 };
 
 type renderFunction = unit => bool;
+external _javaScriptRenderLoop: renderFunction => unit =
+  "resdl__javascript__renderloop";
 external _javaScriptRenderLoop: renderFunction => unit =
   "resdl__javascript__renderloop";
 

--- a/src/reason-sdl2/sdl2_wrapper.cpp
+++ b/src/reason-sdl2/sdl2_wrapper.cpp
@@ -1564,6 +1564,10 @@ CAMLprim value resdl_SDL_Init() {
 
 #if SDL_VIDEO_DRIVER_UIKIT
 value resdl_uikit_main_callback;
+int resdl_uikit_SDL_main (int argc, char *argv[]) {
+  caml_callback(resdl_uikit_main_callback, Val_unit);
+  return 0;
+}
 #endif
 
 CAMLprim value resdl_SDL_main(value ml_argc, value ml_argv, value closure) {
@@ -1578,10 +1582,7 @@ CAMLprim value resdl_SDL_main(value ml_argc, value ml_argv, value closure) {
     }
 
     resdl_uikit_main_callback = closure;
-    SDL_UIKitRunApp(argc, argv, [](int argc, char *argv[]){
-      caml_callback(resdl_uikit_main_callback, Val_unit);
-      return 0;
-    });
+    SDL_UIKitRunApp(argc, argv, resdl_uikit_SDL_main);
   #else
     caml_callback(closure, Val_unit);
   #endif

--- a/src/reason-sdl2/sdl2_wrapper.cpp
+++ b/src/reason-sdl2/sdl2_wrapper.cpp
@@ -601,6 +601,28 @@ CAMLprim value resdl_SDL_GL_GetString(value vStr) {
   CAMLreturn(ret);
 }
 
+typedef void (*glGetIntegervFunc)(GLenum, GLint*);
+CAMLprim value resdl_SDL_GL_GetFramebufferBinding(value vInt) {
+  CAMLparam1(vInt);
+  
+  GLenum name = GL_FRAMEBUFFER_BINDING;
+  switch (Int_val(vInt)) {
+  case 0:
+    name = GL_FRAMEBUFFER_BINDING;
+    break;
+  default:
+    break;
+  }
+  
+  GLint ret = -1;
+  glGetIntegervFunc glGetIntegerv =
+      (glGetIntegervFunc)(SDL_GL_GetProcAddress("glGetIntegerv"));
+  if (glGetIntegerv) {
+    glGetIntegerv(name, &ret);
+  }
+  CAMLreturn(Val_int(ret));
+}
+
 CAMLprim value resdl_SDL_GL_MakeCurrent(value vWindow, value vContext) {
   CAMLparam2(vWindow, vContext);
   SDL_Window *win = (SDL_Window *)vWindow;


### PR DESCRIPTION
Again, more system detection code, but this time is done.

## Changes 

- Add iOS specific flags to revery, reason-sdl2 and reason-skia
- proper detection of framebufferId
- the application lives inside an SDL_main

This last change is required as our application needs to live inside the [UIApplicationMain](https://github.com/SDL-mirror/SDL/blob/2cf2cfd5b0b0e634bba32295d7ba7e64b298aea3/src/video/uikit/SDL_uikitappdelegate.m#L70), this is essentially a no-op on other platforms.

## How to test

Same as #943 will publish a guide and a CI today