### PR TITLE
feat(style): Bring back `opacity` style

### DIFF
--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -505,6 +505,7 @@ let alignSelf = a => `AlignSelf(alignment(a));
 
 let cursor = c => `Cursor(Some(c));
 
+let opacity = o => `Opacity(o);
 let transform = t => `Transform(t);
 let boxShadow = (~xOffset, ~yOffset, ~spreadRadius, ~blurRadius, ~color) =>
   `BoxShadow(BoxShadow.{xOffset, yOffset, spreadRadius, blurRadius, color});
@@ -669,6 +670,7 @@ let merge = (~source, ~target) =>
               | (`BorderVertical(_), `BorderVertical(_)) => targetStyle
               | (`BorderRadius(_), `BorderRadius(_)) => targetStyle
               | (`Transform(_), `Transform(_)) => targetStyle
+              | (`Opacity(_), `Opacity(_)) => targetStyle
               | (`PointerEvents(_), `PointerEvents(_)) => targetStyle
               | (`Opacity(_), `Opacity(_)) => targetStyle
               | (`BoxShadow(_), `BoxShadow(_)) => targetStyle

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -672,7 +672,6 @@ let merge = (~source, ~target) =>
               | (`Transform(_), `Transform(_)) => targetStyle
               | (`Opacity(_), `Opacity(_)) => targetStyle
               | (`PointerEvents(_), `PointerEvents(_)) => targetStyle
-              | (`Opacity(_), `Opacity(_)) => targetStyle
               | (`BoxShadow(_), `BoxShadow(_)) => targetStyle
               | (newRule, _) => newRule
               }


### PR DESCRIPTION
The `opacity` style option was removed in #540 , in trying to factor to semantic components. However, since we don't have that yet (dependent on some larger refactorings, as discussed in #489 ) - we should bring this back.

I'd prefer to use a more semantic component like `<Opacity />`, however, in the current design, that can impact layout, as every primitive has an associated layout node.