### PR TITLE
fix(hooks): tick callback staleness

### DIFF
--- a/src/UI_Hooks/Tick.re
+++ b/src/UI_Hooks/Tick.re
@@ -4,8 +4,8 @@ module Tick = Revery_Core.Tick;
 module Hooks = Revery_UI.React.Hooks;
 
 let tick = (~tickRate=Time.seconds(1), onTick) => {
-  // Because Tick.interval is only called once, intiiallly, with the initial
-  // onTick function, to execute the latest onTIck function we either have to
+  // Because Tick.interval is only called once, initiallly, with the initial
+  // onTick function, to execute the latest onTick function we either have to
   // dispose and recreate it for every call, or use a mutable variable to replace
   // the callback. Here we do the latter.
   let%hook onTickRef = Hooks.ref(onTick);

--- a/src/UI_Hooks/Tick.re
+++ b/src/UI_Hooks/Tick.re
@@ -1,16 +1,25 @@
 module Time = Revery_Core.Time;
+module Tick = Revery_Core.Tick;
 
 module Hooks = Revery_UI.React.Hooks;
 
 let tick = (~tickRate=Time.seconds(1), onTick) => {
+  // Because Tick.interval is only called once, intiiallly, with the initial
+  // onTick function, to execute the latest onTIck function we either have to
+  // dispose and recreate it for every call, or use a mutable variable to replace
+  // the callback. Here we do the latter.
+  let%hook onTickRef = Hooks.ref(onTick);
+  onTickRef := onTick;
+
   let%hook () =
     Hooks.effect(
       OnMount,
       () => {
-        let dispose = Revery_Core.Tick.interval(onTick, tickRate);
+        let dispose = Tick.interval(t => onTickRef^(t), tickRate);
 
         Some(dispose);
       },
     );
+
   ();
 };

--- a/src/UI_Hooks/Tick.rei
+++ b/src/UI_Hooks/Tick.rei
@@ -5,7 +5,7 @@ module Time = Revery_Core.Time;
 let tick:
   (
     ~tickRate: Time.t=?,
-    Revery_Core.Tick.callback,
-    t(Effect.t(Effect.onMount) => 'a, 'b)
+    Time.t => unit,
+    t((ref(Time.t => unit), Effect.t(Effect.onMount)) => 'a, 'b)
   ) =>
   (unit, t('a, 'b));

--- a/test/UI/HooksTest.re
+++ b/test/UI/HooksTest.re
@@ -124,7 +124,7 @@ describe("Hooks", ({describe, _}) => {
       };
     };
 
-    test("Single: Timer starts and stops", ({expect, _}) => {
+    test("Callback does not go stale", ({expect, _}) => {
       let rootNode = (new viewNode)();
       let container = Container.create(rootNode);
       let count = ref(0);

--- a/test/UI/HooksTest.re
+++ b/test/UI/HooksTest.re
@@ -1,3 +1,4 @@
+open Revery_Core;
 open Revery_UI;
 open Revery_UI_Primitives;
 
@@ -6,26 +7,26 @@ module Hooks = Revery_UI_Hooks;
 
 open TestFramework;
 
-let getTickerCount = () => Tick.getActiveTickers() |> List.length;
-
-module SingleTimer = {
-  let%component make = (~timerActive, ()) => {
-    let%hook (_dt, _reset) = Hooks.timer(~active=timerActive, ());
-
-    <View />;
-  };
-};
-
-module DoubleTimer = {
-  let%component make = (~timer1Active, ~timer2Active, ()) => {
-    let%hook (_dt, _reset) = Hooks.timer(~active=timer1Active, ());
-    let%hook (_dt, _reset) = Hooks.timer(~active=timer2Active, ());
-    <View />;
-  };
-};
-
 describe("Hooks", ({describe, _}) => {
   describe("Timer", ({test, _}) => {
+    module SingleTimer = {
+      let%component make = (~timerActive, ()) => {
+        let%hook (_dt, _reset) = Hooks.timer(~active=timerActive, ());
+
+        <View />;
+      };
+    };
+
+    module DoubleTimer = {
+      let%component make = (~timer1Active, ~timer2Active, ()) => {
+        let%hook (_dt, _reset) = Hooks.timer(~active=timer1Active, ());
+        let%hook (_dt, _reset) = Hooks.timer(~active=timer2Active, ());
+        <View />;
+      };
+    };
+
+    let getTickerCount = () => Tick.getActiveTickers() |> List.length;
+
     test("Single: Timer starts and stops", ({expect, _}) => {
       expect.int(getTickerCount()).toBe(0);
 
@@ -112,5 +113,31 @@ describe("Hooks", ({describe, _}) => {
       Tick.pump();
       expect.int(getTickerCount()).toBe(0);
     });
-  })
+  });
+
+  describe("Tick", ({test, _}) => {
+    module Ticker = {
+      let%component make = (~f, ()) => {
+        let%hook () = Hooks.tick(~tickRate=Time.zero, f);
+
+        <View />;
+      };
+    };
+
+    test("Single: Timer starts and stops", ({expect, _}) => {
+      let rootNode = (new viewNode)();
+      let container = Container.create(rootNode);
+      let count = ref(0);
+
+      let container =
+        Container.update(container, <Ticker f={_ => count := 1} />);
+      Tick.pump();
+      expect.int(count^).toBe(1);
+
+      let _container =
+        Container.update(container, <Ticker f={_ => count := 2} />);
+      Tick.pump();
+      expect.int(count^).toBe(2);
+    });
+  });
 });


### PR DESCRIPTION
As reported by @lessp on Discord, this fixes an issue where the tick hook would always execute the initial callback instead of updating with the latest given to it. The fix is to store the callback in a ref, and call that instead of calling the closed over callback directly.

Technically this is a breaking change for code relying on the behavior that the callback goes stale. That seems highly unlikely though, at least intentionally.