### PR TITLE
fix(box-shadow): Toggling box-shadow style had no effect

### DIFF
--- a/packages/reason-skia/examples/skia-cli/SkiaCli.re
+++ b/packages/reason-skia/examples/skia-cli/SkiaCli.re
@@ -45,7 +45,7 @@ let draw = canvas => {
   Paint.setColor(fill, Color.makeArgb(0xCCl, 0x00l, 0xFFl, 0x00l));
   Paint.setImageFilter(
     fill,
-    ImageFilter.makeDropShadow(
+    Some(ImageFilter.makeDropShadow(
       10.,
       10.,
       3.,
@@ -54,7 +54,7 @@ let draw = canvas => {
       DrawShadowAndForeground,
       None,
       None,
-    ),
+    )),
   );
   let rect2 = Rect.makeLtrb(120., 120., 520., 360.);
   Canvas.drawOval(canvas, rect2, fill);
@@ -109,6 +109,12 @@ let draw = canvas => {
       "Large measured text: " ++ string_of_float(largeMeasurement),
     );
   };
+
+  // Turn off drop shadow
+  Paint.setImageFilter(
+    fill,
+    None
+  );
 
   // Validate loading a non-existent file returns None, but doesn't crash
   let nonExistentData = Data.makeFromFileName("file-that-does-not-exist.png");

--- a/packages/reason-skia/examples/skia-cli/SkiaCli.re
+++ b/packages/reason-skia/examples/skia-cli/SkiaCli.re
@@ -45,16 +45,18 @@ let draw = canvas => {
   Paint.setColor(fill, Color.makeArgb(0xCCl, 0x00l, 0xFFl, 0x00l));
   Paint.setImageFilter(
     fill,
-    Some(ImageFilter.makeDropShadow(
-      10.,
-      10.,
-      3.,
-      3.,
-      Color.makeArgb(0xAAl, 0x00l, 0x00l, 0x00l),
-      DrawShadowAndForeground,
-      None,
-      None,
-    )),
+    Some(
+      ImageFilter.makeDropShadow(
+        10.,
+        10.,
+        3.,
+        3.,
+        Color.makeArgb(0xAAl, 0x00l, 0x00l, 0x00l),
+        DrawShadowAndForeground,
+        None,
+        None,
+      ),
+    ),
   );
   let rect2 = Rect.makeLtrb(120., 120., 520., 360.);
   Canvas.drawOval(canvas, rect2, fill);
@@ -111,10 +113,7 @@ let draw = canvas => {
   };
 
   // Turn off drop shadow
-  Paint.setImageFilter(
-    fill,
-    None
-  );
+  Paint.setImageFilter(fill, None);
 
   // Validate loading a non-existent file returns None, but doesn't crash
   let nonExistentData = Data.makeFromFileName("file-that-does-not-exist.png");

--- a/packages/reason-skia/src/Skia.rei
+++ b/packages/reason-skia/src/Skia.rei
@@ -209,7 +209,7 @@ module Paint: {
 
   let setStyle: (t, style) => unit;
   let setStrokeWidth: (t, float) => unit;
-  let setImageFilter: (t, ImageFilter.t) => unit;
+  let setImageFilter: (t, option(ImageFilter.t)) => unit;
   let setTypeface: (t, Typeface.t) => unit;
   let setLcdRenderText: (t, bool) => unit;
   let setSubpixelText: (t, bool) => unit;

--- a/packages/reason-skia/src/wrapped/bindings/SkiaWrappedBindings.re
+++ b/packages/reason-skia/src/wrapped/bindings/SkiaWrappedBindings.re
@@ -351,7 +351,7 @@ module M = (F: FOREIGN) => {
     let setImageFilter =
       foreign(
         "sk_paint_set_imagefilter",
-        t @-> ImageFilter.t @-> returning(void),
+        t @-> ptr_opt(SkiaTypes.ImageFilter.t) @-> returning(void),
       );
 
     let getTextEncoding =

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -306,6 +306,37 @@ class viewNode (()) = {
 
     let borderRadius = style.borderRadius;
     Skia.Rect.Mutable.setLtrb(~out=_helperRect, 0., 0., width, height);
+
+    let color = Color.multiplyAlpha(opacity, style.backgroundColor);
+    let colorAlpha = Color.getAlpha(color);
+
+    // Draw the shadow before anything else, so we don't clip the border
+    let isDrawingShadow = style.boxShadow.blurRadius > 0.1;
+
+    if (isDrawingShadow) {
+      let shadowImageFilter = makeShadowImageFilter(style.boxShadow);
+      Skia.Paint.setImageFilter(_fillPaint, Some(shadowImageFilter));
+
+      // This isn't perfect - we're redrawing the background color again, later,
+      // which might cause issues when the background color is non-opaque.
+      // The issue is, to use the `setImageFilter` stratey for rendering a shadow,
+      // we need to render _something_. We could consider instead drawing a blurred, offset
+      // rectangle underneath...
+      let shadowInteriorColor = Color.toSkia(color);
+      Skia.Paint.setColor(_fillPaint, shadowInteriorColor);
+
+      Revery_Draw.CanvasContext.drawRect(
+        ~rect=_helperRect,
+        ~paint=_fillPaint,
+        canvas,
+      );
+
+      // Reset the image filter, as the `_fillPaint` is stateful - if we don't reset it,
+      // then if the style changes such that there should be no shadow drawn, `_fillPaint`
+      // will still have the draw-shadow image filter applied.
+      Skia.Paint.setImageFilter(_fillPaint, None);
+    };
+
     Skia.RRect.setRectXy(
       _outerRRect,
       _helperRect,
@@ -316,23 +347,7 @@ class viewNode (()) = {
     let innerRRect =
       renderBorders(~canvas, ~style, ~outerRRect=_outerRRect, ~opacity);
 
-    let color = Color.multiplyAlpha(opacity, style.backgroundColor);
-    let colorAlpha = Color.getAlpha(color);
     if (colorAlpha > 0.001) {
-      // switch (style.boxShadow) {
-      // | {xOffset: 0., yOffset: 0., blurRadius: 0., spreadRadius: 0., color: _} =>
-      // ()
-      // | boxShadow => {
-      if (style.boxShadow.blurRadius != 0.) {
-        /*  print_endline(
-              "drawing shadow..." ++ string_of_float(style.boxShadow.blurRadius),
-            );*/
-        let shadowImageFilter = makeShadowImageFilter(style.boxShadow);
-        Skia.Paint.setImageFilter(_fillPaint, shadowImageFilter);
-      };
-      // }
-      // };
-
       let skiaColor = Color.toSkia(color);
       Skia.Paint.setColor(_fillPaint, skiaColor);
 


### PR DESCRIPTION
__Issue:__ If a `boxShadow(...)` style was set on a node, and then turned off later, the box-shadow would continue to be shown.

__Defect:__ When `boxShadow(..)` is set - we add an image filter onto the `Skia.Paint.t` owned by the node. This is stateful - if we don't do anything, the box shadow image filter will continue to be applied.

__Fix:__ Turn off the image filter when we don't need it anymore.

This also moves the box-shadow rendering to occur before the border and interior elements are painted. Without this, the box-shadow would be rendered along with the interior element, which would actually draw part of the shadow over the border. I think a better flow would be to draw the interior element first w/ a shadow, and _then_ the borders - but right now, we use the borders to calculate the interior element positioning.