### PR TITLE
fix(text wrap): make UTF-8 aware

### DIFF
--- a/examples/text-wrap-cli/ReveryTextWrapCli.re
+++ b/examples/text-wrap-cli/ReveryTextWrapCli.re
@@ -1,42 +1,38 @@
 open Revery_TextWrap.Wrap;
 
 /* Get the width of a character */
-let width_of_char =
-  fun
-  | '1'
-  | 'i'
-  | 'l'
-  | 'I' => 0.5
-  | 'w'
-  | 'W'
-  | 'm'
-  | 'M' => 1.2
-  | '\t' => 4.0
-  | '\n' => 0.0
-  | _ => 1.0;
+let width_of_token = str => {
+  String.length(str) |> float;
+};
+
+Printexc.record_backtrace(true);
 
 let () = {
   print_endline("0:");
   Tokenize.split_tokens("0") |> Queue.iter(print_endline);
   print_endline("------------------");
-  wrap(~width_of_char, ~max_width=100.0, ~debug=true, "0")
+  wrap(~width_of_token, ~max_width=100.0, ~debug=true, "0")
   |> List.iter(print_endline);
   let wrapInput =
     "Here's another example of text where wrapping might be more difficult. "
     ++ "This string is very, very long and consists of words of varying lengths. "
     ++ "By utilizing some extremely long words, we can hopefully trigger some of "
     ++ "the more obscure edge-cases that word-wrapping can result in, such as "
-    ++ "placing a hyphen in the middle of a word on top of another hyphen.";
+    ++ "placing a hyphen in the middle of a word on top of another hyphen."
+    ++ "Let's also throw some UTF8 in here, who doesn't like a good emoji or 10?"
+    ++ "😀 🤔 🤭 🤫 🤥 😶 😐 😑 😬"
+    ++ "Also let's try some CJK!"
+    ++ "日本語の場合はランダムに生成された文章以外に、 著作権が切れた小説などが利用されることもある。";
   print_endline("==================");
-  wrap(~width_of_char, ~max_width=5.0, ~hyphenate=true, wrapInput)
+  wrap(~width_of_token, ~debug=true, ~max_width=5.0, ~hyphenate=true, wrapInput)
   |> List.iter(print_endline);
   print_endline("==================");
-  wrap(~width_of_char, ~max_width=10.0, ~hyphenate=true, wrapInput)
+  wrap(~width_of_token, ~max_width=10.0, ~hyphenate=true, wrapInput)
   |> List.iter(print_endline);
   print_endline("==================");
-  wrap(~width_of_char, ~max_width=15.0, wrapInput)
+  wrap(~width_of_token, ~max_width=15.0, wrapInput)
   |> List.iter(print_endline);
   print_endline("==================");
-  wrap(~width_of_char, ~max_width=40.0, wrapInput)
+  wrap(~width_of_token, ~max_width=40.0, wrapInput)
   |> List.iter(print_endline);
 };

