### PR TITLE
fix(font): Fix hang in font-fallback code

### DIFF
--- a/src/Font/FontCache.re
+++ b/src/Font/FontCache.re
@@ -207,11 +207,17 @@ let generateShapes:
       Log.debugf(m =>
         m("Resolving fallback for: %s at byte offset %d", str, byteOffset)
       );
-      let uchar =
-        try(Zed_utf8.extract(str, byteOffset)) {
-        | _ => Constants.emptyUchar
+      let maybeUchar =
+        try(Some(Zed_utf8.extract(str, byteOffset))) {
+        | exn =>
+          Log.debugf(m =>
+            m("Unable to get uchar: %s", Printexc.to_string(exn))
+          );
+          None;
         };
-      matchCharacter(font.fallbackCharacterCache, uchar, font.skiaFace)
+      Option.bind(maybeUchar, uchar =>
+        matchCharacter(font.fallbackCharacterCache, uchar, font.skiaFace)
+      )
       |> load;
     };
 

--- a/src/Font/FontCache.re
+++ b/src/Font/FontCache.re
@@ -94,7 +94,6 @@ module Internal = {
 
 module Constants = {
   let unresolvedGlyphID = 0;
-  let emptyUchar = Uchar.of_int(0);
 };
 
 let skiaFaceToHarfbuzzFace = skiaFace => {

--- a/test/Font/FontCacheTest.re
+++ b/test/Font/FontCacheTest.re
@@ -24,6 +24,12 @@ describe("FontCache", ({test, _}) => {
     |> Skia.Typeface.getUniqueID
     |> Int32.to_int;
 
+  test("empty string has empty shapes", ({expect, _}) => {
+    let {glyphStrings}: ShapeResult.t = "" |> FontCache.shape(defaultFont);
+
+    expect.int(glyphStrings |> runCount).toBe(0);
+  });
+
   test("shape simple ASCII text", ({expect, _}) => {
     let {glyphStrings}: ShapeResult.t = "a" |> FontCache.shape(defaultFont);
 

--- a/test/Font/FontCacheTest.re
+++ b/test/Font/FontCacheTest.re
@@ -1,86 +1,93 @@
 open Revery_Font;
 open TestFramework;
-open Skia;
 
-open FontCache;
-
-
-let runCount = (glyphStrings) => List.length(glyphStrings);
+let runCount = glyphStrings => List.length(glyphStrings);
 
 let glyphCount = ((_typeface, glyphs)) =>
-        // Each glyph is 2 bytes
-        String.length(glyphs) / 2;
+  // Each glyph is 2 bytes
+  String.length(glyphs) / 2;
 
 let run = (index, runs) => List.nth(runs, index);
 
 let typefaceId = ((typeface, _glyphs)) =>
-typeface |> Skia.Typeface.getUniqueID
-|> Int32.to_int;
+  typeface |> Skia.Typeface.getUniqueID |> Int32.to_int;
 
 describe("FontCache", ({test, _}) => {
-    let defaultFont = Family.default
+  let defaultFont =
+    Family.default
     |> Family.resolve(~italic=false, Weight.Normal)
     |> Result.get_ok;
 
-    let defaultFontId = defaultFont
+  let defaultFontId =
+    defaultFont
     |> FontCache.getSkiaTypeface
     |> Skia.Typeface.getUniqueID
     |> Int32.to_int;
-    test("shape simple ASCII text", ({expect, _}) => {
-        
-        let { glyphStrings }: ShapeResult.t = "a"
-        |> FontCache.shape(defaultFont);
 
-        expect.int(glyphStrings |> runCount).toBe(1);
-        expect.int(glyphStrings |> run(0) |> glyphCount).toBe(1);
-    });
-    
-    test("shape simple ASCII string", ({expect, _}) => {
-        let { glyphStrings }: ShapeResult.t = "abc"
-        |> FontCache.shape(defaultFont);
+  test("shape simple ASCII text", ({expect, _}) => {
+    let {glyphStrings}: ShapeResult.t = "a" |> FontCache.shape(defaultFont);
 
-        expect.int(glyphStrings |> runCount).toBe(1);
-        expect.int(glyphStrings |> run(0) |> glyphCount).toBe(3);
-    });
+    expect.int(glyphStrings |> runCount).toBe(1);
+    expect.int(glyphStrings |> run(0) |> glyphCount).toBe(1);
+  });
 
-    test("shape string w/ fallback", ({expect, _}) => {
-        let { glyphStrings }: ShapeResult.t = "a⌋"
-        |> FontCache.shape(defaultFont);
+  test("shape simple ASCII string", ({expect, _}) => {
+    let {glyphStrings}: ShapeResult.t =
+      "abc" |> FontCache.shape(defaultFont);
 
-        expect.int(glyphStrings |> runCount).toBe(2);
-        expect.int(glyphStrings |> run(0) |> glyphCount).toBe(1);
-        expect.int(glyphStrings |> run(0) |> typefaceId).toBe(defaultFontId);
-        
-        expect.int(glyphStrings |> run(1) |> glyphCount).toBe(1);
-        expect.int(glyphStrings |> run(1) |> typefaceId).not.toBe(defaultFontId);
-    });
-    
-    test("fallback first, then shape", ({expect, _}) => {
-        let { glyphStrings }: ShapeResult.t = "⌋a"
-        |> FontCache.shape(defaultFont);
+    expect.int(glyphStrings |> runCount).toBe(1);
+    expect.int(glyphStrings |> run(0) |> glyphCount).toBe(3);
+  });
 
-        expect.int(glyphStrings |> runCount).toBe(2);
-        expect.int(glyphStrings |> run(0) |> glyphCount).toBe(1);
-        expect.int(glyphStrings |> run(0) |> typefaceId).not.toBe(defaultFontId);
+  test("shape string w/ fallback", ({expect, _}) => {
+    let {glyphStrings}: ShapeResult.t =
+      "a⌋" |> FontCache.shape(defaultFont);
 
-        expect.int(glyphStrings |> run(1) |> glyphCount).toBe(1);
-        expect.int(glyphStrings |> run(1) |> typefaceId).toBe(defaultFontId);
-    });
-    
-    test("non-fallback surrounded by holes", ({expect, _}) => {
-        let fallbackChar = "⌋";
-        let nonfallbackChar = "a";
-        let { glyphStrings }: ShapeResult.t = fallbackChar ++ nonfallbackChar ++ fallbackChar
-        |> FontCache.shape(defaultFont);
+    expect.int(glyphStrings |> runCount).toBe(2);
+    expect.int(glyphStrings |> run(0) |> glyphCount).toBe(1);
+    expect.int(glyphStrings |> run(0) |> typefaceId).toBe(defaultFontId);
 
-        expect.int(glyphStrings |> runCount).toBe(3);
-        expect.int(glyphStrings |> run(0) |> glyphCount).toBe(1);
-        expect.int(glyphStrings |> run(0) |> typefaceId).not.toBe(defaultFontId);
+    expect.int(glyphStrings |> run(1) |> glyphCount).toBe(1);
+    expect.int(glyphStrings |> run(1) |> typefaceId).not.toBe(
+      defaultFontId,
+    );
+  });
 
-        expect.int(glyphStrings |> run(1) |> glyphCount).toBe(1);
-        expect.int(glyphStrings |> run(1) |> typefaceId).toBe(defaultFontId);
+  test("fallback first, then shape", ({expect, _}) => {
+    let {glyphStrings}: ShapeResult.t =
+      "⌋a" |> FontCache.shape(defaultFont);
 
-        expect.int(glyphStrings |> run(2) |> glyphCount).toBe(1);
-        expect.int(glyphStrings |> run(2) |> typefaceId).not.toBe(defaultFontId);
-    });
-})
+    expect.int(glyphStrings |> runCount).toBe(2);
+    expect.int(glyphStrings |> run(0) |> glyphCount).toBe(1);
+    expect.int(glyphStrings |> run(0) |> typefaceId).not.toBe(
+      defaultFontId,
+    );
+
+    expect.int(glyphStrings |> run(1) |> glyphCount).toBe(1);
+    expect.int(glyphStrings |> run(1) |> typefaceId).toBe(defaultFontId);
+  });
+
+  test("non-fallback surrounded by holes (onivim/oni2#2178)", ({expect, _}) => {
+    let fallbackChar = "⌋";
+    let nonfallbackChar = "a";
+    let {glyphStrings}: ShapeResult.t =
+      fallbackChar
+      ++ nonfallbackChar
+      ++ fallbackChar
+      |> FontCache.shape(defaultFont);
+
+    expect.int(glyphStrings |> runCount).toBe(3);
+    expect.int(glyphStrings |> run(0) |> glyphCount).toBe(1);
+    expect.int(glyphStrings |> run(0) |> typefaceId).not.toBe(
+      defaultFontId,
+    );
+
+    expect.int(glyphStrings |> run(1) |> glyphCount).toBe(1);
+    expect.int(glyphStrings |> run(1) |> typefaceId).toBe(defaultFontId);
+
+    expect.int(glyphStrings |> run(2) |> glyphCount).toBe(1);
+    expect.int(glyphStrings |> run(2) |> typefaceId).not.toBe(
+      defaultFontId,
+    );
+  });
+});

--- a/test/Font/FontCacheTest.re
+++ b/test/Font/FontCacheTest.re
@@ -1,0 +1,86 @@
+open Revery_Font;
+open TestFramework;
+open Skia;
+
+open FontCache;
+
+
+let runCount = (glyphStrings) => List.length(glyphStrings);
+
+let glyphCount = ((_typeface, glyphs)) =>
+        // Each glyph is 2 bytes
+        String.length(glyphs) / 2;
+
+let run = (index, runs) => List.nth(runs, index);
+
+let typefaceId = ((typeface, _glyphs)) =>
+typeface |> Skia.Typeface.getUniqueID
+|> Int32.to_int;
+
+describe("FontCache", ({test, _}) => {
+    let defaultFont = Family.default
+    |> Family.resolve(~italic=false, Weight.Normal)
+    |> Result.get_ok;
+
+    let defaultFontId = defaultFont
+    |> FontCache.getSkiaTypeface
+    |> Skia.Typeface.getUniqueID
+    |> Int32.to_int;
+    test("shape simple ASCII text", ({expect, _}) => {
+        
+        let { glyphStrings }: ShapeResult.t = "a"
+        |> FontCache.shape(defaultFont);
+
+        expect.int(glyphStrings |> runCount).toBe(1);
+        expect.int(glyphStrings |> run(0) |> glyphCount).toBe(1);
+    });
+    
+    test("shape simple ASCII string", ({expect, _}) => {
+        let { glyphStrings }: ShapeResult.t = "abc"
+        |> FontCache.shape(defaultFont);
+
+        expect.int(glyphStrings |> runCount).toBe(1);
+        expect.int(glyphStrings |> run(0) |> glyphCount).toBe(3);
+    });
+
+    test("shape string w/ fallback", ({expect, _}) => {
+        let { glyphStrings }: ShapeResult.t = "a⌋"
+        |> FontCache.shape(defaultFont);
+
+        expect.int(glyphStrings |> runCount).toBe(2);
+        expect.int(glyphStrings |> run(0) |> glyphCount).toBe(1);
+        expect.int(glyphStrings |> run(0) |> typefaceId).toBe(defaultFontId);
+        
+        expect.int(glyphStrings |> run(1) |> glyphCount).toBe(1);
+        expect.int(glyphStrings |> run(1) |> typefaceId).not.toBe(defaultFontId);
+    });
+    
+    test("fallback first, then shape", ({expect, _}) => {
+        let { glyphStrings }: ShapeResult.t = "⌋a"
+        |> FontCache.shape(defaultFont);
+
+        expect.int(glyphStrings |> runCount).toBe(2);
+        expect.int(glyphStrings |> run(0) |> glyphCount).toBe(1);
+        expect.int(glyphStrings |> run(0) |> typefaceId).not.toBe(defaultFontId);
+
+        expect.int(glyphStrings |> run(1) |> glyphCount).toBe(1);
+        expect.int(glyphStrings |> run(1) |> typefaceId).toBe(defaultFontId);
+    });
+    
+    test("non-fallback surrounded by holes", ({expect, _}) => {
+        let fallbackChar = "⌋";
+        let nonfallbackChar = "a";
+        let { glyphStrings }: ShapeResult.t = fallbackChar ++ nonfallbackChar ++ fallbackChar
+        |> FontCache.shape(defaultFont);
+
+        expect.int(glyphStrings |> runCount).toBe(3);
+        expect.int(glyphStrings |> run(0) |> glyphCount).toBe(1);
+        expect.int(glyphStrings |> run(0) |> typefaceId).not.toBe(defaultFontId);
+
+        expect.int(glyphStrings |> run(1) |> glyphCount).toBe(1);
+        expect.int(glyphStrings |> run(1) |> typefaceId).toBe(defaultFontId);
+
+        expect.int(glyphStrings |> run(2) |> glyphCount).toBe(1);
+        expect.int(glyphStrings |> run(2) |> typefaceId).not.toBe(defaultFontId);
+    });
+})


### PR DESCRIPTION
__Issue:__ Certain unicode constructions could cause the font-fallback algorithm to hang, as described in https://github.com/onivim/oni2/issues/2178

__Defect:__ We'd run into an infinite loop in the `fallbackFor` code, because we were assuming a `character index` when we actually needed a `byte offset`. This is another case where it'd be great to have the type system help us differentiate between these!

__Fix:__ The value passed into `fallbackFor` is a byte index, not a character index - so use `Zed_utf8.extract`, which operates on byte offsets, instead of `get`, which operates on character indices. Add several test cases.