### PR TITLE
feat(components): expose text-wrap for RichTextView

### DIFF
--- a/src/UI_Components/RichTextView.re
+++ b/src/UI_Components/RichTextView.re
@@ -3,13 +3,19 @@ open Revery_UI_Primitives;
 open Revery_Font;
 
 let make =
-    (~style=[], ~smoothing=Smoothing.default, ~richtext: RichText.t, ()) => {
+    (
+      ~style=[],
+      ~smoothing=Smoothing.default,
+      ~richtext: RichText.t,
+      ~textWrap as textWrapping: Revery_Core.TextWrapping.wrapType=Wrap,
+      (),
+    ) => {
   let text =
     RichText.foldRight(
       (acc, {italic, fontFamily, fontSize, fontWeight, text, color}) =>
         [
           <Text
-            style=[Style.color(color)]
+            style=[Style.color(color), Style.textWrap(textWrapping)]
             fontFamily
             fontWeight
             italic


### PR DESCRIPTION
While creating the `FloatingNavigationBar`-example I stumbled upon the fact that I could not control the text-wrapping of a `RichTextView`. I believe this makes sense to expose, but I guess that it could perhaps be exposed on the `text`-function instead?

![Screen Recording 2020-07-26 at 09 11 47](https://user-images.githubusercontent.com/17602389/88473695-63e3d480-cf20-11ea-83be-8f6cdc2e2a43.gif)

