### PR TITLE
add usage example for hooks

### DIFF
--- a/src/UI_Hooks/Effect.rei
+++ b/src/UI_Hooks/Effect.rei
@@ -1,5 +1,16 @@
 open Revery_UI.React.Hooks;
 
+/**
+{2 Description:}
+
+The Effect Hook lets you perform side effects in function components.
+
+{2 Usage:}
+
+{[
+let%hook (state, dispatch) = Hooks.effect(OnMount, reduce);
+]}
+*/
 let effect:
   (
     Effect.condition('a),

--- a/src/UI_Hooks/Effect.rei
+++ b/src/UI_Hooks/Effect.rei
@@ -8,7 +8,12 @@ The Effect Hook lets you perform side effects in function components.
 {2 Usage:}
 
 {[
-let%hook (state, dispatch) = Hooks.effect(OnMount, reduce);
+let%hook () = Hooks.effect(OnMount, () => {
+  // Some side-effect
+
+  // Clean-up function
+  None;
+});
 ]}
 */
 let effect:

--- a/src/UI_Hooks/Reducer.rei
+++ b/src/UI_Hooks/Reducer.rei
@@ -3,7 +3,7 @@ open Revery_UI.React.Hooks;
 /**
 {2 Description:}
 
-TODO
+An alternative to Hooks.state. Accepts a reducer of type (state, action) => newState, and returns the current state paired with a dispatch function.
 
 {2 Usage:}
 

--- a/src/UI_Hooks/Reducer.rei
+++ b/src/UI_Hooks/Reducer.rei
@@ -3,7 +3,7 @@ open Revery_UI.React.Hooks;
 /**
 {2 Description:}
 
-An alternative to Hooks.state. Accepts a reducer of type (state, action) => newState, and returns the current state paired with a dispatch function.
+An alternative to Hooks.state. Accepts a reducer of type (action, state) => newState, and returns the current state paired with a dispatch function.
 
 {2 Usage:}
 

--- a/src/UI_Hooks/Reducer.rei
+++ b/src/UI_Hooks/Reducer.rei
@@ -1,5 +1,16 @@
 open Revery_UI.React.Hooks;
 
+/**
+{2 Description:}
+
+TODO
+
+{2 Usage:}
+
+{[
+let%hook (state, dispatch) = Hooks.reducer(~initialState={counter:0}, reduce);
+]}
+*/
 let reducer:
   (~initialState: 'a, ('b, 'a) => 'a, t(Reducer.t('a) => 'c, 'd)) =>
   (('a, 'b => unit), t('c, 'd));

--- a/src/UI_Hooks/State.rei
+++ b/src/UI_Hooks/State.rei
@@ -1,4 +1,15 @@
 open Revery_UI.React.Hooks;
 
+/**
+{2 Description:}
+
+TODO
+
+{2 Usage:}
+
+{[
+let%hook (state, setState) = Hooks.state(0);
+]}
+*/
 let state:
   ('a, t(State.t('a) => 'b, 'c)) => (('a, ('a => 'a) => unit), t('b, 'c));


### PR DESCRIPTION
The type signatures for the hooks are quite hard to read.

Especially since most parts of it are abstracted away by the brisk-reconciler.
This change makes it easier to discover how to use the common hooks.

![image](https://user-images.githubusercontent.com/18226001/90973151-9b1ac500-e562-11ea-8770-5a88dacc5f33.png)
