### PR TITLE
fix(font-fallback): Fix hang when font is duplicated between system / Revery

### DIFF
--- a/src/Font/FontCache.re
+++ b/src/Font/FontCache.re
@@ -225,7 +225,7 @@ let generateShapes:
        don't include emojis, and Latin fonts often don't include
        CJK characters. This module contains functions that
        relate to the creation and resolution of these "holes" */
-    let rec resolveHole = (~acc, ~start, ~stop) => {
+    let rec resolveHole = (~acc, ~start, ~stop) =>
       if (start >= stop) {
         acc;
       } else {
@@ -279,8 +279,7 @@ let generateShapes:
           // we shape the super-string.
           loop(~start, ~stop, ~acc, fallbackFont);
         };
-      };
-    }
+      }
     and loopShapes =
         (
           ~stopCluster,

--- a/src/Font/FontCache.re
+++ b/src/Font/FontCache.re
@@ -225,15 +225,13 @@ let generateShapes:
        don't include emojis, and Latin fonts often don't include
        CJK characters. This module contains functions that
        relate to the creation and resolution of these "holes" */
-    let rec resolveHole = (~acc, ~start, ~stop) =>
+    let rec resolveHole = (~acc, ~start, ~stop) => {
       if (start >= stop) {
         acc;
       } else {
         switch (fallbackFor(~byteOffset=start, str)) {
         | Ok(fallbackFont)
-            when
-              Skia.Typeface.getUniqueID(fallbackFont.skiaFace)
-              == Skia.Typeface.getUniqueID(font.skiaFace) =>
+            when Skia.Typeface.equal(fallbackFont.skiaFace, font.skiaFace) =>
           resolveHole(
             ~acc=[
               ShapeResult.{
@@ -264,13 +262,25 @@ let generateShapes:
             ~start=start + 1,
             ~stop,
           )
-        | Ok(font) =>
+        | Ok(fallbackFont) =>
+          Log.debugf(m =>
+            m(
+              "Got fallback font - id: %d name: %s (from source font - id: %d %s)",
+              fallbackFont.skiaFace
+              |> Skia.Typeface.getUniqueID
+              |> Int32.to_int,
+              fallbackFont.skiaFace |> Skia.Typeface.getFamilyName,
+              font.skiaFace |> Skia.Typeface.getUniqueID |> Int32.to_int,
+              font.skiaFace |> Skia.Typeface.getFamilyName,
+            )
+          );
+
           // We found a fallback font! Now we just have to shape it the same way
           // we shape the super-string.
-          loop(~start, ~stop, ~acc, font)
+          loop(~start, ~stop, ~acc, fallbackFont);
         };
-      }
-
+      };
+    }
     and loopShapes =
         (
           ~stopCluster,


### PR DESCRIPTION
__Issue:__ Having a font installed system-wide, and locally, could cause a hang in our font-fallback code.

__Defect:__ This is actually the same root cause as https://github.com/revery-ui/revery/pull/974 - however, there is a case exposed that we weren't handling.

This logic: 
```
        | Ok(fallbackFont)
          when
          Skia.Typeface.getUniqueID(fallbackFont.skiaFace)
          == Skia.Typeface.getUniqueID(font.skiaFace) 
```

wasn't quite sufficient. It turns out, in the case where a system font is installed that is the same as local font - we could run into a case where we have _different unique ids_ but _actually the same font_. So in this case - this equality check would be `false`, because the unique ids are different... but actually, we were getting the same font, so we'd hit the same loop as in #974 

__Fix:__ Use `Skia.Typeface.equal` instead - this works as we expected for that condition
