### PR TITLE
fix(harfbuzz): uncouple from Skia

### DIFF
--- a/packages/reason-harfbuzz/examples/harfbuzz-cli/HarfbuzzCli.re
+++ b/packages/reason-harfbuzz/examples/harfbuzz-cli/HarfbuzzCli.re
@@ -1,5 +1,4 @@
 open Harfbuzz;
-open Skia;
 
 Printexc.record_backtrace(true);
 
@@ -14,9 +13,6 @@ let getExecutingDirectory = () =>
   isNative ? Filename.dirname(Sys.argv[0]) ++ Filename.dir_sep : "";
 
 let run = () => {
-  let fontManager = FontManager.makeDefault();
-  let style = FontStyle.make(400, 5, Upright);
-
   let show = ({glyphId, cluster}: hb_shape) =>
     Printf.sprintf("GlyphID: %d Cluster: %d", glyphId, cluster);
 
@@ -36,27 +32,6 @@ let run = () => {
     ++ runtimeVersion
     ++ " **\n",
   );
-  let skiaFaceToHarfbuzzFace = skiaFace => {
-    let stream = Skia.Typeface.toStream(skiaFace);
-    let length = Skia.Stream.getLength(stream);
-    let data = Skia.Data.makeFromStream(stream, length);
-    let bytes = Skia.Data.makeString(data);
-
-    Harfbuzz.hb_face_from_data(bytes);
-  };
-
-  print_endline("__ Font Discovery: Arial __");
-  let maybeTypeface =
-    FontManager.matchFamilyStyle(fontManager, "Arial", style);
-  let result = maybeTypeface |> Option.map(skiaFaceToHarfbuzzFace);
-  switch (result) {
-  | Some(Error(msg)) => failwith(msg)
-  | Some(Ok(font)) =>
-    renderString(font, "abc");
-    renderString(font, "!=ajga");
-    renderString(font, "a==>b");
-  | None => failwith("Font Arial not found!")
-  };
 
   print_endline("__ Font Path: Roboto Regular __");
   let result = hb_face_from_path("examples/Roboto-Regular.ttf");
@@ -66,6 +41,8 @@ let run = () => {
   switch (result) {
   | Error(msg) => failwith(msg)
   | Ok(font) =>
+    renderString(font, "abc");
+    renderString(font, "Harfbuzz");
     renderString(font, "ff");
     renderString(~features, font, "ff");
   };

--- a/packages/reason-harfbuzz/examples/harfbuzz-cli/HarfbuzzCli.re
+++ b/packages/reason-harfbuzz/examples/harfbuzz-cli/HarfbuzzCli.re
@@ -36,11 +36,19 @@ let run = () => {
     ++ runtimeVersion
     ++ " **\n",
   );
+  let skiaFaceToHarfbuzzFace = skiaFace => {
+    let stream = Skia.Typeface.toStream(skiaFace);
+    let length = Skia.Stream.getLength(stream);
+    let data = Skia.Data.makeFromStream(stream, length);
+    let bytes = Skia.Data.makeString(data);
+
+    Harfbuzz.hb_face_from_data(bytes);
+  };
 
   print_endline("__ Font Discovery: Arial __");
   let maybeTypeface =
     FontManager.matchFamilyStyle(fontManager, "Arial", style);
-  let result = maybeTypeface |> Option.map(face => hb_face_from_skia(face));
+  let result = maybeTypeface |> Option.map(skiaFaceToHarfbuzzFace);
   switch (result) {
   | Some(Error(msg)) => failwith(msg)
   | Some(Ok(font)) =>

--- a/packages/reason-harfbuzz/examples/harfbuzz-cli/dune
+++ b/packages/reason-harfbuzz/examples/harfbuzz-cli/dune
@@ -2,7 +2,7 @@
  (name HarfbuzzCli)
  (package ReveryExamples)
  (public_name HarfbuzzCli)
- (libraries bigarray harfbuzz skia reason-native-crash-utils.asan))
+ (libraries bigarray harfbuzz reason-native-crash-utils.asan))
 
 (install
  (section bin)

--- a/packages/reason-harfbuzz/examples/harfbuzz-cli/dune
+++ b/packages/reason-harfbuzz/examples/harfbuzz-cli/dune
@@ -2,7 +2,7 @@
  (name HarfbuzzCli)
  (package ReveryExamples)
  (public_name HarfbuzzCli)
- (libraries bigarray harfbuzz reason-native-crash-utils.asan))
+ (libraries bigarray harfbuzz skia reason-native-crash-utils.asan))
 
 (install
  (section bin)

--- a/packages/reason-harfbuzz/src/Harfbuzz.re
+++ b/packages/reason-harfbuzz/src/Harfbuzz.re
@@ -81,12 +81,7 @@ let hb_shape = (~features=[], ~start=`Start, ~stop=`End, {face}, str) => {
 };
 let hb_new_face = str => hb_face_from_path(str);
 
-let hb_face_from_skia = sk_typeface => {
-  let stream = Skia.Typeface.toStream(sk_typeface);
-  let length = Skia.Stream.getLength(stream);
-  let data = Skia.Data.makeFromStream(stream, length);
-  let bytes = Skia.Data.makeString(data);
-
+let hb_face_from_data = bytes => {
   switch (Internal.hb_face_from_data(bytes, String.length(bytes))) {
   | Error(_) as e => e
   | Ok(face) =>

--- a/packages/reason-harfbuzz/src/Harfbuzz.rei
+++ b/packages/reason-harfbuzz/src/Harfbuzz.rei
@@ -14,7 +14,7 @@ type feature = {
 };
 
 let hb_face_from_path: string => result(hb_face, string);
-let hb_face_from_skia: Skia.Typeface.t => result(hb_face, string);
+let hb_face_from_data: string => result(hb_face, string);
 
 [@ocaml.deprecated "Deprecated in favor of hb_face_from_path"]
 let hb_new_face: string => result(hb_face, string);

--- a/packages/reason-harfbuzz/src/dune
+++ b/packages/reason-harfbuzz/src/dune
@@ -1,7 +1,6 @@
 (library
  (name harfbuzz)
  (public_name reason-harfbuzz)
- (libraries skia ctypes)
  (library_flags
   (:include flags.sexp))
  (c_flags (:include c_flags.sexp))

--- a/src/Font/FontCache.re
+++ b/src/Font/FontCache.re
@@ -97,6 +97,15 @@ module Constants = {
   let emptyUchar = Uchar.of_int(0);
 };
 
+let skiaFaceToHarfbuzzFace = skiaFace => {
+  let stream = Skia.Typeface.toStream(skiaFace);
+  let length = Skia.Stream.getLength(stream);
+  let data = Skia.Data.makeFromStream(stream, length);
+  let bytes = Skia.Data.makeString(data);
+
+  Harfbuzz.hb_face_from_data(bytes);
+};
+
 let load: option(Skia.Typeface.t) => result(t, string) =
   (skiaTypeface: option(Skia.Typeface.t)) => {
     switch (FontCache.find(skiaTypeface, Internal.cache)) {
@@ -104,8 +113,7 @@ let load: option(Skia.Typeface.t) => result(t, string) =
       FontCache.promote(skiaTypeface, Internal.cache);
       v;
     | None =>
-      let harfbuzzFace =
-        skiaTypeface |> Option.map(tf => Harfbuzz.hb_face_from_skia(tf));
+      let harfbuzzFace = skiaTypeface |> Option.map(skiaFaceToHarfbuzzFace);
       let metricsCache = MetricsCache.create(~initialSize=8, 64);
       let shapeCache = ShapeResultCache.create(~initialSize=1024, 128 * 1024);
       let fallbackCache = FallbackCache.create(~initialSize=1024, 128 * 1024);


### PR DESCRIPTION
@glennsl mentioned in #927 that these two libraries should be separate, and I totally agree. This uncouples them completely, except for the examples/CI to get font discovery working. @glennsl, let me know if you want me to remove that as well.