### PR TITLE
feat(api): CanvasContext - Add createLayer / drawLayer methods

### DIFF
--- a/examples/CanvasExample.re
+++ b/examples/CanvasExample.re
@@ -92,29 +92,36 @@ module Sample = {
           );
           let rect = Skia.Rect.makeLtrb(200., 150., 250., 300.);
           CanvasContext.drawOval(~rect, ~paint=fill, canvasContext);
-          let red = Skia.Color.makeArgb(0xFFl, 0xFFl, 0x00l, 0x00l);
-          let blue = Skia.Color.makeArgb(0xFFl, 0x00l, 0x00l, 0xFFl);
+//          let red = Skia.Color.makeArgb(0xFFl, 0xFFl, 0x00l, 0x00l);
+//          let blue = Skia.Color.makeArgb(0xFFl, 0x00l, 0x00l, 0xFFl);
           let paint = Skia.Paint.make();
-          let linearGradient =
-            Skia.Shader.makeLinearGradient2(
-              ~startPoint=Skia.Point.make(200.0, 200.0),
-              ~stopPoint=Skia.Point.make(220.0, 220.0),
-              ~startColor=red,
-              ~stopColor=blue,
-              ~tileMode=`clamp,
-            );
-          Skia.Paint.setShader(paint, linearGradient);
+//          let linearGradient =
+//            Skia.Shader.makeLinearGradient2(
+//              ~startPoint=Skia.Point.make(200.0, 200.0),
+//              ~stopPoint=Skia.Point.make(220.0, 220.0),
+//              ~startColor=red,
+//              ~stopColor=blue,
+//              ~tileMode=`clamp,
+//            );
+//          Skia.Paint.setShader(paint, linearGradient);
           Skia.Paint.setColor(
             paint,
             Skia.Color.makeArgb(0xFFl, 0x00l, 0xFFl, 0x00l),
           );
+
+          // Test out some layers...
+
+          let layer = CanvasContext.createLayer(~width=128l, ~height=128l, canvasContext);
           CanvasContext.drawCircle(
-            ~x=225.,
-            ~y=225.,
-            ~radius=100.,
+            ~x=32.,
+            ~y=32.,
+            ~radius=16.,
             ~paint,
-            canvasContext,
+            layer,
           );
+
+          CanvasContext.drawLayer(~layer, ~x=300., ~y=300., canvasContext);
+          CanvasContext.drawLayer(~layer, ~x=264., ~y=264., canvasContext);
         }}
       />
     </View>;

--- a/examples/CanvasExample.re
+++ b/examples/CanvasExample.re
@@ -92,26 +92,33 @@ module Sample = {
           );
           let rect = Skia.Rect.makeLtrb(200., 150., 250., 300.);
           CanvasContext.drawOval(~rect, ~paint=fill, canvasContext);
-//          let red = Skia.Color.makeArgb(0xFFl, 0xFFl, 0x00l, 0x00l);
-//          let blue = Skia.Color.makeArgb(0xFFl, 0x00l, 0x00l, 0xFFl);
+          let red = Skia.Color.makeArgb(0xFFl, 0xFFl, 0x00l, 0x00l);
+          let blue = Skia.Color.makeArgb(0xFFl, 0x00l, 0x00l, 0xFFl);
+          // Test out some layers...
+
+          let layer =
+            CanvasContext.createLayer(
+              ~width=128l,
+              ~height=128l,
+              canvasContext,
+            );
+
+          // Draw a circle onto our new layer...
           let paint = Skia.Paint.make();
