### PR TITLE
fix(windows): Remove freetype2 + another usage of cmake build on Windows

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "62154ecc1104c11cf006e470fac09fef",
+  "checksum": "bde87f54ae2b1b70819f9d8a43d8981f",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -34,7 +34,8 @@
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "flex@1.2.3@d41d8cd9", "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
-        "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
+        "esy-sdl2@2.0.10008@d41d8cd9",
+        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
@@ -289,19 +290,18 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-freetype2@2.9.1007@d41d8cd9": {
-      "id": "esy-freetype2@2.9.1007@d41d8cd9",
+    "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9": {
+      "id":
+        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
       "name": "esy-freetype2",
-      "version": "2.9.1007",
+      "version": "github:esy-packages/esy-freetype2#20f5279",
       "source": {
         "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/esy-freetype2/-/esy-freetype2-2.9.1007.tgz#sha1:6ef0ac0142837e44cc6e845868b0fb592dd72b74"
-        ]
+        "source": [ "github:esy-packages/esy-freetype2#20f5279" ]
       },
       "overrides": [],
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
-      "devDependencies": []
+      "devDependencies": [ "esy-cmake@0.3.5@d41d8cd9" ]
     },
     "esy-cmake@0.3.5@d41d8cd9": {
       "id": "esy-cmake@0.3.5@d41d8cd9",

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "bde87f54ae2b1b70819f9d8a43d8981f",
+  "checksum": "1e94b1b9a7580372490621692a5c2c6d",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -34,8 +34,7 @@
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "flex@1.2.3@d41d8cd9", "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
-        "esy-sdl2@2.0.10008@d41d8cd9",
-        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
+        "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1008@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
@@ -290,18 +289,19 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9": {
-      "id":
-        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
+    "esy-freetype2@2.9.1008@d41d8cd9": {
+      "id": "esy-freetype2@2.9.1008@d41d8cd9",
       "name": "esy-freetype2",
-      "version": "github:esy-packages/esy-freetype2#20f5279",
+      "version": "2.9.1008",
       "source": {
         "type": "install",
-        "source": [ "github:esy-packages/esy-freetype2#20f5279" ]
+        "source": [
+          "archive:https://registry.npmjs.org/esy-freetype2/-/esy-freetype2-2.9.1008.tgz#sha1:cdc4443f6bf763fd44b3eeaf8fd0b1c1df6fdea9"
+        ]
       },
       "overrides": [],
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
-      "devDependencies": [ "esy-cmake@0.3.5@d41d8cd9" ]
+      "devDependencies": []
     },
     "esy-cmake@0.3.5@d41d8cd9": {
       "id": "esy-cmake@0.3.5@d41d8cd9",

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5404a13ba843186e8cbe1f3e8951c4a8",
+  "checksum": "fa65bcc1edbe4b825232fb3fbf95cdc0",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -77,7 +77,8 @@
         "http-server@0.12.3@d41d8cd9", "flex@1.2.3@d41d8cd9",
         "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
-        "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
+        "esy-sdl2@2.0.10008@d41d8cd9",
+        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
@@ -321,14 +322,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "lodash@4.17.19@d41d8cd9": {
-      "id": "lodash@4.17.19@d41d8cd9",
+    "lodash@4.17.20@d41d8cd9": {
+      "id": "lodash@4.17.20@d41d8cd9",
       "name": "lodash",
-      "version": "4.17.19",
+      "version": "4.17.20",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz#sha1:e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz#sha1:b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
         ]
       },
       "overrides": [],
@@ -540,19 +541,18 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-freetype2@2.9.1007@d41d8cd9": {
-      "id": "esy-freetype2@2.9.1007@d41d8cd9",
+    "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9": {
+      "id":
+        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
       "name": "esy-freetype2",
-      "version": "2.9.1007",
+      "version": "github:esy-packages/esy-freetype2#20f5279",
       "source": {
         "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/esy-freetype2/-/esy-freetype2-2.9.1007.tgz#sha1:6ef0ac0142837e44cc6e845868b0fb592dd72b74"
-        ]
+        "source": [ "github:esy-packages/esy-freetype2#20f5279" ]
       },
       "overrides": [],
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
-      "devDependencies": []
+      "devDependencies": [ "esy-cmake@0.3.5@d41d8cd9" ]
     },
     "esy-cmake@0.3.5@d41d8cd9": {
       "id": "esy-cmake@0.3.5@d41d8cd9",
@@ -692,7 +692,7 @@
         ]
       },
       "overrides": [],
