### PR TITLE
fix(font-fallback): Hang when trying to shape 'flaming heart' emoji

### DIFF
--- a/src/Font/FontCache.re
+++ b/src/Font/FontCache.re
@@ -238,18 +238,13 @@ let generateShapes:
           );
           None;
         };
-      Option.bind(
-        maybeUchar,
-        uchar => {
-          // Only fallback if the character is non-ASCII (UTF-8)
-
-          Log.debugf(m => m("-- Got uchar: %d", Uchar.to_int(uchar)));
-          if (Uchar.to_int(uchar) > 256) {
-            fallback(uchar);
-          } else {
-            None;
-          };
-        },
+      Option.bind(maybeUchar, uchar =>
+        // Only fallback if the character is non-ASCII (UTF-8)
+        if (Uchar.to_int(uchar) > 256) {
+          fallback(uchar);
+        } else {
+          None;
+        }
       )
       |> (
         fun

--- a/src/Font/FontCache.re
+++ b/src/Font/FontCache.re
@@ -238,14 +238,15 @@ let generateShapes:
           );
           None;
         };
-      Option.bind(maybeUchar, uchar =>
+      Option.bind(maybeUchar, uchar
         // Only fallback if the character is non-ASCII (UTF-8)
-        if (Uchar.to_int(uchar) > 256) {
-          fallback(uchar);
-        } else {
-          None;
-        }
-      )
+        =>
+          if (Uchar.to_int(uchar) > 256) {
+            fallback(uchar);
+          } else {
+            None;
+          }
+        )
       |> (
         fun
         | Some(_) as font => {

--- a/src/Font/FontCache.re
+++ b/src/Font/FontCache.re
@@ -123,7 +123,9 @@ let load: option(Skia.Typeface.t) => result(t, string) =
         switch (skiaTypeface, harfbuzzFace) {
         | (Some(skiaFace), Some(Ok(hbFace))) =>
           Event.dispatch(onFontLoaded, ());
-          Log.info("Loaded : " ++ Skia.Typeface.getFamilyName(skiaFace));
+          Log.infof(m =>
+            m("Loaded: %s", Skia.Typeface.getFamilyName(skiaFace))
+          );
           Ok({
             hbFace,
             skiaFace,
@@ -221,25 +223,34 @@ let generateShapes:
   (~fallback, ~features, font, str) => {
     let fallbackFor = (~byteOffset, str) => {
       Log.debugf(m =>
-        m("Resolving fallback for: %s at byte offset %d", str, byteOffset)
+        m(
+          "Resolving fallback for: %s at byte offset %d - source font is: %s",
+          str,
+          byteOffset,
+          font.skiaFace |> Skia.Typeface.getFamilyName,
+        )
       );
       let maybeUchar =
         try(Some(Zed_utf8.extract(str, byteOffset))) {
         | exn =>
           Log.debugf(m =>
-            m("Unable to get uchar: %s", Printexc.to_string(exn))
+            m("Unable to get uchar from string: %s", Printexc.to_string(exn))
           );
           None;
         };
-      Option.bind(maybeUchar, uchar
-        // Only fallback if the character is non-ASCII (UTF-8)
-        =>
+      Option.bind(
+        maybeUchar,
+        uchar => {
+          // Only fallback if the character is non-ASCII (UTF-8)
+
+          Log.debugf(m => m("-- Got uchar: %d", Uchar.to_int(uchar)));
           if (Uchar.to_int(uchar) > 256) {
             fallback(uchar);
           } else {
             None;
-          }
-        )
+          };
+        },
+      )
       |> (
         fun
         | Some(_) as font => {
@@ -298,13 +309,14 @@ let generateShapes:
         | Ok(fallbackFont) =>
           Log.debugf(m =>
             m(
-              "Got fallback font - id: %d name: %s (from source font - id: %d %s)",
+              "Got fallback font - id: %d name: %s (from source font - id: %d %s) - attempt %d",
               fallbackFont.skiaFace
               |> Skia.Typeface.getUniqueID
               |> Int32.to_int,
               fallbackFont.skiaFace |> Skia.Typeface.getFamilyName,
               font.skiaFace |> Skia.Typeface.getUniqueID |> Int32.to_int,
               font.skiaFace |> Skia.Typeface.getFamilyName,
+              attempts,
             )
           );
 
@@ -359,7 +371,8 @@ let generateShapes:
             ...acc,
           ];
           loopShapes(
-            ~attempts=0,
+            // TODO: Bring back fix! Just see if we can repro
+            ~attempts,
             ~stopCluster,
             ~acc,
             ~index=index + 1,

--- a/test/Font/FontCacheTest.re
+++ b/test/Font/FontCacheTest.re
@@ -221,5 +221,24 @@ describe("FontCache", ({describe, test, _}) => {
         expect.int(fallbackSensor^).toBe(0);
       };
     });
+    test(
+      "heart-on-fire case: hole with unresolved glyph in middle shouldn't hang",
+      ({expect, _}) => {
+      // Regression Test:
+      // From the heart-on-fire test case: https://unicode.org/Public/emoji/13.1/emoji-test.txt
+      // We don't handle it quite correctly currently, but we certainly shouldn't hang!
+
+      let str =
+        Zed_utf8.make(1, Uchar.of_int(0x2764))
+        ++ Zed_utf8.make(1, Uchar.of_int(0xFE0F))
+        ++ Zed_utf8.make(1, Uchar.of_int(0x200D))
+        ++ Zed_utf8.make(1, Uchar.of_int(0x1F525));
+
+      let {glyphStrings}: ShapeResult.t =
+        FontCache.shape(~fallback, font, str);
+
+      // ...really just making sure we didn't hang.
+      expect.equal(true, glyphStrings |> runCount > 1);
+    });
   });
 });


### PR DESCRIPTION
__Issue:__ While working on https://github.com/onivim/oni2/pull/2563, I observed a hang in the editor some emojis, like the 'heart on fire' emoji:
```
2764 FE0F 200D 1F525                                   ; fully-qualified     # ❤️‍🔥 E13.1 heart on fire
```
From these cases: https://unicode.org/Public/emoji/13.1/emoji-test.txt

__Defect:__ We use a counter to break cycles in the font-fallback resolution strategy (`attempts`), so that we don't get in an infinite loop when we shape, fallback to a font, and then try shaping again. 

However, in this case, we had a hole spanning multiple unicode characters - the heart (`2764`) would resolve correctly, but then the modifiers would not discover a fallback font. In this case, we were resetting the `attempts` counter, and would fail to completely resolve the hole, causing us to spin.

The rendering still isn't completely correct for this, as we use unresolved glyphs for the modifiers. We should be smart enough to recognize grapheme clusters and that these modifiers should not be drawn as unresolved glyphs. This fix, though, does prevent us from hanging in this case.

__Fix:__ Don't reset `attempts` in this case. Add test case covering this sort of emoji.