### PR TITLE
fix(image): Use the image size as the default width/ height if none specified

### DIFF
--- a/examples/Hello.re
+++ b/examples/Hello.re
@@ -45,8 +45,6 @@ module Logo = {
         <Image
           src={`File("outrun-logo.png")}
           style=Style.[
-            width(512),
-            height(256),
             transform([
               Transform.RotateY(Angle.from_radians(rotationY)),
               Transform.RotateX(Angle.from_radians(rotationX)),

--- a/packages/reason-skia/examples/skia-cli/SkiaCli.re
+++ b/packages/reason-skia/examples/skia-cli/SkiaCli.re
@@ -135,6 +135,14 @@ let draw = canvas => {
   switch (maybeImg) {
   | None => failwith("Unable to load image: uv.png")
   | Some(img) =>
+    print_endline(
+      Printf.sprintf(
+        "%s Image dimensions: %dx%d",
+        imgPath,
+        Skia.Image.width(img),
+        Skia.Image.height(img),
+      ),
+    );
     let imgFill = Paint.make();
     Paint.setAlpha(imgFill, 0.0);
     Canvas.drawImage(canvas, img, 250., 250., Some(imgFill));

--- a/packages/reason-skia/src/Skia.re
+++ b/packages/reason-skia/src/Skia.re
@@ -723,6 +723,9 @@ module Image = {
     Gc.finalise(SkiaWrapped.Data.delete, data);
     data;
   };
+
+  let width = SkiaWrapped.Image.width;
+  let height = SkiaWrapped.Image.height;
 };
 
 type pixelGeometry = SkiaWrapped.pixelGeometry;

--- a/packages/reason-skia/src/Skia.rei
+++ b/packages/reason-skia/src/Skia.rei
@@ -413,6 +413,9 @@ module Image: {
 
   let makeFromEncoded: (Data.t, option(IRect.t)) => option(t);
   let encodeToData: t => Data.t;
+
+  let width: t => int;
+  let height: t => int;
 };
 
 type pixelGeometry = SkiaWrapped.pixelGeometry;

--- a/packages/reason-skia/src/wrapped/bindings/SkiaWrappedBindings.re
+++ b/packages/reason-skia/src/wrapped/bindings/SkiaWrappedBindings.re
@@ -785,6 +785,9 @@ module M = (F: FOREIGN) => {
     let delete = foreign("sk_image_unref", t @-> returning(void));
 
     let encode = foreign("sk_image_encode", t @-> returning(Data.t));
+
+    let width = foreign("sk_image_get_width", t @-> returning(int));
+    let height = foreign("sk_image_get_height", t @-> returning(int));
   };
 
   type pixelGeometry = SkiaTypes.pixelGeometry;

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -56,17 +56,28 @@ class imageNode (data: option(Skia.Image.t)) = {
     Skia.Paint.setFilterQuality(_paint, quality);
   };
   pub! setStyle = style => {
+    // If neither the height and width are defined, then
+    // use the image size as the default height and width.
+
     let adjustedStyle =
-      Layout.Encoding.{
-        ...style,
-        width:
-          style.width == cssUndefined
-            ? _maybeWidth |> Option.value(~default=cssUndefined) : style.width,
-        height:
-          style.height == cssUndefined
-            ? _maybeHeight |> Option.value(~default=cssUndefined)
-            : style.height,
-      };
+      Layout.Encoding.(
+        {
+          let noDimensionsSet =
+            style.width == cssUndefined && style.height == cssUndefined;
+
+          Style.{
+            ...style,
+            width:
+              noDimensionsSet
+                ? _maybeWidth |> Option.value(~default=cssUndefined)
+                : style.width,
+            height:
+              noDimensionsSet
+                ? _maybeHeight |> Option.value(~default=cssUndefined)
+                : style.height,
+          };
+        }
+      );
     _super#setStyle(adjustedStyle);
   };
   pub setData = maybeImg => {

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -18,6 +18,8 @@ class imageNode (data: option(Skia.Image.t)) = {
   inherit (class node)() as _super;
   val mutable _opacity = 1.0;
   val mutable _resizeMode = ImageResizeMode.Stretch;
+  val mutable _maybeWidth = None;
+  val mutable _maybeHeight = None;
   val _paint = Skia.Paint.make();
   pub! draw = (parentContext: NodeDrawContext.t) => {
     /* Draw background first */
@@ -53,7 +55,24 @@ class imageNode (data: option(Skia.Image.t)) = {
   pub setQuality = quality => {
     Skia.Paint.setFilterQuality(_paint, quality);
   };
-  pub setData = newData => {
-    data = newData;
+  pub! setStyle = style => {
+    let adjustedStyle =
+      Layout.Encoding.{
+        ...style,
+        width:
+          style.width == cssUndefined
+            ? _maybeWidth |> Option.value(~default=cssUndefined) : style.width,
+        height:
+          style.height == cssUndefined
+            ? _maybeHeight |> Option.value(~default=cssUndefined)
+            : style.height,
+      };
+    _super#setStyle(adjustedStyle);
+  };
+  pub setData = maybeImg => {
+    data = maybeImg;
+    _maybeWidth = maybeImg |> Option.map(Skia.Image.width);
+    _maybeHeight = maybeImg |> Option.map(Skia.Image.height);
+    _this#setStyle(_super#getStyle());
   };
 };


### PR DESCRIPTION
__Issue:__ If no width or height are specified (ie, `<Image src="some-image.png />`), the image won't render.

__Fix:__ When no width / height is set, use the image dimensions as the default.

This also wires up the `Skia.Image.width` / `sk_image_get_width` and `Skia.Image.height`/ `sk_image_get_height` APIs