### PR TITLE
feat(native): system menus (macOS)

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -368,6 +368,11 @@ let init = app => {
       Console.log(Printf.sprintf("Moved: %d x %d", x, y))
     );
 
+  let menuBar = Revery.Native.Menu.getMenuBar(Window.getSdlWindow(window));
+  let menuItem = Revery.Native.Menu.Item.create(~title="Zach's Item");
+
+  menuItem |> Revery.Native.Menu.addItem(menuBar);
+
   let _renderFunction =
     UI.start(window, <ExampleHost window initialExample />);
   ();

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -185,6 +185,11 @@ let examples = [
     render: _ => ImageQualityExample.render(),
     source: "ImageQualityExample.re",
   },
+  {
+    name: "Menus",
+    render: w => MenuExample.render(w),
+    source: "MenuExample.re",
+  },
 ];
 
 let getExampleByName = name =>
@@ -367,22 +372,6 @@ let init = app => {
     Window.onMoved(window, ((x, y)) =>
       Console.log(Printf.sprintf("Moved: %d x %d", x, y))
     );
-
-  let menuBar = Revery.Native.Menu.getMenuBar(Window.getSdlWindow(window));
-  let menuItem = Revery.Native.Menu.Item.create(~title="Zach's Item");
-  let myMenu = Revery.Native.Menu.create(~title="Zach's Menu");
-
-  let testItem1 = Revery.Native.Menu.Item.create(~title="Test item 1");
-  let testItem1Callback = () => {
-    print_endline("Printing from OCaml!");
-  };
-
-  testItem1 |> Revery.Native.Menu.addItem(myMenu);
-  testItem1Callback |> Revery.Native.Menu.Item.setOnClick(testItem1);
-
-  myMenu |> Revery.Native.Menu.Item.setSubmenu(menuItem);
-
-  menuItem |> Revery.Native.Menu.addItem(menuBar);
 
   let _renderFunction =
     UI.start(window, <ExampleHost window initialExample />);

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -370,6 +370,17 @@ let init = app => {
 
   let menuBar = Revery.Native.Menu.getMenuBar(Window.getSdlWindow(window));
   let menuItem = Revery.Native.Menu.Item.create(~title="Zach's Item");
+  let myMenu = Revery.Native.Menu.create(~title="Zach's Menu");
+
+  let testItem1 = Revery.Native.Menu.Item.create(~title="Test item 1");
+  let testItem1Callback = () => {
+    print_endline("Printing from OCaml!");
+  };
+
+  testItem1 |> Revery.Native.Menu.addItem(myMenu);
+  testItem1Callback |> Revery.Native.Menu.Item.setOnClick(testItem1);
+
+  myMenu |> Revery.Native.Menu.Item.setSubmenu(menuItem);
 
   menuItem |> Revery.Native.Menu.addItem(menuBar);
 

--- a/examples/MenuExample.re
+++ b/examples/MenuExample.re
@@ -22,9 +22,7 @@ module Example = {
                   Menu.Item.create(~title="Item #" ++ string_of_int(i));
                 let () =
                   item
-                  |> Menu.Item.setOnClick(item =>
-                       print_endline(Utilities.MacOS.nsObjectToString(item))
-                     );
+                  |> Menu.Item.setOnClick(_ => setLastClicked(_ => Some(i)));
                 item;
               },
             );

--- a/examples/MenuExample.re
+++ b/examples/MenuExample.re
@@ -21,7 +21,10 @@ module Example = {
                 let item =
                   Menu.Item.create(~title="Item #" ++ string_of_int(i));
                 let () =
-                  item |> Menu.Item.setOnClick(() => Window.minimize(window));
+                  item
+                  |> Menu.Item.setOnClick(item =>
+                       print_endline(Utilities.MacOS.nsObjectToString(item))
+                     );
                 item;
               },
             );

--- a/examples/MenuExample.re
+++ b/examples/MenuExample.re
@@ -1,0 +1,58 @@
+open Revery;
+open Revery.UI;
+open Revery.UI.Components;
+
+open Revery.Native;
+
+module Example = {
+  let menu = Menu.create(~title="Zach's Menu");
+
+  let%component make = (~window, ()) => {
+    let%hook (lastClicked, setLastClicked) = Hooks.state(None);
+
+    let%hook () =
+      Hooks.effect(
+        OnMount,
+        () => {
+          let menuItems =
+            Array.init(
+              10,
+              i => {
+                let item =
+                  Menu.Item.create(~title="Item #" ++ string_of_int(i));
+                let () =
+                  item |> Menu.Item.setOnClick(() => Window.minimize(window));
+                item;
+              },
+            );
+          let () =
+            menuItems |> Array.iter(item => {Menu.addItem(menu, item)});
+          None;
+        },
+      );
+
+    Gc.full_major();
+
+    <View>
+      <Center>
+        <Button
+          title="Display menu!"
+          onClick={() =>
+            Menu.displayAt(
+              ~window=Window.getSdlWindow(window),
+              ~x=200,
+              ~y=200,
+              menu,
+            )
+          }
+        />
+        {switch (lastClicked) {
+         | Some(i) => <Text text={"Clicked on Item #" ++ string_of_int(i)} />
+         | None => React.empty
+         }}
+      </Center>
+    </View>;
+  };
+};
+
+let render = window => <Example window />;

