### PR TITLE
feat(window): expose a few more window-options

### DIFF
--- a/packages/reason-sdl2/src/sdl2.re
+++ b/packages/reason-sdl2/src/sdl2.re
@@ -226,6 +226,7 @@ module Window = {
   // MacOS-Only
   external setMacTitlebarTransparent: t => unit =
     "resdl_SDL_SetMacTitlebarTransparent";
+  external setMacTitlebarHidden: t => unit = "resdl_SDL_SetMacTitlebarHidden";
   external setMacBackgroundColor: (t, float, float, float, float) => unit =
     "resdl_SDL_SetMacBackgroundColor";
 };

--- a/packages/reason-sdl2/src/sdl2_wrapper.cpp
+++ b/packages/reason-sdl2/src/sdl2_wrapper.cpp
@@ -319,6 +319,22 @@ extern "C" {
         CAMLreturn(Val_int(ret));
     }
 
+    CAMLprim value resdl_SDL_SetMacTitlebarHidden(value vWin) {
+        CAMLparam1(vWin);
+
+#ifdef SDL_VIDEO_DRIVER_COCOA
+        SDL_Window *win = (SDL_Window *)vWin;
+        SDL_SysWMinfo wmInfo;
+        SDL_VERSION(&wmInfo.version);
+        SDL_GetWindowWMInfo(win, &wmInfo);
+        NSWindow *nWindow = wmInfo.info.cocoa.window;
+        [nWindow 
+         setStyleMask:[nWindow styleMask] | NSWindowStyleMaskDocModalWindow];
+#endif
+
+        CAMLreturn(Val_unit);
+    }
+
     CAMLprim value resdl_SDL_SetMacTitlebarTransparent(value vWin) {
         CAMLparam1(vWin);
 

--- a/packages/reason-sdl2/src/sdl2_wrapper.cpp
+++ b/packages/reason-sdl2/src/sdl2_wrapper.cpp
@@ -328,7 +328,7 @@ extern "C" {
         SDL_VERSION(&wmInfo.version);
         SDL_GetWindowWMInfo(win, &wmInfo);
         NSWindow *nWindow = wmInfo.info.cocoa.window;
-        [nWindow 
+        [nWindow
          setStyleMask:[nWindow styleMask] | NSWindowStyleMaskDocModalWindow];
 #endif
 

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -352,6 +352,12 @@ let setSize = (~width: int, ~height: int, win: t) => {
   Internal.setRawSize(win, adjWidth, adjHeight);
 };
 
+let setMinimumSize = (~width: int, ~height: int, win: t) => {
+  Log.tracef(m => m("setMinimumSize - calling with: %ux%u", width, height));
+
+  Sdl2.Window.setMinimumSize(win.sdlWindow, width, height);
+};
+
 let setZoom = (window, zoom) => {
   window.metrics = WindowMetrics.setZoom(max(zoom, 0.1), window.metrics);
 };
@@ -650,6 +656,14 @@ let create = (name: string, options: WindowCreateOptions.t) => {
   // until after we create the window, so after creation we have to check
   // to make sure we're at the correct size for scaling.
   setSize(~width, ~height, window);
+
+  // Set a minimum size for the window
+  setMinimumSize(
+    ~width=options.minimumWidth,
+    ~height=options.minimumHeight,
+    window,
+  );
+
   setVsync(window, options.vsync);
 
   if (!options.decorated) {
@@ -674,11 +688,6 @@ let create = (name: string, options: WindowCreateOptions.t) => {
   if (options.maximized) {
     Sdl2.Window.maximize(sdlWindow);
   };
-
-  // onivim/oni2#791
-  // Set a minimum size for the window
-  // TODO: Make configurable
-  Sdl2.Window.setMinimumSize(sdlWindow, 200, 100);
 
   Sdl2.Window.setTransparency(sdlWindow, options.transparency);
 
@@ -711,7 +720,9 @@ let setInputRect = (_w: t, x, y, width, height) => {
 
 let setTransparency = (w: t, transparency) => w.transparency = transparency;
 
-let setBackgroundColor = (w: t, color: Color.t) => w.backgroundColor = color;
+let setBackgroundColor = (w: t, color: Color.t) => {
+  w.backgroundColor = color;
+};
 
 let getBackgroundColor = window => window.backgroundColor;
 

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -243,6 +243,7 @@ module Internal = {
       }
     | Android
     | Browser
+    // NOTE: might work for IOS?
     | IOS
     | Linux
     | Unknown

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -241,8 +241,12 @@ module Internal = {
       | Hidden => Sdl2.Window.setMacTitlebarHidden(w)
       | System => ()
       }
-    | Windows
-    | Linux => ()
+    | Android
+    | Browser
+    | IOS
+    | Linux
+    | Unknown
+    | Windows => ()
     };
   };
 

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -241,7 +241,8 @@ module Internal = {
       | Hidden => Sdl2.Window.setMacTitlebarHidden(w)
       | System => ()
       }
-    | Windows | Linux => ()
+    | Windows
+    | Linux => ()
     };
   };
 

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -233,16 +233,24 @@ type t = {
 };
 
 module Internal = {
-  let setTitlebarTransparent = (w: Sdl2.Window.t) =>
+  let setTitlebarStyle = (w: Sdl2.Window.t, style: WindowStyles.titlebar) => {
     switch (Environment.os) {
-    | Mac => Sdl2.Window.setMacTitlebarTransparent(w)
+    | Mac =>
+      switch (style) {
+      | Transparent => Sdl2.Window.setMacTitlebarTransparent(w)
+      | Hidden => Sdl2.Window.setMacTitlebarHidden(w)
+      | _ => ()
+      }
     | _ => ()
     };
+  };
 
   let resetTitlebarStyle = window =>
     // On restore, we need to set the titlebar transparent again on Mac
-    if (window.titlebarStyle == Transparent) {
-      setTitlebarTransparent(window.sdlWindow);
+    switch (window.titlebarStyle) {
+    | Transparent => setTitlebarStyle(window.sdlWindow, Transparent)
+    | Hidden => setTitlebarStyle(window.sdlWindow, Hidden)
+    | _ => ()
     };
 
   let updateMetrics = (w: t) => {
@@ -680,7 +688,8 @@ let create = (name: string, options: WindowCreateOptions.t) => {
 
   switch (options.titlebarStyle) {
   | System => ()
-  | Transparent => Internal.setTitlebarTransparent(sdlWindow)
+  | Transparent => Internal.setTitlebarStyle(sdlWindow, Transparent)
+  | Hidden => Internal.setTitlebarStyle(sdlWindow, Hidden)
   };
 
   Revery_Native.initWindow(sdlWindow);

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -201,7 +201,7 @@ type t = {
   // True if composition (IME) is active
   mutable isComposingText: bool,
   mutable dropState: option(list(string)),
-  mutable transparency: float,
+  mutable opacity: float,
   titlebarStyle: WindowStyles.titlebar,
   isDecorated: bool,
   onBeforeRender: Event.t(unit),
@@ -623,7 +623,7 @@ let create = (name: string, options: WindowCreateOptions.t) => {
     forceScaleFactor: options.forceScaleFactor,
 
     isDecorated: options.decorated,
-    transparency: options.transparency,
+    opacity: options.opacity,
 
     onBeforeRender: Event.create(),
     onAfterRender: Event.create(),
@@ -698,7 +698,9 @@ let create = (name: string, options: WindowCreateOptions.t) => {
     Sdl2.Window.maximize(sdlWindow);
   };
 
-  Sdl2.Window.setTransparency(sdlWindow, options.transparency);
+  // Sdl2 has this named as Transparency, but it actually works as opacity
+  // where a value of 1.0 means it's fully opaque
+  Sdl2.Window.setTransparency(sdlWindow, options.opacity);
 
   Internal.updateMetrics(window);
 
@@ -727,7 +729,7 @@ let setInputRect = (_w: t, x, y, width, height) => {
   );
 };
 
-let setTransparency = (w: t, transparency) => w.transparency = transparency;
+let setOpacity = (w: t, opacity) => w.opacity = opacity;
 
 let setBackgroundColor = (w: t, color: Color.t) => {
   w.backgroundColor = color;

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -243,7 +243,7 @@ module Internal = {
       }
     | Android
     | Browser
-    // NOTE: might work for IOS?
+    // NOTE: may work for IOS?
     | IOS
     | Linux
     | Unknown

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -201,6 +201,7 @@ type t = {
   // True if composition (IME) is active
   mutable isComposingText: bool,
   mutable dropState: option(list(string)),
+  mutable transparency: float,
   titlebarStyle: WindowStyles.titlebar,
   isDecorated: bool,
   onBeforeRender: Event.t(unit),
@@ -608,6 +609,7 @@ let create = (name: string, options: WindowCreateOptions.t) => {
     forceScaleFactor: options.forceScaleFactor,
 
     isDecorated: options.decorated,
+    transparency: options.transparency,
 
     onBeforeRender: Event.create(),
     onAfterRender: Event.create(),
@@ -678,6 +680,8 @@ let create = (name: string, options: WindowCreateOptions.t) => {
   // TODO: Make configurable
   Sdl2.Window.setMinimumSize(sdlWindow, 200, 100);
 
+  Sdl2.Window.setTransparency(sdlWindow, options.transparency);
+
   Internal.updateMetrics(window);
 
   window;
@@ -704,6 +708,8 @@ let setInputRect = (_w: t, x, y, width, height) => {
     height,
   );
 };
+
+let setTransparency = (w: t, transparency) => w.transparency = transparency;
 
 let setBackgroundColor = (w: t, color: Color.t) => w.backgroundColor = color;
 

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -241,7 +241,7 @@ module Internal = {
       | Hidden => Sdl2.Window.setMacTitlebarHidden(w)
       | _ => ()
       }
-    | _ => ()
+    | Windows | Linux => ()
     };
   };
 

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -239,7 +239,7 @@ module Internal = {
       switch (style) {
       | Transparent => Sdl2.Window.setMacTitlebarTransparent(w)
       | Hidden => Sdl2.Window.setMacTitlebarHidden(w)
-      | _ => ()
+      | System => ()
       }
     | Windows | Linux => ()
     };

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -250,7 +250,7 @@ module Internal = {
     switch (window.titlebarStyle) {
     | Transparent => setTitlebarStyle(window.sdlWindow, Transparent)
     | Hidden => setTitlebarStyle(window.sdlWindow, Hidden)
-    | _ => ()
+    | System => ()
     };
 
   let updateMetrics = (w: t) => {

--- a/src/Core/Window.rei
+++ b/src/Core/Window.rei
@@ -87,7 +87,7 @@ let raise: t => unit;
 let restore: t => unit;
 let minimize: t => unit;
 
-let setTransparency: (t, float) => unit;
+let setOpacity: (t, float) => unit;
 let setBackgroundColor: (t, Color.t) => unit;
 let setPosition: (t, int, int) => unit;
 let setTitle: (t, string) => unit;

--- a/src/Core/Window.rei
+++ b/src/Core/Window.rei
@@ -56,6 +56,11 @@ let getFramebufferSize: t => size;
 */
 let setSize: (~width: int, ~height: int, t) => unit;
 
+/**
+  [setMinimumSize(~width, ~height, window)] sets the minimum window size.
+*/
+let setMinimumSize: (~width: int, ~height: int, t) => unit;
+
 let getPosition: t => (int, int);
 let getScaleAndZoom: t => float;
 let getSdlWindow: t => Sdl2.Window.t;

--- a/src/Core/Window.rei
+++ b/src/Core/Window.rei
@@ -82,6 +82,7 @@ let raise: t => unit;
 let restore: t => unit;
 let minimize: t => unit;
 
+let setTransparency: (t, float) => unit;
 let setBackgroundColor: (t, Color.t) => unit;
 let setPosition: (t, int, int) => unit;
 let setTitle: (t, string) => unit;

--- a/src/Core/WindowCreateOptions.re
+++ b/src/Core/WindowCreateOptions.re
@@ -53,7 +53,7 @@ type t = {
     */
   minimumWidth: int,
   /**
-    [minimumWidth] is the minimal vertical size of the [Window].
+    [minimumWidth] is the minimum vertical size of the [Window].
     */
   minimumHeight: int,
   /**

--- a/src/Core/WindowCreateOptions.re
+++ b/src/Core/WindowCreateOptions.re
@@ -25,6 +25,10 @@ type t = {
     */
   titlebarStyle: WindowStyles.titlebar,
   /**
+   [transparency] sets the transparency of the window.
+   */
+  transparency: float,
+  /**
     [x] is the initial horizontal position of the [Window], either [`Centered]
     or [`Absolute(x)], where [x] is the horizontal pixel coordinate of the left
     edge of the [Window]
@@ -72,6 +76,7 @@ let create =
       ~maximized=false,
       ~decorated=true,
       ~titlebarStyle=WindowStyles.System,
+      ~transparency=1.0,
       ~x=`Centered,
       ~y=`Centered,
       ~width=800,
@@ -87,6 +92,7 @@ let create =
   maximized,
   decorated,
   titlebarStyle,
+  transparency,
   x,
   y,
   width,

--- a/src/Core/WindowCreateOptions.re
+++ b/src/Core/WindowCreateOptions.re
@@ -25,9 +25,11 @@ type t = {
     */
   titlebarStyle: WindowStyles.titlebar,
   /**
-   [transparency] sets the transparency of the window.
+   [opacity] sets the opacity of the window.
+   A value of 1.0 means the window is fully opaque,
+   and a value of 0.0 means the window is completely transparent.
    */
-  transparency: float,
+  opacity: float,
   /**
     [x] is the initial horizontal position of the [Window], either [`Centered]
     or [`Absolute(x)], where [x] is the horizontal pixel coordinate of the left
@@ -84,7 +86,7 @@ let create =
       ~maximized=false,
       ~decorated=true,
       ~titlebarStyle=WindowStyles.System,
-      ~transparency=1.0,
+      ~opacity=1.0,
       ~x=`Centered,
       ~y=`Centered,
       ~width=800,
@@ -102,7 +104,7 @@ let create =
   maximized,
   decorated,
   titlebarStyle,
-  transparency,
+  opacity,
   x,
   y,
   width,

--- a/src/Core/WindowCreateOptions.re
+++ b/src/Core/WindowCreateOptions.re
@@ -49,7 +49,7 @@ type t = {
   */
   height: int,
   /**
-    [minimumWidth] is the minimal horizontal size of the [Window].
+    [minimumWidth] is the minimum horizontal size of the [Window].
     */
   minimumWidth: int,
   /**

--- a/src/Core/WindowCreateOptions.re
+++ b/src/Core/WindowCreateOptions.re
@@ -21,7 +21,7 @@ type t = {
   decorated: bool,
   /**
    [titlebarStyle] sets the appearance of the titlebar. Eventually this will be platform
-   independent, but as of right now, Transparent only works on macOS.
+   independent, but as of right now, [Transparent] and [Hidden] only works on macOS.
     */
   titlebarStyle: WindowStyles.titlebar,
   /**

--- a/src/Core/WindowCreateOptions.re
+++ b/src/Core/WindowCreateOptions.re
@@ -49,6 +49,14 @@ type t = {
   */
   height: int,
   /**
+    [minimumWidth] is the minimal horizontal size of the [Window].
+    */
+  minimumWidth: int,
+  /**
+    [minimumWidth] is the minimal vertical size of the [Window].
+    */
+  minimumHeight: int,
+  /**
     [backgroundColor] specifies the initial Color of the [Window]
   */
   backgroundColor: Color.t,
@@ -81,6 +89,8 @@ let create =
       ~y=`Centered,
       ~width=800,
       ~height=600,
+      ~minimumWidth=200,
+      ~minimumHeight=100,
       ~backgroundColor=Colors.cornflowerBlue,
       ~vsync=Vsync.Synchronized,
       ~icon=None,
@@ -97,6 +107,8 @@ let create =
   y,
   width,
   height,
+  minimumWidth,
+  minimumHeight,
   backgroundColor,
   forceScaleFactor,
   vsync,

--- a/src/Core/WindowStyles.re
+++ b/src/Core/WindowStyles.re
@@ -1,4 +1,5 @@
 type titlebar =
   | System
   // Only works on macOS as of right now
+  | Hidden
   | Transparent;


### PR DESCRIPTION
This adds a `transparency`-option to Window.

EDIT: I guess though, that this puts a transparency on everything, not only the "background-window" as you'd expect. 🤔 

Would close #506