### PR TITLE
fix(text): make overflow UTF-8 aware

### DIFF
--- a/src/Core/TextOverflow.re
+++ b/src/Core/TextOverflow.re
@@ -10,7 +10,7 @@ let removeLineBreaks = text => {
 };
 
 let rec handleOverflow = (~maxWidth, ~text, ~measure, ~character="…", ()) => {
-  let clippedText = String.length(text) - 1 |> Str.string_before(text);
+  let clippedText = Zed_utf8.rchop(text);
 
   let width = measure(clippedText ++ character);
   width >= maxWidth && String.length(clippedText) > 1

--- a/test/Core/TextTests.re
+++ b/test/Core/TextTests.re
@@ -1,0 +1,37 @@
+open Revery_Core;
+open TestFramework;
+
+let font =
+  Revery_Font.Family.fromFile("Roboto-Regular.ttf")
+  |> Revery_Font.Family.toSkia(Revery_Font.Weight.Normal)
+  |> Revery_Font.load
+  |> (
+    result =>
+      switch (result) {
+      | Ok(font) => font
+      | Error(e) => failwith(e)
+      }
+  );
+
+describe("TextOverflow", ({test, _}) => {
+  test("handle overflow UTF-8", ({expect, _}) => {
+    let measure = str =>
+      Revery_Font.measure(
+        ~smoothing=Revery_Font.Smoothing.default,
+        font,
+        12.0,
+        str,
+      ).
+        width;
+
+    let abcSize = measure("ABC");
+    let overflown =
+      TextOverflow.handleOverflow(
+        ~maxWidth=abcSize,
+        ~text="ABC😀",
+        ~measure,
+        (),
+      );
+    expect.equal("A…", overflown);
+  })
+});

--- a/test/Core/TextTests.re
+++ b/test/Core/TextTests.re
@@ -5,13 +5,7 @@ let font =
   Revery_Font.Family.fromFile("Roboto-Regular.ttf")
   |> Revery_Font.Family.toSkia(Revery_Font.Weight.Normal)
   |> Revery_Font.load
-  |> (
-    result =>
-      switch (result) {
-      | Ok(font) => font
-      | Error(e) => failwith(e)
-      }
-  );
+  |> Result.get_ok;
 
 describe("TextOverflow", ({test, _}) => {
   test("handle overflow UTF-8", ({expect, _}) => {

--- a/test/Core/dune
+++ b/test/Core/dune
@@ -2,4 +2,4 @@
     (name Revery_Core_Test)
     (library_flags (-linkall -g))
     (modules (:standard))
-    (libraries Revery_Core rely.lib))
+    (libraries Revery_Core Revery_Font rely.lib))


### PR DESCRIPTION
This is a pretty simple fix, since Zed already gives us a function to do exactly what we were doing before but with UTF-8. 

I will also add some tests for this, just to make sure it's robust!