-//          let linearGradient =
-//            Skia.Shader.makeLinearGradient2(
-//              ~startPoint=Skia.Point.make(200.0, 200.0),
-//              ~stopPoint=Skia.Point.make(220.0, 220.0),
-//              ~startColor=red,
-//              ~stopColor=blue,
-//              ~tileMode=`clamp,
-//            );
-//          Skia.Paint.setShader(paint, linearGradient);
+          let linearGradient =
+            Skia.Shader.makeLinearGradient2(
+              ~startPoint=Skia.Point.make(16., 16.0),
+              ~stopPoint=Skia.Point.make(48.0, 48.0),
+              ~startColor=red,
+              ~stopColor=blue,
+              ~tileMode=`clamp,
+            );
+          Skia.Paint.setShader(paint, linearGradient);
           Skia.Paint.setColor(
             paint,
             Skia.Color.makeArgb(0xFFl, 0x00l, 0xFFl, 0x00l),
           );
 
-          // Test out some layers...
-
-          let layer = CanvasContext.createLayer(~width=128l, ~height=128l, canvasContext);
           CanvasContext.drawCircle(
             ~x=32.,
             ~y=32.,
@@ -120,8 +127,11 @@ module Sample = {
             layer,
           );
 
+          // And then draw the layer a bunch of places!
           CanvasContext.drawLayer(~layer, ~x=300., ~y=300., canvasContext);
           CanvasContext.drawLayer(~layer, ~x=264., ~y=264., canvasContext);
+          CanvasContext.drawLayer(~layer, ~x=264., ~y=300., canvasContext);
+          CanvasContext.drawLayer(~layer, ~x=300., ~y=264., canvasContext);
         }}
       />
     </View>;

--- a/packages/reason-skia/src/Skia.re
+++ b/packages/reason-skia/src/Skia.re
@@ -892,13 +892,8 @@ module Surface = {
     };
   };
 
-  let draw = (
-    ~paint=None,
-    ~canvas,
-    ~x,
-    ~y,
-    surface
-  ) => SkiaWrapped.Surface.draw(surface, canvas, x, y, paint);
+  let draw = (~paint=None, ~canvas, ~x, ~y, surface) =>
+    SkiaWrapped.Surface.draw(surface, canvas, x, y, paint);
 
   let getCanvas = SkiaWrapped.Surface.getCanvas;
   let makeImageSnapshot = surface => {

--- a/packages/reason-skia/src/Skia.re
+++ b/packages/reason-skia/src/Skia.re
@@ -892,6 +892,14 @@ module Surface = {
     };
   };
 
+  let draw = (
+    ~paint=None,
+    ~canvas,
+    ~x,
+    ~y,
+    surface
+  ) => SkiaWrapped.Surface.draw(surface, canvas, x, y, paint);
+
   let getCanvas = SkiaWrapped.Surface.getCanvas;
   let makeImageSnapshot = surface => {
     let imageSnapshot = SkiaWrapped.Surface.allocateImageSnapshot(surface);

--- a/packages/reason-skia/src/Skia.rei
+++ b/packages/reason-skia/src/Skia.rei
@@ -521,7 +521,9 @@ module Surface: {
     option(t);
 
   // Draw surface [surface] onto a [canvas] at the specified [x,y] points.
-  let draw: (~paint: option(Paint.t)=?, ~canvas: Canvas.t, ~x: float, ~y: float, t) => unit;
+  let draw:
+    (~paint: option(Paint.t)=?, ~canvas: Canvas.t, ~x: float, ~y: float, t) =>
+    unit;
   let makeImageSnapshot: t => Image.t;
   let getCanvas: t => Canvas.t;
   let getWidth: t => int;

--- a/packages/reason-skia/src/Skia.rei
+++ b/packages/reason-skia/src/Skia.rei
@@ -520,6 +520,8 @@ module Surface: {
     ) =>
     option(t);
 
+  // Draw surface [surface] onto a [canvas] at the specified [x,y] points.
+  let draw: (~paint: option(Paint.t)=?, ~canvas: Canvas.t, ~x: float, ~y: float, t) => unit;
   let makeImageSnapshot: t => Image.t;
   let getCanvas: t => Canvas.t;
   let getWidth: t => int;

--- a/packages/reason-skia/src/wrapped/bindings/SkiaWrappedBindings.re
+++ b/packages/reason-skia/src/wrapped/bindings/SkiaWrappedBindings.re
@@ -1056,9 +1056,16 @@ module M = (F: FOREIGN) => {
       );
     let delete = foreign("sk_surface_unref", t @-> returning(void));
 
-    let draw = foreign("sk_surface_draw", 
-      t @-> Canvas.t @-> float @-> float @-> ptr_opt(SkiaTypes.Paint.t)
-      @-> returning(void));
+    let draw =
+      foreign(
+        "sk_surface_draw",
+        t
+        @-> Canvas.t
+        @-> float
+        @-> float
+        @-> ptr_opt(SkiaTypes.Paint.t)
+        @-> returning(void),
+      );
 
     let getCanvas =
       foreign("sk_surface_get_canvas", t @-> returning(Canvas.t));

--- a/packages/reason-skia/src/wrapped/bindings/SkiaWrappedBindings.re
+++ b/packages/reason-skia/src/wrapped/bindings/SkiaWrappedBindings.re
@@ -1056,6 +1056,10 @@ module M = (F: FOREIGN) => {
       );
     let delete = foreign("sk_surface_unref", t @-> returning(void));
 
+    let draw = foreign("sk_surface_draw", 
+      t @-> Canvas.t @-> float @-> float @-> ptr_opt(SkiaTypes.Paint.t)
+      @-> returning(void));
+
     let getCanvas =
       foreign("sk_surface_get_canvas", t @-> returning(Canvas.t));
     let allocateImageSnapshot =

--- a/src/Draw/CanvasContext.re
+++ b/src/Draw/CanvasContext.re
@@ -101,14 +101,13 @@ let createLayer = (~width, ~height, context: t) => {
   let imageInfo = ImageInfo.make(width, height, Rgba8888, Premul, None);
 
   let createCpuSurface = () => {
-      Log.tracef(m => m("Created CPU surface: %ld x %ld", width, height));
-      Surface.makeRaster(imageInfo, 0, None);
+    Log.tracef(m => m("Created CPU surface: %ld x %ld", width, height));
+    Surface.makeRaster(imageInfo, 0, None);
   };
 
   let (gpuContext, surface) =
     switch (context.maybeGPUContext) {
-    | None =>
-      (None, createCpuSurface());
+    | None => (None, createCpuSurface())
     | Some(gpuContext) as outContext =>
       Log.trace("Trying to create GPU surface...");
       let surfaceProps = SurfaceProps.make(Unsigned.UInt32.of_int(0), RgbH);
@@ -123,16 +122,18 @@ let createLayer = (~width, ~height, context: t) => {
           false,
         );
 
-        // The gpu surface creation can fail, so we should be
-        // prepared to fall back to a CPU surface.
-        switch (maybeGpuSurface) {
-        | Some(surface) =>
-        Log.tracef(m => m("Successfully created GPU surface: %ld x %ld", width, height));
-        (outContext, surface)
-        | None =>
+      // The gpu surface creation can fail, so we should be
+      // prepared to fall back to a CPU surface.
+      switch (maybeGpuSurface) {
+      | Some(surface) =>
+        Log.tracef(m =>
+          m("Successfully created GPU surface: %ld x %ld", width, height)
+        );
+        (outContext, surface);
+      | None =>
         Log.warn("Unable to create GPU surface; falling back to CPU surface");
         (None, createCpuSurface());
-        };
+      };
     };
 
   {


### PR DESCRIPTION
This adds supporting for creating new GPU-backed or CPU-backed surfaces that we can render to, cache, and re-draw later - adding a new method `createLayer` and `drawLayer` on the `CanvasContext`.

This lets us create a layer from an existing `CanvasContext.t`:
```
          let layer =
            CanvasContext.createLayer(
              ~width=128l,
              ~height=128l,
              canvasContext,
            );
```

... then draw to it:

```
          CanvasContext.drawCircle(
            ~x=32.,
            ~y=32.,
            ~radius=16.,
            ~paint,
            layer,
          );
```

Then, we can draw the layer on the current canvas:
```
          // And then draw the layer a bunch of places!
          CanvasContext.drawLayer(~layer, ~x=300., ~y=300., canvasContext);
          CanvasContext.drawLayer(~layer, ~x=264., ~y=264., canvasContext);
          CanvasContext.drawLayer(~layer, ~x=264., ~y=300., canvasContext);
          CanvasContext.drawLayer(~layer, ~x=300., ~y=264., canvasContext);
```

So it gets repeated multiple times:
![image](https://user-images.githubusercontent.com/13532591/94345380-3972ce00-ffda-11ea-81d8-100e28dab385.png)

The motivation for this change is ultimately to improve performance - right now, Revery's rendering model is to redraw the entire screen, every time something changes. This is OK for small applications, but for larger applications - like Onivim:

![image](https://user-images.githubusercontent.com/13532591/94345408-5e674100-ffda-11ea-9668-421c9cab4a04.png)

It doesn't make sense for us to redraw the file explorer when the editor cursor moves... or for us to redraw the minimap when we scroll in the file explorer.  In other words - we're redrawing elements way more often than we should be!

The next step is to provide a compositing primitive - a `<Layer />` component - that can render to one of these surfaces, and then cache until it actually needs to render. In the case of Onivim, we could wrap parts of the UI in this primitive - the editor surface, the file explorer, the status bar, etc - so that we are only re-rendering the parts of the screen that are relevant.

It's a lot like how the browser creates separate layers based on some properties (ie, if you use `transform`, the browser will create a layer that can be independently animated). This is just a bit more explicit and requires the developer to opt-in.

Still need to figure out the exact API, but it'd be something like: `<Layer style renderIf={Condition((!=), [state1,state2,...] />` - kind of like the condition we use for the effect hook. 