### PR TITLE
fix(rendering): Aliasing in rounded borders

### DIFF
--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -288,7 +288,12 @@ let makeShadowImageFilter = boxShadow => {
 class viewNode (()) = {
   as _this;
   inherit (class node)() as _super;
-  val _fillPaint = Skia.Paint.make();
+  val _fillPaint = {
+    let paint = Skia.Paint.make();
+    // Set antialias for fill paint, so that rounded edges for the inner rectangle look OK
+    Skia.Paint.setAntiAlias(paint, true);
+    paint;
+  };
   val _outerRRect = Skia.RRect.make();
   val _helperRect = Skia.Rect.makeLtrb(0., 0., 0., 0.);
   pub! draw = (parentContext: NodeDrawContext.t) => {


### PR DESCRIPTION
__Issue:__

When using rounded borders, even though we set the anti-alias property on the border paint object, we can still end up with jagged edges:

![Screen Shot 2020-09-29 at 12 03 40 PM](https://user-images.githubusercontent.com/13532591/94604248-3ed74f00-024c-11eb-8201-0d63800e729f.png)

__Defect:__

The inner-rounded rectangle wasn't getting anti-aliasing applied, so jagged edges could still sneak through.

__Fix:__

Set anti-alias on the view node paint as well - this smooths out the edge, which is visually superior:

![Screen Shot 2020-09-29 at 12 01 54 PM](https://user-images.githubusercontent.com/13532591/94604308-56163c80-024c-11eb-825a-92e1d0fcbebf.png)