--- a/src/Native/Menu.re
+++ b/src/Native/Menu.re
@@ -1,6 +1,6 @@
 type t;
 type menuItem;
-type clickHandler = unit => unit;
+type clickHandler = menuItem => unit;
 
 open {
        external c_getMenuBarHandle: Sdl2.Window.nativeWindow => t =
@@ -23,6 +23,9 @@ open {
        external c_displayMenuAtPositionInWindow:
          (t, Sdl2.Window.nativeWindow, int, int) => unit =
          "revery_displayMenuAtPositionInWindow";
+
+       external c_removeItemFromMenu: (t, menuItem) => unit =
+         "revery_removeItemFromMenu";
      };
 
 let create = (~title: string) => c_createMenu(title);
@@ -31,6 +34,7 @@ let getMenuBar = sdlWindow =>
   c_getMenuBarHandle(sdlWindow |> Sdl2.Window.getNativeWindow);
 
 let addItem = c_insertItemIntoMenu;
+let removeItem = c_removeItemFromMenu;
 
 let displayAt = (~window as sdlWindow, ~x, ~y, menu) =>
   c_displayMenuAtPositionInWindow(

--- a/src/Native/Menu.re
+++ b/src/Native/Menu.re
@@ -16,7 +16,7 @@ open {
        external c_setSubmenuForItem: (menuItem, t) => unit =
          "revery_setSubmenuForItem";
 
-       external c_setOnClickForMenuItem: (menuItem, clickHandler) => unit =
+       external c_setOnClickForMenuItem: (clickHandler, menuItem) => unit =
          "revery_setOnClickForMenuItem";
 
        // Arguments: (menu, window, x, y)
@@ -49,7 +49,5 @@ module Item = {
 
   let create = (~title: string) => c_createMenuItem(title);
   let setSubmenu = c_setSubmenuForItem;
-  let setOnClick = (clickHandler, menuItem) => {
-    c_setOnClickForMenuItem(menuItem, clickHandler);
-  };
+  let setOnClick = c_setOnClickForMenuItem;
 };

--- a/src/Native/Menu.re
+++ b/src/Native/Menu.re
@@ -1,0 +1,8 @@
+type t;
+
+external getMenuBarHandle: Sdl2.Window.nativeWindow => t =
+  "revery_getMenuBarHandle";
+
+module Item = {
+  type t;
+};

--- a/src/Native/Menu.re
+++ b/src/Native/Menu.re
@@ -1,8 +1,23 @@
 type t;
+type menuItem;
 
-external getMenuBarHandle: Sdl2.Window.nativeWindow => t =
-  "revery_getMenuBarHandle";
+open {
+       external getMenuBarHandle': Sdl2.Window.nativeWindow => t =
+         "revery_getMenuBarHandle";
+
+       external createMenuItem': string => menuItem = "revery_createMenuItem";
+
+       external insertItemIntoMenu': (t, menuItem) => unit =
+         "revery_insertItemIntoMenu";
+     };
+
+let getMenuBar = sdlWindow =>
+  getMenuBarHandle'(sdlWindow |> Sdl2.Window.getNativeWindow);
+
+let addItem = insertItemIntoMenu';
 
 module Item = {
-  type t;
+  type t = menuItem;
+
+  let create = (~title: string) => createMenuItem'(title);
 };

--- a/src/Native/Menu.re
+++ b/src/Native/Menu.re
@@ -3,34 +3,49 @@ type menuItem;
 type clickHandler = unit => unit;
 
 open {
-       external getMenuBarHandle': Sdl2.Window.nativeWindow => t =
+       external c_getMenuBarHandle: Sdl2.Window.nativeWindow => t =
          "revery_getMenuBarHandle";
 
-       external createMenuItem': string => menuItem = "revery_createMenuItem";
+       external c_createMenuItem: string => menuItem = "revery_createMenuItem";
 
-       external insertItemIntoMenu': (t, menuItem) => unit =
+       external c_insertItemIntoMenu: (t, menuItem) => unit =
          "revery_insertItemIntoMenu";
 
-       external createMenu': string => t = "revery_createMenu";
+       external c_createMenu: string => t = "revery_createMenu";
 
-       external setSubmenuForItem': (menuItem, t) => unit =
+       external c_setSubmenuForItem: (menuItem, t) => unit =
          "revery_setSubmenuForItem";
 
-       external setOnClickForMenuItem': (menuItem, clickHandler) => unit =
+       external c_setOnClickForMenuItem: (menuItem, clickHandler) => unit =
          "revery_setOnClickForMenuItem";
+
+       // Arguments: (menu, window, x, y)
+       external c_displayMenuAtPositionInWindow:
+         (t, Sdl2.Window.nativeWindow, int, int) => unit =
+         "revery_displayMenuAtPositionInWindow";
      };
 
-let create = (~title: string) => createMenu'(title);
+let create = (~title: string) => c_createMenu(title);
 
 let getMenuBar = sdlWindow =>
-  getMenuBarHandle'(sdlWindow |> Sdl2.Window.getNativeWindow);
+  c_getMenuBarHandle(sdlWindow |> Sdl2.Window.getNativeWindow);
 
-let addItem = insertItemIntoMenu';
+let addItem = c_insertItemIntoMenu;
+
+let displayAt = (~window as sdlWindow, ~x, ~y, menu) =>
+  c_displayMenuAtPositionInWindow(
+    menu,
+    sdlWindow |> Sdl2.Window.getNativeWindow,
+    x,
+    y,
+  );
 
 module Item = {
   type t = menuItem;
 
-  let create = (~title: string) => createMenuItem'(title);
-  let setSubmenu = setSubmenuForItem';
-  let setOnClick = setOnClickForMenuItem';
+  let create = (~title: string) => c_createMenuItem(title);
+  let setSubmenu = c_setSubmenuForItem;
+  let setOnClick = (clickHandler, menuItem) => {
+    c_setOnClickForMenuItem(menuItem, clickHandler);
+  };
 };

--- a/src/Native/Menu.re
+++ b/src/Native/Menu.re
@@ -1,5 +1,6 @@
 type t;
 type menuItem;
+type clickHandler = unit => unit;
 
 open {
        external getMenuBarHandle': Sdl2.Window.nativeWindow => t =
@@ -9,7 +10,17 @@ open {
 
        external insertItemIntoMenu': (t, menuItem) => unit =
          "revery_insertItemIntoMenu";
+
+       external createMenu': string => t = "revery_createMenu";
+
+       external setSubmenuForItem': (menuItem, t) => unit =
+         "revery_setSubmenuForItem";
+
+       external setOnClickForMenuItem': (menuItem, clickHandler) => unit =
+         "revery_setOnClickForMenuItem";
      };
+
+let create = (~title: string) => createMenu'(title);
 
 let getMenuBar = sdlWindow =>
   getMenuBarHandle'(sdlWindow |> Sdl2.Window.getNativeWindow);
@@ -20,4 +31,6 @@ module Item = {
   type t = menuItem;
 
   let create = (~title: string) => createMenuItem'(title);
+  let setSubmenu = setSubmenuForItem';
+  let setOnClick = setOnClickForMenuItem';
 };

--- a/src/Native/ReveryCocoa.h
+++ b/src/Native/ReveryCocoa.h
@@ -29,3 +29,4 @@ char *revery_getUserLocale_cocoa();
 
 /* Menu functions */
 void *revery_getMenuBarHandle_cocoa();
+void *revery_createMenuItem_cocoa();

--- a/src/Native/ReveryCocoa.h
+++ b/src/Native/ReveryCocoa.h
@@ -30,3 +30,4 @@ char *revery_getUserLocale_cocoa();
 /* Menu functions */
 void *revery_getMenuBarHandle_cocoa();
 void *revery_createMenuItem_cocoa();
+void *revery_insertItemIntoMenu_cocoa(void *menu, void *menuItem);

--- a/src/Native/ReveryCocoa.h
+++ b/src/Native/ReveryCocoa.h
@@ -25,3 +25,7 @@ int revery_openFile_cocoa(const char *path_string);
 
 /* Locale functions */
 char *revery_getUserLocale_cocoa();
+
+
+/* Menu functions */
+void *revery_getMenuBarHandle_cocoa();

--- a/src/Native/ReveryCocoa.h
+++ b/src/Native/ReveryCocoa.h
@@ -34,3 +34,4 @@ void revery_insertItemIntoMenu_cocoa(void *menu, void *menuItem);
 void *revery_createMenu_cocoa(const char *title);
 void revery_setSubmenuForItem_cocoa(void *menuItem, void *menu);
 void revery_setOnClickForMenuItem_cocoa(void *menuItem, long camlCallback);
+void revery_displayMenuAtPositionInWindow_cocoa(void *menu, void *window, int x, int y);

--- a/src/Native/ReveryCocoa.h
+++ b/src/Native/ReveryCocoa.h
@@ -35,3 +35,4 @@ void *revery_createMenu_cocoa(const char *title);
 void revery_setSubmenuForItem_cocoa(void *menuItem, void *menu);
 void revery_setOnClickForMenuItem_cocoa(void *menuItem, long camlCallback);
 void revery_displayMenuAtPositionInWindow_cocoa(void *menu, void *window, int x, int y);
+void revery_removeItemFromMenu_cocoa(void *menu, void *menuItem);

--- a/src/Native/ReveryCocoa.h
+++ b/src/Native/ReveryCocoa.h
@@ -33,6 +33,6 @@ void *revery_createMenuItem_cocoa(const char *title);
 void revery_insertItemIntoMenu_cocoa(void *menu, void *menuItem);
 void *revery_createMenu_cocoa(const char *title);
 void revery_setSubmenuForItem_cocoa(void *menuItem, void *menu);
-void revery_setOnClickForMenuItem_cocoa(void *menuItem, long camlCallback);
+void revery_setOnClickForMenuItem_cocoa(long camlCallback, void *menuItem);
 void revery_displayMenuAtPositionInWindow_cocoa(void *menu, void *window, int x, int y);
 void revery_removeItemFromMenu_cocoa(void *menu, void *menuItem);

--- a/src/Native/ReveryCocoa.h
+++ b/src/Native/ReveryCocoa.h
@@ -29,5 +29,8 @@ char *revery_getUserLocale_cocoa();
 
 /* Menu functions */
 void *revery_getMenuBarHandle_cocoa();
-void *revery_createMenuItem_cocoa();
-void *revery_insertItemIntoMenu_cocoa(void *menu, void *menuItem);
+void *revery_createMenuItem_cocoa(const char *title);
+void revery_insertItemIntoMenu_cocoa(void *menu, void *menuItem);
+void *revery_createMenu_cocoa(const char *title);
+void revery_setSubmenuForItem_cocoa(void *menuItem, void *menu);
+void revery_setOnClickForMenuItem_cocoa(void *menuItem, long camlCallback);

--- a/src/Native/Revery_Native.c
+++ b/src/Native/Revery_Native.c
@@ -5,6 +5,7 @@
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <string.h>
+#include "utilities.h"
 
 #define UNUSED(x) (void)(x)
 

--- a/src/Native/Revery_Native.re
+++ b/src/Native/Revery_Native.re
@@ -4,5 +4,6 @@ module Icon = Icon;
 module Notification = Notification;
 module Shell = Shell;
 module Locale = Locale;
+module Menu = Menu;
 
 include Initialization;

--- a/src/Native/Revery_Native.re
+++ b/src/Native/Revery_Native.re
@@ -5,5 +5,6 @@ module Notification = Notification;
 module Shell = Shell;
 module Locale = Locale;
 module Menu = Menu;
+module Utilities = Utilities;
 
 include Initialization;

--- a/src/Native/Utilities.re
+++ b/src/Native/Utilities.re
@@ -1,0 +1,3 @@
+module MacOS = {
+  external nsObjectToString: _ => string = "revery_NSObjectToString";
+};

--- a/src/Native/cocoa/ReveryMenuHandler.c
+++ b/src/Native/cocoa/ReveryMenuHandler.c
@@ -24,17 +24,30 @@
     if (nsValue != NULL) {
         long *callback = [nsValue pointerValue];
         if (callback != NULL) {
-            revery_caml_call_no_lock(*callback);
+            long args[] = {(long)sender};
+            revery_caml_call_no_lock_n(*callback, 1, args);
         }
     }
 }
 
--(void)registerOnClick:(NSMenuItem *)menuItem callback:(long)camlCallback {
+- (void)registerOnClick:(NSMenuItem *)menuItem callback:(long)camlCallback {
     long *globalCallback = malloc(sizeof(long));
     *globalCallback = camlCallback;
     revery_caml_register_global(globalCallback);
     NSValue *nsValue = [NSValue valueWithPointer:globalCallback];
     self.menuActions[[menuItem identifier]] = nsValue;
+}
+
+- (void)unregisterOnClick:(NSMenuItem *)menuItem {
+    NSValue *nsValue = self.menuActions[[menuItem identifier]];
+    if (nsValue != NULL) {
+        long *callback = [nsValue pointerValue];
+        if (callback != NULL) {
+            revery_caml_unregister_global(callback);
+            free(callback);
+        }
+    }
+    self.menuActions[[menuItem identifier]] = NULL;
 }
 
 @end

--- a/src/Native/cocoa/ReveryMenuHandler.c
+++ b/src/Native/cocoa/ReveryMenuHandler.c
@@ -1,0 +1,34 @@
+#include "config.h"
+#ifdef USE_COCOA
+#import "ReveryMenuHandler.h"
+#import <Cocoa/Cocoa.h>
+
+#import "utilities.h"
+
+#define UNUSED(x) (void)(x)
+
+@implementation ReveryMenuHandler
+- (id)init {
+    self = [super init];
+    if (self) {
+        _menuActions = [NSMutableDictionary new];
+    }
+
+    return self;
+}
+
+- (void)menuClickHandler:(id)sender {
+    NSNumber *nsNumber = self.menuActions[[sender identifier]];
+    long ocamlFunc = [nsNumber longValue];
+    revery_caml_call(ocamlFunc);
+}
+
+-(void)registerOnClick:(NSMenuItem *)menuItem callback:(long)camlCallback {
+    NSLog(@"%s", __func__);
+    self.menuActions[[menuItem identifier]] =
+        [NSNumber numberWithLong:camlCallback];
+}
+
+@end
+
+#endif

--- a/src/Native/cocoa/ReveryMenuHandler.c
+++ b/src/Native/cocoa/ReveryMenuHandler.c
@@ -38,18 +38,6 @@
     self.menuActions[[menuItem identifier]] = nsValue;
 }
 
-- (void)unregisterOnClick:(NSMenuItem *)menuItem {
-    NSValue *nsValue = self.menuActions[[menuItem identifier]];
-    if (nsValue != NULL) {
-        long *callback = [nsValue pointerValue];
-        if (callback != NULL) {
-            revery_caml_unregister_global(callback);
-            free(callback);
-        }
-    }
-    self.menuActions[[menuItem identifier]] = NULL;
-}
-
 @end
 
 #endif

--- a/src/Native/cocoa/ReveryMenuHandler.h
+++ b/src/Native/cocoa/ReveryMenuHandler.h
@@ -8,6 +8,8 @@
 -(void)menuClickHandler:(id)sender;
 
 -(void)registerOnClick:(NSMenuItem *)menuItem callback:(long)camlCallback;
+
+-(void)unregisterOnClick:(NSMenuItem *)menuItem;
 @end
 
 #endif

--- a/src/Native/cocoa/ReveryMenuHandler.h
+++ b/src/Native/cocoa/ReveryMenuHandler.h
@@ -8,8 +8,6 @@
 -(void)menuClickHandler:(id)sender;
 
 -(void)registerOnClick:(NSMenuItem *)menuItem callback:(long)camlCallback;
-
--(void)unregisterOnClick:(NSMenuItem *)menuItem;
 @end
 
 #endif

--- a/src/Native/cocoa/ReveryMenuHandler.h
+++ b/src/Native/cocoa/ReveryMenuHandler.h
@@ -1,0 +1,13 @@
+#include "config.h"
+#ifdef USE_COCOA
+#import <Cocoa/Cocoa.h>
+
+@interface ReveryMenuHandler : NSObject
+@property(nonatomic, strong) NSMutableDictionary *menuActions;
+
+-(void)menuClickHandler:(id)sender;
+
+-(void)registerOnClick:(NSMenuItem *)menuItem callback:(long)camlCallback;
+@end
+
+#endif

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -12,6 +12,7 @@
         icon icon_cocoa icon_win32
         shell shell_cocoa shell_gtk shell_win32
         locale locale_cocoa locale_win32
+        menu menu_cocoa
         utilities
         ReveryAppDelegate ReveryAppDelegate_func
         ReveryProgressBar)

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -15,6 +15,7 @@
         menu menu_cocoa
         utilities
         ReveryAppDelegate ReveryAppDelegate_func
+        ReveryMenuHandler
         ReveryProgressBar)
     (c_flags :standard -Wall -Wextra -Werror (:include c_flags.sexp))
     (c_library_flags (:include c_library_flags.sexp))

--- a/src/Native/menu.c
+++ b/src/Native/menu.c
@@ -25,6 +25,21 @@ CAMLprim value revery_getMenuBarHandle(value vWindow) {
 #ifdef USE_COCOA
     menuBarHandle = revery_getMenuBarHandle_cocoa();
 #else
+    menuBarHandle = NULL;
 #endif
     CAMLreturn((value)menuBarHandle);
+}
+
+CAMLprim value revery_createMenuItem(value vTitle) {
+    CAMLparam1(vTitle);
+
+    const char *title = String_val(vTitle);
+
+    void *menuItem;
+#ifdef USE_COCOA
+    menuItem = revery_createMenuItem_cocoa(title);
+#else
+    menuItem = NULL;
+#endif
+    CAMLreturn((value)menuItem);
 }

--- a/src/Native/menu.c
+++ b/src/Native/menu.c
@@ -115,3 +115,17 @@ CAMLprim value revery_displayMenuAtPositionInWindow(value vMenu, value vWindow, 
 #endif
     CAMLreturn(Val_unit);
 }
+
+CAMLprim value revery_removeItemFromMenu(value vMenu, value vMenuItem) {
+    CAMLparam2(vMenuItem, vMenu);
+
+    void *menu = (void *)vMenu;
+    void *menuItem = (void *)vMenuItem;
+#ifdef USE_COCOA
+    revery_removeItemFromMenu_cocoa(menu, menuItem);
+#else
+    UNUSED(menu);
+    UNUSED(menuItem);
+#endif
+    CAMLreturn(Val_unit);
+}

--- a/src/Native/menu.c
+++ b/src/Native/menu.c
@@ -57,3 +57,43 @@ CAMLprim value revery_insertItemIntoMenu(value vMenu, value vMenuItem) {
 #endif
     CAMLreturn(Val_unit);
 }
+
+CAMLprim value revery_createMenu(value vTitle) {
+    CAMLparam1(vTitle);
+
+    const char *title = String_val(vTitle);
+
+    void *menu;
+#ifdef USE_COCOA
+    menu = revery_createMenu_cocoa(title);
+#else
+    menu = NULL
+#endif
+    CAMLreturn((value)menu);
+}
+
+CAMLprim value revery_setSubmenuForItem(value vMenuItem, value vMenu) {
+    CAMLparam2(vMenuItem, vMenu);
+
+    void *menu = (void *)vMenu;
+    void *menuItem = (void *)vMenuItem;
+#ifdef USE_COCOA
+    revery_setSubmenuForItem_cocoa(menuItem, menu);
+#else
+    UNUSED(menu);
+    UNUSED(menuItem);
+#endif
+    CAMLreturn(Val_unit);
+}
+
+CAMLprim value revery_setOnClickForMenuItem(value vMenuItem, value vCallback) {
+    CAMLparam2(vMenuItem, vCallback);
+
+    void *menuItem = (void *)vMenuItem;
+#ifdef USE_COCOA
+    revery_setOnClickForMenuItem_cocoa(menuItem, vCallback);
+#else
+    UNUSED(menuItem);
+#endif
+    CAMLreturn(Val_unit);
+}

--- a/src/Native/menu.c
+++ b/src/Native/menu.c
@@ -97,3 +97,21 @@ CAMLprim value revery_setOnClickForMenuItem(value vMenuItem, value vCallback) {
 #endif
     CAMLreturn(Val_unit);
 }
+
+CAMLprim value revery_displayMenuAtPositionInWindow(value vMenu, value vWindow, value vX, value vY) {
+    CAMLparam4(vMenu, vWindow, vX, vY);
+
+    void *menu = (void *)vMenu;
+    void *window = (void *)vWindow;
+    int x = Int_val(vX);
+    int y = Int_val(vY);
+#ifdef USE_COCOA
+    revery_displayMenuAtPositionInWindow_cocoa(menu, window, x, y);
+#else
+    UNUSED(menu);
+    UNUSED(window);
+    UNUSED(x);
+    UNUSED(y);
+#endif
+    CAMLreturn(Val_unit);
+}

--- a/src/Native/menu.c
+++ b/src/Native/menu.c
@@ -86,12 +86,12 @@ CAMLprim value revery_setSubmenuForItem(value vMenuItem, value vMenu) {
     CAMLreturn(Val_unit);
 }
 
-CAMLprim value revery_setOnClickForMenuItem(value vMenuItem, value vCallback) {
-    CAMLparam2(vMenuItem, vCallback);
+CAMLprim value revery_setOnClickForMenuItem(value vCallback, value vMenuItem) {
+    CAMLparam2(vCallback, vMenuItem);
 
     void *menuItem = (void *)vMenuItem;
 #ifdef USE_COCOA
-    revery_setOnClickForMenuItem_cocoa(menuItem, vCallback);
+    revery_setOnClickForMenuItem_cocoa(vCallback, menuItem);
 #else
     UNUSED(menuItem);
 #endif

--- a/src/Native/menu.c
+++ b/src/Native/menu.c
@@ -43,3 +43,17 @@ CAMLprim value revery_createMenuItem(value vTitle) {
 #endif
     CAMLreturn((value)menuItem);
 }
+
+CAMLprim value revery_insertItemIntoMenu(value vMenu, value vMenuItem) {
+    CAMLparam2(vMenu, vMenuItem);
+
+    void *menu = (void *)vMenu;
+    void *menuItem = (void *)vMenuItem;
+#ifdef USE_COCOA
+    revery_insertItemIntoMenu_cocoa(menu, menuItem);
+#else
+    UNUSED(menu);
+    UNUSED(menuItem);
+#endif
+    CAMLreturn(Val_unit);
+}

--- a/src/Native/menu.c
+++ b/src/Native/menu.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+
+#include <caml/alloc.h>
+#include <caml/callback.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+
+#include "caml_values.h"
+
+#define UNUSED(x) (void)(x)
+
+#include "config.h"
+#ifdef USE_WIN32
+#include "ReveryWin32.h"
+#elif USE_COCOA
+#include "ReveryCocoa.h"
+#elif USE_GTK
+#include "ReveryGtk.h"
+#endif
+
+CAMLprim value revery_getMenuBarHandle(value vWindow) {
+    CAMLparam1(vWindow);
+
+    void *menuBarHandle;
+#ifdef USE_COCOA
+    menuBarHandle = revery_getMenuBarHandle_cocoa();
+#else
+#endif
+    CAMLreturn((value)menuBarHandle);
+}

--- a/src/Native/menu_cocoa.c
+++ b/src/Native/menu_cocoa.c
@@ -49,10 +49,9 @@ void revery_setSubmenuForItem_cocoa(void *menuItem, void *menu) {
     [nsMenuItem setSubmenu:nsMenu];
 }
 
-void revery_setOnClickForMenuItem_cocoa(void *menuItem, long camlCallback) {
+void revery_setOnClickForMenuItem_cocoa(long camlCallback, void *menuItem) {
     if (revery_menuHandler != NULL) {
         NSMenuItem *nsMenuItem = (NSMenuItem *)menuItem;
-        NSLog(@"%s: %@", __func__, nsMenuItem);
         [revery_menuHandler registerOnClick:nsMenuItem callback:camlCallback];
     }
 }
@@ -70,8 +69,6 @@ void revery_displayMenuAtPositionInWindow_cocoa(void *menu, void *window, int x,
 void revery_removeItemFromMenu_cocoa(void *menu, void *menuItem) {
     NSMenu *nsMenu = (NSMenu *)menu;
     NSMenuItem *nsMenuItem = (NSMenuItem *)menuItem;
-
-    [revery_menuHandler unregisterOnClick:nsMenuItem];
 
     [nsMenu removeItem:nsMenuItem];
 }

--- a/src/Native/menu_cocoa.c
+++ b/src/Native/menu_cocoa.c
@@ -1,17 +1,26 @@
 #include "config.h"
 #ifdef USE_COCOA
 #import <Cocoa/Cocoa.h>
+#import "ReveryMenuHandler.h"
+
+ReveryMenuHandler *revery_menuHandler = NULL;
 
 void *revery_getMenuBarHandle_cocoa() {
-    return (void *)[NSApp windowsMenu];
+    return (void *)[NSApp mainMenu];
 }
 
 void *revery_createMenuItem_cocoa(const char *title) {
+    if (revery_menuHandler == NULL) {
+        revery_menuHandler = [[ReveryMenuHandler alloc] init];
+    }
+
     NSString *nsTitle =
         [NSString stringWithCString:title encoding:NSUTF8StringEncoding];
 
     NSMenuItem *nsMenuItem =
-        [[NSMenuItem alloc] initWithTitle:nsTitle action:NULL keyEquivalent:@""];
+        [[NSMenuItem alloc] initWithTitle:nsTitle action:@selector(menuClickHandler:) keyEquivalent:@""];
+
+    [nsMenuItem setTarget:revery_menuHandler];
 
     return (void *)nsMenuItem;
 }
@@ -23,4 +32,27 @@ void revery_insertItemIntoMenu_cocoa(void *menu, void *menuItem) {
     [nsMenu addItem:nsMenuItem];
 }
 
+void *revery_createMenu_cocoa(const char *title) {
+    NSString *nsTitle =
+        [NSString stringWithCString:title encoding:NSUTF8StringEncoding];
+
+    NSMenu *nsMenu =
+        [[NSMenu alloc] initWithTitle:nsTitle];
+
+    return (void *)nsMenu;
+}
+
+void revery_setSubmenuForItem_cocoa(void *menuItem, void *menu) {
+    NSMenu *nsMenu = (NSMenu *)menu;
+    NSMenuItem *nsMenuItem = (NSMenuItem *)menuItem;
+
+    [nsMenuItem setSubmenu:nsMenu];
+}
+
+void revery_setOnClickForMenuItem_cocoa(void *menuItem, long camlCallback) {
+    if (revery_menuHandler != NULL) {
+        NSMenuItem *nsMenuItem = (NSMenuItem *)menuItem;
+        [revery_menuHandler registerOnClick:nsMenuItem callback:camlCallback];
+    }
+}
 #endif

--- a/src/Native/menu_cocoa.c
+++ b/src/Native/menu_cocoa.c
@@ -52,6 +52,7 @@ void revery_setSubmenuForItem_cocoa(void *menuItem, void *menu) {
 void revery_setOnClickForMenuItem_cocoa(void *menuItem, long camlCallback) {
     if (revery_menuHandler != NULL) {
         NSMenuItem *nsMenuItem = (NSMenuItem *)menuItem;
+        NSLog(@"%s: %@", __func__, nsMenuItem);
         [revery_menuHandler registerOnClick:nsMenuItem callback:camlCallback];
     }
 }
@@ -64,5 +65,14 @@ void revery_displayMenuAtPositionInWindow_cocoa(void *menu, void *window, int x,
     NSView *nsView = [nsWindow contentView];
 
     [nsMenu popUpMenuPositioningItem:NULL atLocation:position inView:nsView];
+}
+
+void revery_removeItemFromMenu_cocoa(void *menu, void *menuItem) {
+    NSMenu *nsMenu = (NSMenu *)menu;
+    NSMenuItem *nsMenuItem = (NSMenuItem *)menuItem;
+
+    [revery_menuHandler unregisterOnClick:nsMenuItem];
+
+    [nsMenu removeItem:nsMenuItem];
 }
 #endif

--- a/src/Native/menu_cocoa.c
+++ b/src/Native/menu_cocoa.c
@@ -3,7 +3,7 @@
 #import <Cocoa/Cocoa.h>
 
 void *revery_getMenuBarHandle_cocoa() {
-    return (void *)[NSApp mainMenu];
+    return (void *)[NSApp windowsMenu];
 }
 
 void *revery_createMenuItem_cocoa(const char *title) {
@@ -14,6 +14,13 @@ void *revery_createMenuItem_cocoa(const char *title) {
         [[NSMenuItem alloc] initWithTitle:nsTitle action:NULL keyEquivalent:@""];
 
     return (void *)nsMenuItem;
+}
+
+void revery_insertItemIntoMenu_cocoa(void *menu, void *menuItem) {
+    NSMenu *nsMenu = (NSMenu *)menu;
+    NSMenuItem *nsMenuItem = (NSMenuItem *)menuItem;
+
+    [nsMenu addItem:nsMenuItem];
 }
 
 #endif

--- a/src/Native/menu_cocoa.c
+++ b/src/Native/menu_cocoa.c
@@ -55,4 +55,14 @@ void revery_setOnClickForMenuItem_cocoa(void *menuItem, long camlCallback) {
         [revery_menuHandler registerOnClick:nsMenuItem callback:camlCallback];
     }
 }
+
+void revery_displayMenuAtPositionInWindow_cocoa(void *menu, void *window, int x, int y) {
+    NSMenu *nsMenu = (NSMenu *)menu;
+    NSWindow *nsWindow = (NSWindow *)window;
+
+    NSPoint position = NSMakePoint((CGFloat)x, (CGFloat)y);
+    NSView *nsView = [nsWindow contentView];
+
+    [nsMenu popUpMenuPositioningItem:NULL atLocation:position inView:nsView];
+}
 #endif

--- a/src/Native/menu_cocoa.c
+++ b/src/Native/menu_cocoa.c
@@ -1,0 +1,9 @@
+#include "config.h"
+#ifdef USE_COCOA
+#import <Cocoa/Cocoa.h>
+
+void *revery_getMenuBarHandle_cocoa() {
+    return (void *)[NSApp mainMenu];
+}
+
+#endif

--- a/src/Native/menu_cocoa.c
+++ b/src/Native/menu_cocoa.c
@@ -6,4 +6,14 @@ void *revery_getMenuBarHandle_cocoa() {
     return (void *)[NSApp mainMenu];
 }
 
+void *revery_createMenuItem_cocoa(const char *title) {
+    NSString *nsTitle =
+        [NSString stringWithCString:title encoding:NSUTF8StringEncoding];
+
+    NSMenuItem *nsMenuItem =
+        [[NSMenuItem alloc] initWithTitle:nsTitle action:NULL keyEquivalent:@""];
+
+    return (void *)nsMenuItem;
+}
+
 #endif

--- a/src/Native/utilities.c
+++ b/src/Native/utilities.c
@@ -5,18 +5,35 @@
 #include <caml/alloc.h>
 
 #include "caml_values.h"
+#include <pthread.h>
 
 /* Sourced from Brisk's `BriskCocoa`
     Thank you @wokalski!
 */
 void revery_caml_call_n(value f, int argCount, value *args) {
     caml_c_thread_register();
-    caml_acquire_runtime_system();
     caml_callbackN(f, argCount, args);
-    caml_release_runtime_system();
 }
 
 void revery_caml_call(value f) {
     value args[] = {Val_unit};
     revery_caml_call_n(f, 1, args);
+}
+
+void revery_caml_call_no_lock_n(value f, int argCount, value *args) {
+    caml_callbackN(f, argCount, args);
+}
+
+void revery_caml_call_no_lock(value f) {
+    printf("%s: f: %ld\n", __func__, f);
+    value args[] = {Val_unit};
+    revery_caml_call_no_lock_n(f, 1, args);
+}
+
+void revery_caml_register_global(value *f) {
+    caml_register_generational_global_root(f);
+}
+
+void revery_caml_unregister_global(value *f) {
+    caml_remove_global_root(f);
 }

--- a/src/Native/utilities.c
+++ b/src/Native/utilities.c
@@ -7,6 +7,12 @@
 #include "caml_values.h"
 #include <pthread.h>
 
+#include "config.h"
+
+#ifdef USE_COCOA
+#import <Cocoa/Cocoa.h>
+#endif
+
 /* Sourced from Brisk's `BriskCocoa`
     Thank you @wokalski!
 */
@@ -36,4 +42,20 @@ void revery_caml_register_global(value *f) {
 
 void revery_caml_unregister_global(value *f) {
     caml_remove_global_root(f);
+}
+
+
+CAMLprim value revery_NSObjectToString(value vObj) {
+    CAMLparam1(vObj);
+    CAMLlocal1(str);
+
+#ifdef USE_COCOA
+    NSObject *obj = (NSObject *)vObj;
+    NSString *nsString = [NSString stringWithFormat:@"%@", obj];
+    str = caml_copy_string([nsString UTF8String]);
+#else
+    str = caml_copy_string(NULL);
+#endif
+
+    CAMLreturn(str);
 }

--- a/src/Native/utilities.h
+++ b/src/Native/utilities.h
@@ -1,2 +1,8 @@
+#pragma once
+
 void revery_caml_call_n(long f, int numArgs, int* args);
 void revery_caml_call(long f);
+void revery_caml_call_no_lock_n(long f, int numArgs, int* args);
+void revery_caml_call_no_lock(long f);
+void revery_caml_register_global(long *f);
+void revery_caml_unregister_global(long *f);

--- a/src/Native/utilities.h
+++ b/src/Native/utilities.h
@@ -1,8 +1,8 @@
 #pragma once
 
-void revery_caml_call_n(long f, int numArgs, int* args);
+void revery_caml_call_n(long f, int numArgs, long *args);
 void revery_caml_call(long f);
-void revery_caml_call_no_lock_n(long f, int numArgs, int* args);
+void revery_caml_call_no_lock_n(long f, int numArgs, long *args);
 void revery_caml_call_no_lock(long f);
 void revery_caml_register_global(long *f);
 void revery_caml_unregister_global(long *f);


### PR DESCRIPTION
⚠️ **Work in progress** ⚠️

This adds a bunch of APIs to `Revery.Native.Menu` for controlling menus. Currently only works on macOS, but hopefully the API I made is generalize-able to Win32/Gtk!