### PR TITLE
feat(diagnostics): Additional display logging

### DIFF
--- a/packages/reason-sdl2/src/sdl2.re
+++ b/packages/reason-sdl2/src/sdl2.re
@@ -45,7 +45,7 @@ module PixelFormat = {
 };
 
 module Display = {
-  type t = int;
+  type t;
 
   module Dpi = {
     type t = {

--- a/packages/reason-sdl2/src/sdl2.re
+++ b/packages/reason-sdl2/src/sdl2.re
@@ -15,6 +15,9 @@ module Rect = {
     width: int,
     height: int,
   };
+
+  let toString = ({x, y, width, height}) =>
+    Printf.sprintf("x: %d y: %d width: %d height: %d", x, y, width, height);
 };
 
 module ScreenSaver = {
@@ -35,8 +38,14 @@ module Clipboard = {
   external hasText: unit => bool = "resdl_SDL_HasClipboardText";
 };
 
-module Display = {
+module PixelFormat = {
   type t;
+
+  external toString: t => string = "resdl_SDL_GetPixelFormatName";
+};
+
+module Display = {
+  type t = int;
 
   module Dpi = {
     type t = {
@@ -52,6 +61,7 @@ module Display = {
 
   module Mode = {
     type t = {
+      pixelFormat: PixelFormat.t,
       width: int,
       height: int,
       refreshRate: int,
@@ -59,7 +69,8 @@ module Display = {
 
     let show = (v: t) => {
       Printf.sprintf(
-        "width: %d height: %d refreshRate: %d",
+        "pixelFormat: %s width: %d height: %d refreshRate: %d",
+        v.pixelFormat |> PixelFormat.toString,
         v.width,
         v.height,
         v.refreshRate,
@@ -74,14 +85,9 @@ module Display = {
   external getDPI: t => Dpi.t = "resdl_SDL_GetDisplayDPI";
   external getCurrentMode: t => Mode.t = "resdl_SDL_GetCurrentDisplayMode";
   external getDesktopMode: t => Mode.t = "resdl_SDL_GetDesktopDisplayMode";
+  external getName: t => string = "resdl_SDL_GetDisplayName";
   external getBounds: t => Rect.t = "resdl_SDL_GetDisplayBounds";
   external getUsableBounds: t => Rect.t = "resdl_SDL_GetDisplayUsableBounds";
-};
-
-module PixelFormat = {
-  type t;
-
-  external toString: t => string = "resdl_SDL_GetPixelFormatName";
 };
 
 module Log = {

--- a/packages/reason-sdl2/src/sdl2_wrapper.cpp
+++ b/packages/reason-sdl2/src/sdl2_wrapper.cpp
@@ -465,10 +465,11 @@ extern "C" {
 
         SDL_GetCurrentDisplayMode(displayIndex, &current);
 
-        ret = caml_alloc(3, 0);
-        Store_field(ret, 0, current.w);
-        Store_field(ret, 1, current.h);
-        Store_field(ret, 2, current.refresh_rate);
+        ret = caml_alloc(4, 0);
+        Store_field(ret, 0, Val_int(current.format));
+        Store_field(ret, 1, current.w);
+        Store_field(ret, 2, current.h);
+        Store_field(ret, 3, current.refresh_rate);
         CAMLreturn(ret);
     };
 
@@ -481,10 +482,11 @@ extern "C" {
 
         SDL_GetDesktopDisplayMode(displayIndex, &current);
 
-        ret = caml_alloc(3, 0);
-        Store_field(ret, 0, current.w);
-        Store_field(ret, 1, current.h);
-        Store_field(ret, 2, current.refresh_rate);
+        ret = caml_alloc(4, 0);
+        Store_field(ret, 0, Val_int(current.format));
+        Store_field(ret, 1, current.w);
+        Store_field(ret, 2, current.h);
+        Store_field(ret, 3, current.refresh_rate);
         CAMLreturn(ret);
     };
 
@@ -503,6 +505,20 @@ extern "C" {
         Store_field(rect, 2, Val_int(sdlRect.w));
         Store_field(rect, 3, Val_int(sdlRect.h));
         CAMLreturn(rect);
+    };
+
+    CAMLprim value resdl_SDL_GetDisplayName(value vDisplay) {
+        CAMLparam1(vDisplay);
+        CAMLlocal1(retStr);
+
+        int displayIndex = Int_val(vDisplay);
+        const char *szDisplayName = SDL_GetDisplayName(displayIndex);
+        if (!szDisplayName) {
+            szDisplayName = "(Null)";
+        };
+
+        retStr = caml_copy_string(szDisplayName);
+        CAMLreturn(retStr);
     };
 
     CAMLprim value resdl_SDL_GetDisplayUsableBounds(value vDisplay) {

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -176,6 +176,7 @@ let start = init => {
   );
 
   let _ = Sdl2.init();
+
   let _dispose = init(appInstance);
 
   let _ = Sdl2.ScreenSaver.enable();

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -516,9 +516,26 @@ let setVsync =
 let create = (name: string, options: WindowCreateOptions.t) => {
   Log.debug("Starting window creation...");
 
+  let displays = Sdl2.Display.getDisplays();
+
+  Log.infof(m => m("Display count: %d", List.length(displays)));
+
+  displays
+  |> List.iteri((idx, display) => {
+       Log.infof(m =>
+         m(
+           "Display %d:%s - %s Bounds: %s",
+           idx,
+           Sdl2.Display.getName(display),
+           Sdl2.Display.getCurrentMode(display) |> Sdl2.Display.Mode.show,
+           Sdl2.Display.getBounds(display) |> Sdl2.Rect.toString,
+         )
+       )
+     });
+
   // Calculate the total bounds of all displays
   let screenBounds =
-    Sdl2.Display.getDisplays()
+    displays
     |> List.fold_left(
          (acc: Sdl2.Rect.t, display) => {
            let bounds = Sdl2.Display.getBounds(display);


### PR DESCRIPTION
__Issue:__ For Onivim issues https://github.com/onivim/oni2/issues/2225 and https://github.com/onivim/oni2/issues/1185 - we still don't have enough details to get the full information. In particular, it'd be useful to see the displays attached along with their pixel formats.

__Fix:__ Add logging for each display prior to window creation to help get further in https://github.com/onivim/oni2/issues/2225 and https://github.com/onivim/oni2/issues/1185

__Test:__
- [x] Validate on OSX
- [x] Validate on Windows
- [x] Validate on Linux 