### PR TITLE
feat(harfbuzz): add start and stop API to shape

### DIFF
--- a/packages/reason-harfbuzz/src/Harfbuzz.re
+++ b/packages/reason-harfbuzz/src/Harfbuzz.re
@@ -64,9 +64,14 @@ let hb_shape = (~features=[], ~start=`Start, ~stop=`End, {face}, str) => {
        )
     |> Array.of_list;
   let startPosition = positionToInt(start);
-  let stopPosition = positionToInt(stop);
+  let length =
+    switch (stop) {
+    | `Position(n) => n - startPosition
+    | `Start => 0
+    | `End => (-1)
+    };
 
-  Internal.hb_shape(face, str, arr, startPosition, stopPosition);
+  Internal.hb_shape(face, str, arr, startPosition, length);
 };
 let hb_new_face = str => hb_face_from_path(str);
 

--- a/packages/reason-harfbuzz/src/Harfbuzz.re
+++ b/packages/reason-harfbuzz/src/Harfbuzz.re
@@ -16,7 +16,8 @@ module Internal = {
   external hb_face_from_data: (string, int) => result(face, string) =
     "rehb_face_from_bytes";
   external hb_destroy_face: face => unit = "rehb_destroy_face";
-  external hb_shape: (face, string, array(feature)) => array(hb_shape) =
+  external hb_shape:
+    (face, string, array(feature), int, int) => array(hb_shape) =
     "rehb_shape";
 };
 
@@ -50,7 +51,7 @@ let hb_face_from_path = str => {
   };
 };
 
-let hb_shape = (~features=[], {face}, str) => {
+let hb_shape = (~features=[], ~start=`Start, ~stop=`End, {face}, str) => {
   let arr =
     features
     |> List.map(
@@ -62,7 +63,10 @@ let hb_shape = (~features=[], {face}, str) => {
          }: feature => Internal.feature,
        )
     |> Array.of_list;
-  Internal.hb_shape(face, str, arr);
+  let startPosition = positionToInt(start);
+  let stopPosition = positionToInt(stop);
+
+  Internal.hb_shape(face, str, arr, startPosition, stopPosition);
 };
 let hb_new_face = str => hb_face_from_path(str);
 

--- a/packages/reason-harfbuzz/src/Harfbuzz.rei
+++ b/packages/reason-harfbuzz/src/Harfbuzz.rei
@@ -20,4 +20,11 @@ let hb_face_from_skia: Skia.Typeface.t => result(hb_face, string);
 let hb_new_face: string => result(hb_face, string);
 
 let hb_shape:
-  (~features: list(feature)=?, hb_face, string) => array(hb_shape);
+  (
+    ~features: list(feature)=?,
+    ~start: position=?,
+    ~stop: position=?,
+    hb_face,
+    string
+  ) =>
+  array(hb_shape);

--- a/packages/reason-harfbuzz/src/harfbuzz.cpp
+++ b/packages/reason-harfbuzz/src/harfbuzz.cpp
@@ -126,10 +126,13 @@ static value createShapeTuple(unsigned int codepoint, unsigned int cluster) {
   CAMLreturn(ret);
 }
 
-CAMLprim value rehb_shape(value vFace, value vString, value vFeatures) {
-  CAMLparam3(vFace, vString, vFeatures);
+CAMLprim value rehb_shape(value vFace, value vString, value vFeatures, value vStart, value vEnd) {
+  CAMLparam5(vFace, vString, vFeatures, vStart, vEnd);
   CAMLlocal2(ret, feat);
 
+  int start = Int_val(vStart);
+  int end = Int_val(vEnd);
+ 
   int featuresLen = Wosize_val(vFeatures);
   hb_feature_t *features = (hb_feature_t *)malloc(featuresLen * sizeof(hb_feature_t));
   for (int i = 0; i < featuresLen; i++) {
@@ -143,9 +146,10 @@ CAMLprim value rehb_shape(value vFace, value vString, value vFeatures) {
 
   hb_font_t *hb_font = (hb_font_t *)vFace;
 
+
   hb_buffer_t *hb_buffer;
   hb_buffer = hb_buffer_create();
-  hb_buffer_add_utf8(hb_buffer, String_val(vString), -1, 0, -1);
+  hb_buffer_add_utf8(hb_buffer, String_val(vString), -1, start, end);
   hb_buffer_guess_segment_properties(hb_buffer);
 
   hb_shape(hb_font, hb_buffer, features, featuresLen);

--- a/packages/reason-harfbuzz/src/harfbuzz.cpp
+++ b/packages/reason-harfbuzz/src/harfbuzz.cpp
@@ -126,12 +126,12 @@ static value createShapeTuple(unsigned int codepoint, unsigned int cluster) {
   CAMLreturn(ret);
 }
 
-CAMLprim value rehb_shape(value vFace, value vString, value vFeatures, value vStart, value vEnd) {
-  CAMLparam5(vFace, vString, vFeatures, vStart, vEnd);
+CAMLprim value rehb_shape(value vFace, value vString, value vFeatures, value vStart, value vLen) {
+  CAMLparam5(vFace, vString, vFeatures, vStart, vLen);
   CAMLlocal2(ret, feat);
 
   int start = Int_val(vStart);
-  int end = Int_val(vEnd);
+  int len = Int_val(vLen);
  
   int featuresLen = Wosize_val(vFeatures);
   hb_feature_t *features = (hb_feature_t *)malloc(featuresLen * sizeof(hb_feature_t));
@@ -149,7 +149,7 @@ CAMLprim value rehb_shape(value vFace, value vString, value vFeatures, value vSt
 
   hb_buffer_t *hb_buffer;
   hb_buffer = hb_buffer_create();
-  hb_buffer_add_utf8(hb_buffer, String_val(vString), -1, start, end);
+  hb_buffer_add_utf8(hb_buffer, String_val(vString), -1, start, len);
   hb_buffer_guess_segment_properties(hb_buffer);
 
   hb_shape(hb_font, hb_buffer, features, featuresLen);

--- a/packages/reason-harfbuzz/test/FeaturesTest.re
+++ b/packages/reason-harfbuzz/test/FeaturesTest.re
@@ -1,9 +1,6 @@
 open Harfbuzz;
 open TestFramework;
 
-let font =
-  hb_face_from_path("./examples/Roboto-Regular.ttf") |> Result.get_ok;
-
 describe("Features", ({test, _}) => {
   test("default (ff)", ({expect, _}) => {
     let expectedResult = [|

--- a/packages/reason-harfbuzz/test/FeaturesTest.re
+++ b/packages/reason-harfbuzz/test/FeaturesTest.re
@@ -9,14 +9,14 @@ describe("Features", ({test, _}) => {
     |];
     let shapes = hb_shape(font, "ff");
 
-    expect.equal(shapes, expectedResult);
+    expect.equal(expectedResult, shapes);
   });
 
   test("default (fi)", ({expect, _}) => {
     let expectedResult = [|{glyphId: 444, cluster: 0}|];
     let shapes = hb_shape(font, "fi");
 
-    expect.equal(shapes, expectedResult);
+    expect.equal(expectedResult, shapes);
   });
 
   test("discretionary ligatures enabled (ff)", ({expect, _}) => {

--- a/packages/reason-harfbuzz/test/ShapingTest.re
+++ b/packages/reason-harfbuzz/test/ShapingTest.re
@@ -11,7 +11,7 @@ describe("Shaping", ({test, _}) => {
 
     let shapes = hb_shape(font, "abc");
 
-    expect.equal(shapes, expectedResult);
+    expect.equal(expectedResult, shapes);
   });
 
   test("substring", ({expect, _}) => {

--- a/packages/reason-harfbuzz/test/ShapingTest.re
+++ b/packages/reason-harfbuzz/test/ShapingTest.re
@@ -1,0 +1,24 @@
+open Harfbuzz;
+open TestFramework;
+
+describe("Shaping", ({test, _}) => {
+  test("whole string", ({expect, _}) => {
+    let expectedResult = [|
+      {glyphId: 69, cluster: 0},
+      {glyphId: 70, cluster: 1},
+      {glyphId: 71, cluster: 2},
+    |];
+
+    let shapes = hb_shape(font, "abc");
+
+    expect.equal(shapes, expectedResult);
+  });
+
+  test("substring", ({expect, _}) => {
+    let expectedResult = [|{glyphId: 70, cluster: 1}|];
+    let shapes =
+      hb_shape(font, "abc", ~start=`Position(1), ~stop=`Position(2));
+
+    expect.equal(expectedResult, shapes);
+  });
+});

--- a/packages/reason-harfbuzz/test/ShapingTest.re
+++ b/packages/reason-harfbuzz/test/ShapingTest.re
@@ -21,4 +21,12 @@ describe("Shaping", ({test, _}) => {
 
     expect.equal(expectedResult, shapes);
   });
+
+  test("substring UTF-8", ({expect, _}) => {
+    let expectedResult = [|{glyphId: 1007, cluster: 1}|];
+    let shapes =
+      hb_shape(font, "aҙc", ~start=`Position(1), ~stop=`Position(3));
+
+    expect.equal(expectedResult, shapes);
+  });
 });

--- a/packages/reason-harfbuzz/test/TestFramework.re
+++ b/packages/reason-harfbuzz/test/TestFramework.re
@@ -5,3 +5,6 @@ include Rely.Make({
       projectDir: "",
     });
 });
+
+let font =
+  Harfbuzz.hb_face_from_path("./examples/Roboto-Regular.ttf") |> Result.get_ok;


### PR DESCRIPTION
Rather than creating substrings to shape, we can just pass in the start and stop into Harfbuzz 👍 