### PR TITLE
chore(skia): bring back ASAN for SkiaFontManagerCli

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -19,10 +19,8 @@ steps:
     displayName: '@esy @examples x SkiaCli'
   - script: esy @examples x SkiaCli.bc
     displayName: '@esy @examples x SkiaCli.bc'
-  - script: esy @examples x SkiaFontManagerCli
-    displayName: 'esy @examples x SkiaFontManagerCli'
-  - script: esy @examples x SkiaFontManagerCli.bc
-    displayName: 'esy @examples x SkiaFontManagerCli.bc'
+  - script: esy @examples run-skia-fontmanager
+    displayName: 'esy @examples run-skia-fontmanager'
   - script: esy @examples x ReveryTextWrapCli
     displayName: 'esy @examples x ReveryTextWrapCli'
   - script: esy @examples x ReveryTextWrapCli.bc

--- a/examples.json
+++ b/examples.json
@@ -2,7 +2,8 @@
   "source": "./package.json",
   "scripts": {
       "run": "esy @examples x Examples",
-      "run-harfbuzz": "esy @examples x bash -c run-harfbuzz.sh #{os}"
+      "run-harfbuzz": "esy @examples x bash -c run-harfbuzz.sh #{os}",
+      "run-skia-fontmanager": "esy @examples x bash -c run-skia-fontmanager.sh #{os}"
   },
   "override": {
       "build": ["dune build -p reason-harfbuzz,reason-skia,reason-sdl2,Revery,ReveryExamples -j4"],

--- a/packages/reason-skia/examples/skia-font-manager-cli/dune
+++ b/packages/reason-skia/examples/skia-font-manager-cli/dune
@@ -3,9 +3,9 @@
  (package ReveryExamples)
  (public_names SkiaFontManagerCli)
  (modes native byte)
- (libraries reason-skia reason-skia.wrapped.bindings reason-skia.wrapped Revery.zed))
+ (libraries reason-skia reason-native-crash-utils.asan reason-skia.wrapped.bindings reason-skia.wrapped Revery.zed))
 
 (install
  (section bin)
  (package ReveryExamples)
- (files SkiaFontManagerCli.bc))
+ (files SkiaFontManagerCli.bc run-skia-fontmanager.sh))

--- a/packages/reason-skia/examples/skia-font-manager-cli/run-skia-fontmanager.sh
+++ b/packages/reason-skia/examples/skia-font-manager-cli/run-skia-fontmanager.sh
@@ -1,0 +1,6 @@
+set -e
+
+CWD=$(dirname $0)
+if [[ $1 == 'windows' ]]; then executable="SkiaFontManagerCli.exe"; else executable="SkiaFontManagerCli"; fi
+
+LSAN_OPTIONS=suppressions=lsan.supp $CWD/$executable

--- a/packages/reason-skia/src/Skia.re
+++ b/packages/reason-skia/src/Skia.re
@@ -678,7 +678,12 @@ module Typeface = {
     stream;
   };
 
-  let getFontStyle = SkiaWrapped.Typeface.getFontStyle;
+  let getFontStyle = typeface => {
+    let style = SkiaWrapped.Typeface.getFontStyle(typeface);
+    Gc.finalise(SkiaWrapped.FontStyle.delete, style);
+    style;
+  };
+
   let getUniqueID = SkiaWrapped.Typeface.getUniqueID;
 
   let equal = (tfA, tfB) => {

--- a/packages/reason-skia/src/Skia.re
+++ b/packages/reason-skia/src/Skia.re
@@ -489,7 +489,11 @@ module FontStyle = {
   let getWidth = SkiaWrapped.FontStyle.getWidth;
   let getWeight = SkiaWrapped.FontStyle.getWeight;
 
-  let make = SkiaWrapped.FontStyle.make;
+  let make = (weight, width, slant) => {
+    let style = SkiaWrapped.FontStyle.make(weight, width, slant);
+    Gc.finalise(SkiaWrapped.FontStyle.delete, style);
+    style;
+  };
 };
 
 module FontManager = {

--- a/packages/reason-skia/src/wrapped/bindings/SkiaWrappedBindings.re
+++ b/packages/reason-skia/src/wrapped/bindings/SkiaWrappedBindings.re
@@ -76,6 +76,8 @@ module M = (F: FOREIGN) => {
     let getWeight = foreign("sk_fontstyle_get_weight", t @-> returning(int));
 
     let getWidth = foreign("sk_fontstyle_get_width", t @-> returning(int));
+
+    let delete = foreign("sk_fontstyle_delete", t @-> returning(void));
   };
 
   module TextEncoding = {


### PR DESCRIPTION
Now that we have a way to suppress the fontconfig leaks, this should have leak detection. This will prevent future leaks from Skia in regards to the font manager.