### PR TITLE
use static libSDL2.a on skia

### DIFF
--- a/packages/reason-skia/src/config/discover.re
+++ b/packages/reason-skia/src/config/discover.re
@@ -31,6 +31,8 @@ let detect_system_header = {|
   #endif
 |};
 
+let sdl2FilePath = Sys.getenv("SDL2_LIB_PATH") ++ "/libSDL2.a";
+
 let get_os = t => {
   let header = {
     let file = Filename.temp_file("discover", "os.h");
@@ -66,7 +68,6 @@ let flags = os =>
     @ cclib("-lfreetype")
     @ cclib("-lz")
     @ cclib("-lskia")
-    @ cclib("-lSDL2")
     @ cclib("-lGLESv2")
     @ cclib("-lGLESv1_CM")
     @ cclib("-lm")
@@ -91,7 +92,7 @@ let flags = os =>
     @ cclib("-lz")
     @ cclib("-lbz2")
     @ cclib("-lskia")
-    @ cclib("-lSDL2")
+    @ cclib(sdl2FilePath)
     @ ccopt("-L" ++ getenv("FREETYPE2_LIB_PATH"))
     @ ccopt("-L" ++ getenv("SDL2_LIB_PATH"))
     @ ccopt("-L" ++ getenv("SKIA_LIB_PATH"))
@@ -104,7 +105,7 @@ let flags = os =>
   | Windows =>
     []
     @ cclib("-lskia")
-    @ cclib("-lSDL2")
+    @ cclib(sdl2FilePath)
     @ ccopt("-L" ++ getenv("SDL2_LIB_PATH"))
     @ ccopt("-L" ++ getenv("SKIA_LIB_PATH"))
   };
@@ -113,7 +114,7 @@ let cflags = os =>
   switch (os) {
   | Android =>
     []
-    @ ["-lSDL2"]
+    @ [sdl2FilePath]
     @ ["-lGLESv2"]
     @ ["-lGLESv1_CM"]
     @ ["-lm"]
@@ -130,7 +131,7 @@ let cflags = os =>
     @ ["-ljpeg"]
   | Linux =>
     []
-    @ ["-lSDL2"]
+    @ [sdl2FilePath]
     @ ["-lskia"]
     @ ["-I" ++ getenv("SDL2_INCLUDE_PATH")]
     @ ["-I" ++ getenv("SKIA_INCLUDE_PATH")]
@@ -159,7 +160,7 @@ let libs = os =>
   | Android =>
     []
     @ [
-      "-lSDL2",
+      sdl2FilePath,
       "-lGLESv2",
       "-lGLESv1_CM",
       "-lm",
@@ -199,14 +200,14 @@ let libs = os =>
     @ framework("IOKit")
     @ framework("Metal")
     @ ["-liconv"]
-    @ ["-lSDL2"]
+    @ [sdl2FilePath]
     @ ["-lskia"]
     @ ["-lstdc++"]
     @ [getenv("JPEG_LIB_PATH") ++ "/libturbojpeg.a"]
   | Linux =>
     []
     @ [
-      "-lSDL2",
+      sdl2FilePath,
       "-lskia",
       "-lfreetype",
       "-lfontconfig",
@@ -240,7 +241,7 @@ let libs = os =>
     @ framework("IOKit")
     @ framework("Metal")
     @ ["-liconv"]
-    @ ["-lSDL2"]
+    @ [sdl2FilePath]
     @ ["-lskia"]
     @ ["-lstdc++"]
     @ [getenv("JPEG_LIB_PATH") ++ "/libturbojpeg.a"]
@@ -248,7 +249,7 @@ let libs = os =>
     []
     @ ["-luser32"]
     @ ["-lskia"]
-    @ ["-lSDL2"]
+    @ [sdl2FilePath]
     @ ["-lstdc++"]
     @ ["-L" ++ getenv("SDL2_LIB_PATH")]
     @ ["-L" ++ getenv("SKIA_LIB_PATH")]

--- a/packages/reason-skia/src/config/discover.re
+++ b/packages/reason-skia/src/config/discover.re
@@ -105,7 +105,7 @@ let flags = os =>
   | Windows =>
     []
     @ cclib("-lskia")
-    @ cclib(sdl2FilePath)
+    @ cclib("-lSDL2")
     @ ccopt("-L" ++ getenv("SDL2_LIB_PATH"))
     @ ccopt("-L" ++ getenv("SKIA_LIB_PATH"))
   };
@@ -249,7 +249,7 @@ let libs = os =>
     []
     @ ["-luser32"]
     @ ["-lskia"]
-    @ [sdl2FilePath]
+    @ ["-lSDL2"]
     @ ["-lstdc++"]
     @ ["-L" ++ getenv("SDL2_LIB_PATH")]
     @ ["-L" ++ getenv("SKIA_LIB_PATH")]


### PR DESCRIPTION
Currently `reason-sdl2` uses the static version while skia uses `-lSDL2` this makes the binary link to SDL2 both dynamically and statically. This is a bug on iOS