--- a/examples/text-wrap-cli/ReveryTextWrapCli.re
+++ b/examples/text-wrap-cli/ReveryTextWrapCli.re
@@ -24,7 +24,13 @@ let () = {
     ++ "Also let's try some CJK!"
     ++ "日本語の場合はランダムに生成された文章以外に、 著作権が切れた小説などが利用されることもある。";
   print_endline("==================");
-  wrap(~width_of_token, ~debug=true, ~max_width=5.0, ~hyphenate=true, wrapInput)
+  wrap(
+    ~width_of_token,
+    ~debug=true,
+    ~max_width=5.0,
+    ~hyphenate=true,
+    wrapInput,
+  )
   |> List.iter(print_endline);
   print_endline("==================");
   wrap(~width_of_token, ~max_width=10.0, ~hyphenate=true, wrapInput)

--- a/examples/text-wrap-cli/ReveryTextWrapCli.re
+++ b/examples/text-wrap-cli/ReveryTextWrapCli.re
@@ -24,13 +24,7 @@ let () = {
     ++ "Also let's try some CJK!"
     ++ "日本語の場合はランダムに生成された文章以外に、 著作権が切れた小説などが利用されることもある。";
   print_endline("==================");
-  wrap(
-    ~width_of_token,
-    ~debug=true,
-    ~max_width=5.0,
-    ~hyphenate=true,
-    wrapInput,
-  )
+  wrap(~width_of_token, ~max_width=5.0, ~hyphenate=true, wrapInput)
   |> List.iter(print_endline);
   print_endline("==================");
   wrap(~width_of_token, ~max_width=10.0, ~hyphenate=true, wrapInput)

--- a/src/Core/TextWrapping.re
+++ b/src/Core/TextWrapping.re
@@ -18,11 +18,6 @@ let wrapText = (~text, ~measureWidth as width_of_token, ~maxWidth, ~mode) => {
       ~ignore_preceding_whitespace=false,
     )
   | WrapHyphenate =>
-    Wrap.wrap(
-      text,
-      ~max_width=maxWidth,
-      ~width_of_token,
-      ~hyphenate=true,
-    )
+    Wrap.wrap(text, ~max_width=maxWidth, ~width_of_token, ~hyphenate=true)
   };
 };

--- a/src/Core/TextWrapping.re
+++ b/src/Core/TextWrapping.re
@@ -6,22 +6,22 @@ type wrapType =
   | WrapIgnoreWhitespace
   | WrapHyphenate;
 
-let wrapText = (~text, ~measureWidth, ~maxWidth, ~mode) => {
+let wrapText = (~text, ~measureWidth as width_of_token, ~maxWidth, ~mode) => {
   switch (mode) {
   | NoWrap => [text]
-  | Wrap => Wrap.wrap(text, ~max_width=maxWidth, ~width_of_char=measureWidth)
+  | Wrap => Wrap.wrap(text, ~max_width=maxWidth, ~width_of_token)
   | WrapIgnoreWhitespace =>
     Wrap.wrap(
       text,
       ~max_width=maxWidth,
-      ~width_of_char=measureWidth,
+      ~width_of_token,
       ~ignore_preceding_whitespace=false,
     )
   | WrapHyphenate =>
     Wrap.wrap(
       text,
       ~max_width=maxWidth,
-      ~width_of_char=measureWidth,
+      ~width_of_token,
       ~hyphenate=true,
     )
   };

--- a/src/Draw/Text.re
+++ b/src/Draw/Text.re
@@ -33,13 +33,13 @@ let charWidth =
       ~fontFamily,
       ~fontSize,
       ~fontWeight,
-      char,
+      uchar,
     ) => {
   let maybeSkia = Family.toSkia(~italic?, fontWeight, fontFamily);
 
   switch (FontCache.load(maybeSkia)) {
   | Ok(font) =>
-    let text = String.make(1, char);
+    let text = Zed_utf8.singleton(uchar);
     FontRenderer.measure(~smoothing, font, fontSize, text).width;
 
   | Error(_) => 0.

--- a/src/Draw/Text.rei
+++ b/src/Draw/Text.rei
@@ -11,7 +11,7 @@ let charWidth:
     ~fontFamily: Family.t,
     ~fontSize: float,
     ~fontWeight: Weight.t,
-    char
+    Uchar.t
   ) =>
   float;
 

--- a/src/Draw/dune
+++ b/src/Draw/dune
@@ -13,4 +13,5 @@
         Revery_Core
         Revery_Font
         Revery_Math
+        Revery_Zed
 ))

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -237,14 +237,15 @@ class textNode (text: string) = {
          );
 
     let measureWidth = str =>
