### PR TITLE
feat(window): Add option for choosing acceleration strategy

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -329,6 +329,7 @@ let init = app => {
           ~icon=Some("revery-icon.png"),
           ~decorated=decorated^,
           ~forceScaleFactor=forceScaleFactor^,
+          ~acceleration=`Auto,
           (),
         ),
       app,

--- a/packages/reason-sdl2/src/sdl2.re
+++ b/packages/reason-sdl2/src/sdl2.re
@@ -159,10 +159,11 @@ module Window = {
       [ | `Undefined | `Centered | `Absolute(int)],
       [ | `Undefined | `Centered | `Absolute(int)],
       int,
-      int
+      int,
+      [ | `Auto | `ForceHardware | `ForceSoftware]
     ) =>
     t =
-    "resdl_SDL_CreateWindow";
+    "resdl_SDL_CreateWindow_byte" "resdl_SDL_CreateWindow";
   external getId: t => int = "resdl_SDL_GetWindowId";
   external getSize: t => Size.t = "resdl_SDL_GetWindowSize";
   external getPosition: t => (int, int) = "resdl_SDL_GetWindowPosition";

--- a/packages/reason-sdl2/src/sdl2_wrapper.cpp
+++ b/packages/reason-sdl2/src/sdl2_wrapper.cpp
@@ -1324,8 +1324,9 @@ extern "C" {
     }
 
     CAMLprim value resdl_SDL_CreateWindow(value vName, value vX, value vY,
-                                          value vWidth, value vHeight) {
+                                          value vWidth, value vHeight, value vAcceleration) {
         CAMLparam5(vName, vX, vY, vWidth, vHeight);
+        CAMLxparam1(vAcceleration);
 
         int x;
         if (vX == hash_variant("Centered")) {
@@ -1379,7 +1380,12 @@ extern "C" {
         SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 0);
         SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, kStencilBits);
 
-        SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
+        // If vAcceleration is Auto, don't set SDL_GL_ACCELERATED_VISUAL at all.
+        if (vAcceleration == hash_variant("ForceHardware")) {
+            SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
+        } else if (vAcceleration == hash_variant("ForceSoftware")) {
+            SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 0);
+        }
 
         SDL_Window *win = (SDL_CreateWindow(
                                String_val(vName), x, y, width, height,
@@ -1392,6 +1398,17 @@ extern "C" {
 
         value vWindow = (value)win;
         CAMLreturn(vWindow);
+    }
+
+    CAMLprim value resdl_SDL_CreateWindow_byte(value *argv, int argn) {
+        return resdl_SDL_CreateWindow(
+                   argv[0],
+                   argv[1],
+                   argv[2],
+                   argv[3],
+                   argv[4],
+                   argv[5]
+               );
     }
 
     CAMLprim value resdl_SDL_SetWindowBordered(value vWin, value vBordered) {

--- a/packages/reason-skia/examples/skia-sdl2/SkiaSdl.re
+++ b/packages/reason-skia/examples/skia-sdl2/SkiaSdl.re
@@ -85,7 +85,7 @@ let run = () => {
     };
 
   let primaryWindow =
-    Sdl2.Window.create("test", `Undefined, `Undefined, 100, 100);
+    Sdl2.Window.create("test", `Undefined, `Undefined, 100, 100, `Auto);
   let glContext = Sdl2.Gl.setup(primaryWindow);
 
   Sdl2.Gl.setSwapInterval(1);

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -566,7 +566,8 @@ let create = (name: string, options: WindowCreateOptions.t) => {
   Log.infof(m =>
     m("Creating window %s width: %u height: %u", name, width, height)
   );
-  let sdlWindow = Sdl2.Window.create(name, x, y, width, height);
+  let sdlWindow =
+    Sdl2.Window.create(name, x, y, width, height, options.acceleration);
   Log.info("Window created successfully.");
 
   let uniqueId = Sdl2.Window.getId(sdlWindow);

--- a/src/Core/WindowCreateOptions.re
+++ b/src/Core/WindowCreateOptions.re
@@ -77,6 +77,14 @@ type t = {
        as well as the scaling of UI elements.
    */
   forceScaleFactor: option(float),
+  /*
+       [acceleration] sets the strategy for picking a renderer - one of:
+       - [`Auto] - will select either a hardware or software renderer (most platforms prefer a hardware renderer)
+       - [`ForceHardware] - forces selection of a hardware-accelerated renderer
+       - [`ForceSoftware] - forces selection of a software renderer
+       This is a proxy for the [SDL_GL_ACCELERATED_VISUAL](https://wiki.libsdl.org/SDL_GL_SetAttribute) setting.
+   */
+  acceleration: [ | `Auto | `ForceHardware | `ForceSoftware],
 };
 
 let create =
@@ -97,6 +105,7 @@ let create =
       ~vsync=Vsync.Synchronized,
       ~icon=None,
       ~forceScaleFactor=None,
+      ~acceleration=`Auto,
       (),
     ) => {
   resizable,
@@ -115,6 +124,7 @@ let create =
   forceScaleFactor,
   vsync,
   icon,
+  acceleration,
 };
 
 let default = create();


### PR DESCRIPTION
This change adds an option when creating a window to determine the acceleration strategy:
- `Auto` - let the platform decide whether to create a hardware or software renderer. Usually this will default to hardware if available.
- `ForceHardware` - only allow hardware-accelerated renderers
- `ForceSoftware` - only allow software-accelerated renderers

The motivation for this change comes from investigating https://github.com/onivim/oni2/issues/2225 https://github.com/onivim/oni2/issues/1185 - it seems that, in some multiple-display cases, there may not be a hardware-accelerated renderer available. 

In that case, Onivim fails to start (`no pixel format available`) - because when it queries the available renderers, there is none matching a hardware-supported OGL context.

This can also allow Onivim to have a configuration setting - `--gpu-acceleration=hardware`/`--gpu-acceleration=software`/`--gpu-acceleration=auto` (default)

I believe this should fix #2225 and #1185 once brought into Onivim (with the caveat that the software renderer will be used, which may have perf implications - but the OpenGL software implementation on Apple actually seems pretty performant...)