### PR TITLE
Markdown: Add hook for rendering images

### DIFF
--- a/examples/MarkdownExample.re
+++ b/examples/MarkdownExample.re
@@ -41,6 +41,8 @@ let example = () =>
 An h2 header
 ------------
 
+![Test Image](https://raw.githubusercontent.com/revery-ui/revery/master/assets/logo.png)
+
 Here's a numbered list:
 
  1. first item

--- a/src/UI_Components/Markdown.rei
+++ b/src/UI_Components/Markdown.rei
@@ -34,7 +34,8 @@ let make:
     ~h6Style: list(Revery_UI.Style.textStyleProps)=?,
     ~inlineCodeStyle: list(Revery_UI.Style.textStyleProps)=?,
     ~codeBlockStyle: list(Revery_UI.Style.viewStyleProps)=?,
+    ~imageElement: (~url: string) => Revery_UI.element=?,
     ~syntaxHighlighter: SyntaxHighlight.t=?,
     unit
   ) =>
-  Brisk_reconciler.element(Revery_UI.React.node);
+  Revery_UI.element;


### PR DESCRIPTION
This adds some basic handling (at least, a hook) for a consumer of the `<Markdown />` component to provide an image renderer. Needed for markdown rendering in Onivim (extension details tend to have a lot of screenshots!)