-      "dependencies": [ "lodash@4.17.19@d41d8cd9" ],
+      "dependencies": [ "lodash@4.17.20@d41d8cd9" ],
       "devDependencies": []
     },
     "@revery/esy-harfbuzz@2.6.8001@d41d8cd9": {

--- a/doc.esy.lock/index.json
+++ b/doc.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "fa65bcc1edbe4b825232fb3fbf95cdc0",
+  "checksum": "2e4db64a3fbd5d3cf72bf34f9b30f19a",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -77,8 +77,7 @@
         "http-server@0.12.3@d41d8cd9", "flex@1.2.3@d41d8cd9",
         "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
-        "esy-sdl2@2.0.10008@d41d8cd9",
-        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
+        "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1008@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
@@ -541,18 +540,19 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9": {
-      "id":
-        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
+    "esy-freetype2@2.9.1008@d41d8cd9": {
+      "id": "esy-freetype2@2.9.1008@d41d8cd9",
       "name": "esy-freetype2",
-      "version": "github:esy-packages/esy-freetype2#20f5279",
+      "version": "2.9.1008",
       "source": {
         "type": "install",
-        "source": [ "github:esy-packages/esy-freetype2#20f5279" ]
+        "source": [
+          "archive:https://registry.npmjs.org/esy-freetype2/-/esy-freetype2-2.9.1008.tgz#sha1:cdc4443f6bf763fd44b3eeaf8fd0b1c1df6fdea9"
+        ]
       },
       "overrides": [],
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
-      "devDependencies": [ "esy-cmake@0.3.5@d41d8cd9" ]
+      "devDependencies": []
     },
     "esy-cmake@0.3.5@d41d8cd9": {
       "id": "esy-cmake@0.3.5@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "62154ecc1104c11cf006e470fac09fef",
+  "checksum": "bde87f54ae2b1b70819f9d8a43d8981f",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -34,7 +34,8 @@
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "flex@1.2.3@d41d8cd9", "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
-        "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
+        "esy-sdl2@2.0.10008@d41d8cd9",
+        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
@@ -289,19 +290,18 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-freetype2@2.9.1007@d41d8cd9": {
-      "id": "esy-freetype2@2.9.1007@d41d8cd9",
+    "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9": {
+      "id":
+        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
       "name": "esy-freetype2",
-      "version": "2.9.1007",
+      "version": "github:esy-packages/esy-freetype2#20f5279",
       "source": {
         "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/esy-freetype2/-/esy-freetype2-2.9.1007.tgz#sha1:6ef0ac0142837e44cc6e845868b0fb592dd72b74"
-        ]
+        "source": [ "github:esy-packages/esy-freetype2#20f5279" ]
       },
       "overrides": [],
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
-      "devDependencies": []
+      "devDependencies": [ "esy-cmake@0.3.5@d41d8cd9" ]
     },
     "esy-cmake@0.3.5@d41d8cd9": {
       "id": "esy-cmake@0.3.5@d41d8cd9",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "bde87f54ae2b1b70819f9d8a43d8981f",
+  "checksum": "1e94b1b9a7580372490621692a5c2c6d",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -34,8 +34,7 @@
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "flex@1.2.3@d41d8cd9", "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
-        "esy-sdl2@2.0.10008@d41d8cd9",
-        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
+        "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1008@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
@@ -290,18 +289,19 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9": {
-      "id":
-        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
+    "esy-freetype2@2.9.1008@d41d8cd9": {
+      "id": "esy-freetype2@2.9.1008@d41d8cd9",
       "name": "esy-freetype2",
-      "version": "github:esy-packages/esy-freetype2#20f5279",
+      "version": "2.9.1008",
       "source": {
         "type": "install",
-        "source": [ "github:esy-packages/esy-freetype2#20f5279" ]
+        "source": [
+          "archive:https://registry.npmjs.org/esy-freetype2/-/esy-freetype2-2.9.1008.tgz#sha1:cdc4443f6bf763fd44b3eeaf8fd0b1c1df6fdea9"
+        ]
       },
       "overrides": [],
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
-      "devDependencies": [ "esy-cmake@0.3.5@d41d8cd9" ]
+      "devDependencies": []
     },
     "esy-cmake@0.3.5@d41d8cd9": {
       "id": "esy-cmake@0.3.5@d41d8cd9",

--- a/examples.esy.lock/index.json
+++ b/examples.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "62154ecc1104c11cf006e470fac09fef",
+  "checksum": "bde87f54ae2b1b70819f9d8a43d8981f",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -34,7 +34,8 @@
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "flex@1.2.3@d41d8cd9", "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
-        "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
+        "esy-sdl2@2.0.10008@d41d8cd9",
+        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
@@ -289,19 +290,18 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-freetype2@2.9.1007@d41d8cd9": {
-      "id": "esy-freetype2@2.9.1007@d41d8cd9",
+    "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9": {
+      "id":
+        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
       "name": "esy-freetype2",
-      "version": "2.9.1007",
+      "version": "github:esy-packages/esy-freetype2#20f5279",
       "source": {
         "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/esy-freetype2/-/esy-freetype2-2.9.1007.tgz#sha1:6ef0ac0142837e44cc6e845868b0fb592dd72b74"
-        ]
+        "source": [ "github:esy-packages/esy-freetype2#20f5279" ]
       },
       "overrides": [],
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
-      "devDependencies": []
+      "devDependencies": [ "esy-cmake@0.3.5@d41d8cd9" ]
     },
     "esy-cmake@0.3.5@d41d8cd9": {
       "id": "esy-cmake@0.3.5@d41d8cd9",

--- a/examples.esy.lock/index.json
+++ b/examples.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "bde87f54ae2b1b70819f9d8a43d8981f",
+  "checksum": "1e94b1b9a7580372490621692a5c2c6d",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -34,8 +34,7 @@
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "flex@1.2.3@d41d8cd9", "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
-        "esy-sdl2@2.0.10008@d41d8cd9",
-        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
+        "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1008@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
@@ -290,18 +289,19 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9": {
-      "id":
-        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
+    "esy-freetype2@2.9.1008@d41d8cd9": {
+      "id": "esy-freetype2@2.9.1008@d41d8cd9",
       "name": "esy-freetype2",
-      "version": "github:esy-packages/esy-freetype2#20f5279",
+      "version": "2.9.1008",
       "source": {
         "type": "install",
-        "source": [ "github:esy-packages/esy-freetype2#20f5279" ]
+        "source": [
+          "archive:https://registry.npmjs.org/esy-freetype2/-/esy-freetype2-2.9.1008.tgz#sha1:cdc4443f6bf763fd44b3eeaf8fd0b1c1df6fdea9"
+        ]
       },
       "overrides": [],
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
-      "devDependencies": [ "esy-cmake@0.3.5@d41d8cd9" ]
+      "devDependencies": []
     },
     "esy-cmake@0.3.5@d41d8cd9": {
       "id": "esy-cmake@0.3.5@d41d8cd9",

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9a4893fdcd2e450dc8443c5134c6049e",
+  "checksum": "bed690b753584ff53866245d7497284c",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -77,7 +77,8 @@
         "http-server@0.12.3@d41d8cd9", "flex@1.2.3@d41d8cd9",
         "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
-        "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
+        "esy-sdl2@2.0.10008@d41d8cd9",
+        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
@@ -325,14 +326,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "lodash@4.17.19@d41d8cd9": {
-      "id": "lodash@4.17.19@d41d8cd9",
+    "lodash@4.17.20@d41d8cd9": {
+      "id": "lodash@4.17.20@d41d8cd9",
       "name": "lodash",
-      "version": "4.17.19",
+      "version": "4.17.20",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz#sha1:e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz#sha1:b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
         ]
       },
       "overrides": [],
@@ -544,19 +545,18 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-freetype2@2.9.1007@d41d8cd9": {
-      "id": "esy-freetype2@2.9.1007@d41d8cd9",
+    "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9": {
+      "id":
+        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
       "name": "esy-freetype2",
-      "version": "2.9.1007",
+      "version": "github:esy-packages/esy-freetype2#20f5279",
       "source": {
         "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/esy-freetype2/-/esy-freetype2-2.9.1007.tgz#sha1:6ef0ac0142837e44cc6e845868b0fb592dd72b74"
-        ]
+        "source": [ "github:esy-packages/esy-freetype2#20f5279" ]
       },
       "overrides": [],
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
-      "devDependencies": []
+      "devDependencies": [ "esy-cmake@0.3.5@d41d8cd9" ]
     },
     "esy-cmake@0.3.5@d41d8cd9": {
       "id": "esy-cmake@0.3.5@d41d8cd9",
@@ -696,7 +696,7 @@
         ]
       },
       "overrides": [],
-      "dependencies": [ "lodash@4.17.19@d41d8cd9" ],
+      "dependencies": [ "lodash@4.17.20@d41d8cd9" ],
       "devDependencies": []
     },
     "@revery/esy-harfbuzz@2.6.8001@d41d8cd9": {

--- a/js.esy.lock/index.json
+++ b/js.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "bed690b753584ff53866245d7497284c",
+  "checksum": "c7d7296b42be8dc39287e0faf9af20dd",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -77,8 +77,7 @@
         "http-server@0.12.3@d41d8cd9", "flex@1.2.3@d41d8cd9",
         "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
-        "esy-sdl2@2.0.10008@d41d8cd9",
-        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
+        "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1008@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/uucp@opam:13.0.0@e9b515e0",
@@ -545,18 +544,19 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9": {
-      "id":
-        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
+    "esy-freetype2@2.9.1008@d41d8cd9": {
+      "id": "esy-freetype2@2.9.1008@d41d8cd9",
       "name": "esy-freetype2",
-      "version": "github:esy-packages/esy-freetype2#20f5279",
+      "version": "2.9.1008",
       "source": {
         "type": "install",
-        "source": [ "github:esy-packages/esy-freetype2#20f5279" ]
+        "source": [
+          "archive:https://registry.npmjs.org/esy-freetype2/-/esy-freetype2-2.9.1008.tgz#sha1:cdc4443f6bf763fd44b3eeaf8fd0b1c1df6fdea9"
+        ]
       },
       "overrides": [],
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
-      "devDependencies": [ "esy-cmake@0.3.5@d41d8cd9" ]
+      "devDependencies": []
     },
     "esy-cmake@0.3.5@d41d8cd9": {
       "id": "esy-cmake@0.3.5@d41d8cd9",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@opam/charInfo_width": "*",
     "@brisk/brisk-reconciler": "briskml/brisk-reconciler#10cab2d",
     "esy-angle-prebuilt": "1.0.0",
-    "esy-freetype2": "^2.9.1007",
+    "esy-freetype2": "^2.9.1008",
     "@revery/esy-harfbuzz": "^2.6.8001",
     "esy-sdl2": "^2.0.10008",
     "esy-skia": "revery-ui/esy-skia#a3785f9",
@@ -64,8 +64,7 @@
     "@glennsl/timber": "^1.2.0"
   },
   "resolutions": {
-    "@opam/conf-pkg-config": "1.2",
-    "esy-freetype2": "esy-packages/esy-freetype2#20f5279"
+    "@opam/conf-pkg-config": "1.2"
   },
   "devDependencies": {
     "ocaml": "~4.10",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "@glennsl/timber": "^1.2.0"
   },
   "resolutions": {
-    "@opam/conf-pkg-config": "1.2"
+    "@opam/conf-pkg-config": "1.2",
+    "esy-freetype2": "esy-packages/esy-freetype2#20f5279"
   },
   "devDependencies": {
     "ocaml": "~4.10",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "349964c2c6fd0686c45a81bd50b698c9",
+  "checksum": "79d52fd328b87994f243c184866d5702",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -34,8 +34,7 @@
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "flex@1.2.3@d41d8cd9", "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
-        "esy-sdl2@2.0.10008@d41d8cd9",
-        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
+        "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1008@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
@@ -291,18 +290,19 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9": {
-      "id":
-        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
+    "esy-freetype2@2.9.1008@d41d8cd9": {
+      "id": "esy-freetype2@2.9.1008@d41d8cd9",
       "name": "esy-freetype2",
-      "version": "github:esy-packages/esy-freetype2#20f5279",
+      "version": "2.9.1008",
       "source": {
         "type": "install",
-        "source": [ "github:esy-packages/esy-freetype2#20f5279" ]
+        "source": [
+          "archive:https://registry.npmjs.org/esy-freetype2/-/esy-freetype2-2.9.1008.tgz#sha1:cdc4443f6bf763fd44b3eeaf8fd0b1c1df6fdea9"
+        ]
       },
       "overrides": [],
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
-      "devDependencies": [ "esy-cmake@0.3.5@d41d8cd9" ]
+      "devDependencies": []
     },
     "esy-cmake@0.3.5@d41d8cd9": {
       "id": "esy-cmake@0.3.5@d41d8cd9",

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "1eb74bed179c661fb893a6298e3105d6",
+  "checksum": "349964c2c6fd0686c45a81bd50b698c9",
   "root": "revery@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -34,7 +34,8 @@
         "reason-native-crash-utils@github:onivim/reason-native-crash-utils#38c8f00@d41d8cd9",
         "flex@1.2.3@d41d8cd9", "fetch-native-lwt@0.1.0-alpha.5@d41d8cd9",
         "esy-skia@github:revery-ui/esy-skia#a3785f9@d41d8cd9",
-        "esy-sdl2@2.0.10008@d41d8cd9", "esy-freetype2@2.9.1007@d41d8cd9",
+        "esy-sdl2@2.0.10008@d41d8cd9",
+        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
         "esy-angle-prebuilt@1.0.0@d41d8cd9",
         "@revery/esy-harfbuzz@2.6.8001@d41d8cd9",
         "@reason-native/rely@3.2.1@d41d8cd9",
@@ -290,19 +291,18 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-freetype2@2.9.1007@d41d8cd9": {
-      "id": "esy-freetype2@2.9.1007@d41d8cd9",
+    "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9": {
+      "id":
+        "esy-freetype2@github:esy-packages/esy-freetype2#20f5279@d41d8cd9",
       "name": "esy-freetype2",
-      "version": "2.9.1007",
+      "version": "github:esy-packages/esy-freetype2#20f5279",
       "source": {
         "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/esy-freetype2/-/esy-freetype2-2.9.1007.tgz#sha1:6ef0ac0142837e44cc6e845868b0fb592dd72b74"
-        ]
+        "source": [ "github:esy-packages/esy-freetype2#20f5279" ]
       },
       "overrides": [],
       "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
-      "devDependencies": []
+      "devDependencies": [ "esy-cmake@0.3.5@d41d8cd9" ]
     },
     "esy-cmake@0.3.5@d41d8cd9": {
       "id": "esy-cmake@0.3.5@d41d8cd9",


### PR DESCRIPTION
Like #985 , this fixes another failure blocking the windows build - freetype2 was also dependent on CMake.

Manifests as another windows build failure on Onivim nightly/master:
```
error: build failed with exit code: 1
  build log:
    # esy-build-package: building: esy-freetype2@2.9.1007

    # esy-build-package: pwd: C:\Users\VssAdministrator\.esy\3\b\esy_freetype2-2.9.1007-dbc259b7

    # esy-build-package: running: "bash" "-c" "./esy/configure-windows.sh"

    INSTALL: /cygdrive/c/Users/VssAdministrator/.esy/3______________________________________________________/s/esy_freetype2-2.9.1007-dbc259b7
    error: command failed: "bash" "-c" "./esy/configure-windows.sh" (exited with 127)

    esy-build-package: exiting with errors above...

    
  building esy-freetype2@2.9.1007
esy: exiting due to errors above
```

We actually don't use freetype2 at all on Windows, anymore, as Skia uses DirectWrite API - so to unblock the builds, this picks up https://github.com/esy-packages/esy-freetype2 to remove this usage of cmake on Windows.