-      Text.charWidth(
+      Text.dimensions(
         ~smoothing=_smoothing,
         ~italic=_italicized,
         ~fontFamily=_fontFamily,
         ~fontSize=_fontSize,
         ~fontWeight=_fontWeight,
         str,
-      );
+      )
+      |> (value => value.width);
     _lines =
       TextWrapping.wrapText(
         ~text,

--- a/src/revery-text-wrap/wrap.re
+++ b/src/revery-text-wrap/wrap.re
@@ -41,7 +41,8 @@ let wrap_queue =
        let width = ref(0.0);
        /* Tokenize the line by whitespace and for each token: */
        let x = split_tokens(line);
-       x |> Queue.iter(token => {
+       x
+       |> Queue.iter(token => {
             /* Calculate the width of the token */
             let token_width = width_of_token(token);
 
@@ -97,9 +98,11 @@ let wrap_queue =
               };
 
               /* For each character in the token, do processing to determine where to break */
-              Zed_utf8.rev_explode(token) |> List.rev
+              Zed_utf8.rev_explode(token)
+              |> List.rev
               |> List.iteri((i, uchar) => {
-                   let char_width = width_of_token(Zed_utf8.singleton(uchar));
+                   let char_width =
+                     width_of_token(Zed_utf8.singleton(uchar));
 
                    /* If it won't overflow this line OR if there's no way to fit it into a line without overflowing */
                    if (width^
@@ -107,7 +110,9 @@ let wrap_queue =
                        || width^ == 0.0
                        && char_width >= max_width) {
                      if (debug) {
-                       print_endline("--Decision: append (" ++ __LOC__ ++ ")");
+                       print_endline(
+                         "--Decision: append (" ++ __LOC__ ++ ")",
+                       );
                      };
                      /* Append it to the buffer */
                      Buffer.add_utf_8_uchar(buffer, uchar);

--- a/src/revery-text-wrap/wrap.re
+++ b/src/revery-text-wrap/wrap.re
@@ -80,8 +80,7 @@ let wrap_queue =
        /* Store the width of this portion */
        let width = ref(0.0);
        /* Tokenize the line by whitespace and for each token: */
-       let x = split_tokens(line);
-       x
+       split_tokens(line)
        |> Queue.iter(token => {
             /* Calculate the width of the token */
             let token_width = width_of_token(token);

--- a/src/revery-text-wrap/wrap.re
+++ b/src/revery-text-wrap/wrap.re
@@ -1,13 +1,6 @@
 open Tokenize;
 module Tokenize = Tokenize;
 
-/* Get the width of a token (i.e. the sum of each character's width) */
-let width_of_token = (~width_of_char, str) => {
-  let sum = ref(0.0);
-  str |> String.iter(char => sum := sum^ +. width_of_char(char));
-  sum^;
-};
-
 let rec list_of_queue = q =>
   if (Queue.is_empty(q)) {
     [];
@@ -19,10 +12,19 @@ let rec list_of_queue = q =>
     [first, ...list_of_queue(q)];
   };
 
+let last_uchar_of_string = str =>
+  switch (str) {
+  | "" => Uchar.of_int(0)
+  | _ =>
+    let offset = Zed_utf8.prev(str, String.length(str));
+    let offset = offset == String.length(str) ? 0 : offset;
+    Zed_utf8.extract(str, offset);
+  };
+
 let wrap_queue =
     (
       ~max_width,
-      ~width_of_char,
+      ~width_of_token,
       ~hyphenate=false,
       ~ignore_preceding_whitespace=true,
       ~debug=false,
@@ -38,10 +40,10 @@ let wrap_queue =
        /* Store the width of this portion */
        let width = ref(0.0);
        /* Tokenize the line by whitespace and for each token: */
-       split_tokens(line)
-       |> Queue.iter(token => {
+       let x = split_tokens(line);
+       x |> Queue.iter(token => {
             /* Calculate the width of the token */
-            let token_width = width_of_token(~width_of_char, token);
+            let token_width = width_of_token(token);
 
             if (debug) {
               Printf.printf(
@@ -84,7 +86,7 @@ let wrap_queue =
               /* If we can add the token without exceeding the limit, add it to the current line */
             } else if (width^ +. token_width <= max_width) {
               if (debug) {
-                print_endline("Decision: append");
+                print_endline("Decision: append (" ++ __LOC__ ++ ")");
               };
               width := width^ +. token_width;
               Buffer.add_string(buffer, token);
@@ -95,78 +97,71 @@ let wrap_queue =
               };
 
               /* For each character in the token, do processing to determine where to break */
-              for (i in 0 to String.length(token) - 1) {
-                let char_width = width_of_char(token.[i]);
-                if (debug) {
-                  Printf.printf(
-                    "--Index: %d, Char: %c, Char_width: %f\n",
-                    i,
-                    token.[i],
-                    char_width,
-                  );
-                };
+              Zed_utf8.rev_explode(token) |> List.rev
+              |> List.iteri((i, uchar) => {
+                   let char_width = width_of_token(Zed_utf8.singleton(uchar));
 
-                /* If it won't overflow this line OR if there's no way to fit it into a line without overflowing */
-                if (width^
-                    +. char_width <= max_width
-                    || width^ == 0.0
-                    && char_width >= max_width) {
-                  if (debug) {
-                    print_endline("--Decision: append");
-                  };
-                  /* Append it to the buffer */
-                  Buffer.add_char(buffer, token.[i]);
-                  width := width^ +. char_width;
-                  /* If it will overflow... */
-                } else {
-                  if (debug) {
-                    print_endline("--Decision: break");
-                  };
-                  /* Finalize the current line and reset the buffer (if we need to) */
-                  if (width^ > 0.0) {
-                    /* If we're part-way through the string already */
-                    if (i > 0) {
-                      if (debug) {
-                        print_endline("--Clear+hyphenate");
-                      };
-                      /* We need to swap the last char of the buffer with a -, because the
-                         hyphen will be the last character that fits into this width. */
-                      let buffer_length = Buffer.length(buffer);
-                      let last_char = Buffer.nth(buffer, buffer_length - 1);
-                      /* If we've only put one character of the string before hyphenating, we
-                         should just swap with a space, so that we don't have a lonely hyphen
-                         on the previous line */
-                      let hyphen =
-                        if (i == 1) {
-                          " ";
-                        } else {
-                          "-";
-                        };
-                      /* Flush the buffer with the hyphen and reset the buffer to just the last
-                         character that was in the buffer (where the hyphen now is) */
-                      Queue.add(
-                        Buffer.sub(buffer, 0, buffer_length - 1) ++ hyphen,
-                        output_lines,
-                      );
-                      Buffer.reset(buffer);
-                      Buffer.add_char(buffer, last_char);
-                      width := width_of_char(last_char);
-                      /* Otherwise, this is the start of the token */
-                    } else {
-                      if (debug) {
-                        print_endline("--Clear");
-                      };
-                      /* So just flush & reset the buffer */
-                      Queue.add(Buffer.contents(buffer), output_lines);
-                      Buffer.reset(buffer);
-                      width := 0.0;
-                    };
-                  };
-                  /* Then push the next character from this token onto the buffer */
-                  width := width^ +. char_width;
-                  Buffer.add_char(buffer, token.[i]);
-                };
-              };
+                   /* If it won't overflow this line OR if there's no way to fit it into a line without overflowing */
+                   if (width^
+                       +. char_width <= max_width
+                       || width^ == 0.0
+                       && char_width >= max_width) {
+                     if (debug) {
+                       print_endline("--Decision: append (" ++ __LOC__ ++ ")");
+                     };
+                     /* Append it to the buffer */
+                     Buffer.add_utf_8_uchar(buffer, uchar);
+                     width := width^ +. char_width;
+                     /* If it will overflow... */
+                   } else {
+                     if (debug) {
+                       print_endline("--Decision: break");
+                     };
+                     /* Finalize the current line and reset the buffer (if we need to) */
+                     if (width^ > 0.0) {
+                       /* If we're part-way through the string already */
+                       if (i > 0) {
+                         if (debug) {
+                           print_endline("--Clear+hyphenate");
+                         };
+                         /* We need to swap the last char of the buffer with a -, because the
+                            hyphen will be the last character that fits into this width. */
+                         let buffer_str = Buffer.contents(buffer);
+                         let last_uchar = last_uchar_of_string(buffer_str);
+                         /* If we've only put one character of the string before hyphenating, we
+                            should just swap with a space, so that we don't have a lonely hyphen
+                            on the previous line */
+                         let hyphen =
+                           if (i == 1) {
+                             " ";
+                           } else {
+                             "-";
+                           };
+                         /* Flush the buffer with the hyphen and reset the buffer to just the last
+                            character that was in the buffer (where the hyphen now is) */
+                         Queue.add(
+                           Zed_utf8.rchop(buffer_str) ++ hyphen,
+                           output_lines,
+                         );
+                         Buffer.reset(buffer);
+                         Buffer.add_utf_8_uchar(buffer, last_uchar);
+                         width := width_of_token(Zed_utf8.singleton(uchar));
+                         /* Otherwise, this is the start of the token */
+                       } else {
+                         if (debug) {
+                           print_endline("--Clear");
+                         };
+                         /* So just flush & reset the buffer */
+                         Queue.add(Buffer.contents(buffer), output_lines);
+                         Buffer.reset(buffer);
+                         width := 0.0;
+                       };
+                     };
+                     /* Then push the next character from this token onto the buffer */
+                     width := width^ +. char_width;
+                     Buffer.add_utf_8_uchar(buffer, uchar);
+                   };
+                 });
               /* If it would exceed the limit and the user doesn't want hyphenation: */
             } else {
               if (debug) {
@@ -193,7 +188,7 @@ let wrap_queue =
 let wrap =
     (
       ~max_width,
-      ~width_of_char,
+      ~width_of_token,
       ~hyphenate=false,
       ~ignore_preceding_whitespace=true,
       ~debug=false,
@@ -202,7 +197,7 @@ let wrap =
   list_of_queue(
     wrap_queue(
       ~max_width,
-      ~width_of_char,
+      ~width_of_token,
       ~hyphenate,
       ~ignore_preceding_whitespace,
       ~debug,

--- a/src/zed/zed_utf8.ml
+++ b/src/zed/zed_utf8.ml
@@ -486,7 +486,6 @@ let rev_concat sep l =
         Bytes.unsafe_to_string res
 
 let rec explode_rec str ofs acc =
-  let () = print_endline (string_of_int ofs) in
   if ofs = 0 then
     acc
   else

--- a/src/zed/zed_utf8.ml
+++ b/src/zed/zed_utf8.ml
@@ -226,7 +226,7 @@ let unsafe_extract_prev str ofs =
                           let ch4 = String.unsafe_get str (ofs - 4) in
                           match ch4 with
                             | '\xf0' .. '\xf7' ->
-                                (Uchar.of_int (((Char.code ch4 land 0x07) lsl 18) lor ((Char.code ch3 land 0x3f) lsl 12) lor ((Char.code ch2 land 0x3f) lsl 6) lor (Char.code ch1 land 0x3f)), ofs + 4)
+                                (Uchar.of_int (((Char.code ch4 land 0x07) lsl 18) lor ((Char.code ch3 land 0x3f) lsl 12) lor ((Char.code ch2 land 0x3f) lsl 6) lor (Char.code ch1 land 0x3f)), ofs - 4)
                             | _ ->
                                 fail str (ofs - 4) "invalid start of UTF-8 sequence"
                         else
@@ -486,6 +486,7 @@ let rev_concat sep l =
         Bytes.unsafe_to_string res
 
 let rec explode_rec str ofs acc =
+  let () = print_endline (string_of_int ofs) in
   if ofs = 0 then
     acc
   else


### PR DESCRIPTION
Now that we have @OhadRau's revery-text-wrap in the monorepo, we need to make it UTF-8/Unicode aware so that we dont split on arbitrary byte boundaries. This was a big pain point when I was writing font-fallback, and this PR should fix it 👍 