### PR TITLE
perf(diagnostics): Add naming for timers, add trace logging

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,7 @@ jobs:
     # ESY__NPM_ROOT: /usr/local/lib/node_modules/esy
 
   steps:
-  - script: brew update
+  - script: brew update-reset
   - script: brew install libpng ragel
   - script: node --version
   - template: .ci/restore-build-cache.yml
@@ -91,7 +91,7 @@ jobs:
     # ESY__NPM_ROOT: /usr/local/lib/node_modules/esy
 
   steps:
-  - script: brew update
+  - script: brew update-reset
   - script: brew install libpng ragel
   - script: node --version
   - template: .ci/restore-build-cache.yml

--- a/examples/AnalogClock.re
+++ b/examples/AnalogClock.re
@@ -56,7 +56,11 @@ module AnalogClock = {
         OnMount,
         () => {
           let clear =
-            Tick.interval(_ => dispatch(UpdateTime), Time.seconds(1));
+            Tick.interval(
+              ~name="Clock Timer",
+              _ => dispatch(UpdateTime),
+              Time.seconds(1),
+            );
           Some(clear);
         },
       );

--- a/examples/GameOfLife.re
+++ b/examples/GameOfLife.re
@@ -419,7 +419,11 @@ module GameOfLiveComponent = {
         ? dispatch(StopTimer)
         : {
           let dispose =
-            Tick.interval(t => dispatch(TimerTick(t)), Time.zero);
+            Tick.interval(
+              ~name="GameOfLife Timer",
+              t => dispatch(TimerTick(t)),
+              Time.zero,
+            );
           dispatch(StartTimer(dispose));
         };
 

--- a/examples/Hello.re
+++ b/examples/Hello.re
@@ -36,9 +36,14 @@ module Logo = {
   let%component make = () => {
     let%hook (shouldRotate, setShouldRotate) = Hooks.state(true);
     let%hook ((rotationX, rotationY), _animationState, resetRotation) =
-      Hooks.animation(rotationAnimation, ~active=shouldRotate);
+      Hooks.animation(
+        ~name="Rotation Animation",
+        rotationAnimation,
+        ~active=shouldRotate,
+      );
     let%hook (opacity, setOpacity) = Hooks.state(1.0);
-    let%hook transitionedOpacity = Hooks.transition(opacity);
+    let%hook transitionedOpacity =
+      Hooks.transition(~name="Opacity Transition Animation", opacity);
 
     <View>
       <Opacity opacity=transitionedOpacity>
@@ -92,6 +97,7 @@ module AnimatedText = {
   let%component make = (~text: string, ~delay: Time.t, ()) => {
     let%hook (animatedOpacity, _state, _reset) =
       Hooks.animation(
+        ~name="Text Opacity Animation",
         Animation.(
           animate(Time.seconds(1))
           |> delay(Time.seconds(1))
@@ -101,6 +107,7 @@ module AnimatedText = {
       );
     let%hook (translate, _state, _reset) =
       Hooks.animation(
+        ~name="Text Translate Animation",
         Animation.animate(Time.ms(500))
         |> Animation.delay(delay)
         |> Animation.ease(Easing.easeOut)

--- a/examples/SpringExample.re
+++ b/examples/SpringExample.re
@@ -73,6 +73,7 @@ module Example = {
       Hooks.reducer(~initialState=256.0, (value, _) => value);
     let%hook (logoWidth, setImmediately) =
       Hooks.spring(
+        ~name="Spring",
         ~target=targetPosition,
         ~initialState=
           Spring.{

--- a/examples/Stopwatch.re
+++ b/examples/Stopwatch.re
@@ -57,7 +57,11 @@ module Clock = {
          */
         : {
           let dispose =
-            Tick.interval(t => dispatch(TimerTick(t)), Time.zero);
+            Tick.interval(
+              ~name="Stopwatch Interval",
+              t => dispatch(TimerTick(t)),
+              Time.zero,
+            );
 
           /* We'll also keep a handle on the dispose function so we can make sure its called on stop*/
           dispatch(Start(dispose));

--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -37,7 +37,11 @@ module Cursor = {
         OnMount,
         () => {
           let clear =
-            Tick.interval(time => dispatch(Tick(time)), Time.ms(16));
+            Tick.interval(
+              ~name="Revery:Input:Cursor Blink Interval",
+              time => dispatch(Tick(time)),
+              Time.ms(16),
+            );
           Some(clear);
         },
       );

--- a/src/UI_Components/ScrollView.re
+++ b/src/UI_Components/ScrollView.re
@@ -45,11 +45,17 @@ let bounceAnimationHook = (scrollPosition, bouncingState, setBouncingState) => {
   switch (bouncingState) {
   | Idle =>
     // TODO: Why isn't Animation.const always sufficient to stop the timer?
-    Hooks.animation(~active=false, Animation.const(scrollPosition))
+    Hooks.animation(
+      ~name="Revery:ScrollView:Bounce Animation Hook (Idle)",
+      ~active=false,
+      Animation.const(scrollPosition),
+    )
 
   | Bouncing(force) =>
     Hooks.animation(
-      bounceAnimation(~origin=scrollPosition, ~force), ~onComplete=() =>
+      ~name="Revery:ScrollView:Bounce Animation Hook (Bouncing)",
+      bounceAnimation(~origin=scrollPosition, ~force),
+      ~onComplete=() =>
       setBouncingState(_ => Idle)
     )
   };

--- a/src/UI_Components/Ticker.re
+++ b/src/UI_Components/Ticker.re
@@ -12,13 +12,14 @@ let%component make =
                 ~children=React.empty,
                 ~onTick=noop,
                 ~tickRate=Time.seconds(1),
+                ~name="<Ticker />",
                 (),
               ) => {
   let%hook () =
     Hooks.effect(
       OnMount,
       () => {
-        let dispose = Revery_Core.Tick.interval(onTick, tickRate);
+        let dispose = Revery_Core.Tick.interval(~name, onTick, tickRate);
 
         Some(dispose);
       },

--- a/src/UI_Components/Ticker.rei
+++ b/src/UI_Components/Ticker.rei
@@ -24,6 +24,7 @@ let make:
     ~children: Revery_UI.element=?,
     ~onTick: tickFunction=?,
     ~tickRate: Revery_Core.Time.t=?,
+    ~name: string=?,
     unit
   ) =>
   Brisk_reconciler.element(Revery_UI.viewNode);

--- a/src/UI_Hooks/Revery_UI_Hooks.re
+++ b/src/UI_Hooks/Revery_UI_Hooks.re
@@ -11,9 +11,10 @@ include Tick;
 let time = Timer.time;
 let timer = Timer.timer;
 
-let animation = (~active=true, ~onComplete=() => (), animation) => {
+let animation = (~active=true, ~onComplete=() => (), ~name, animation) => {
   let%hook (isCompleted, setCompleted) = state(false);
-  let%hook (time, resetTimer) = timer(~active=active && !isCompleted, ());
+  let%hook (time, resetTimer) =
+    timer(~name, ~active=active && !isCompleted, ());
 
   let (value, animationState) = Animation.apply(time, animation);
 
@@ -48,6 +49,7 @@ module Internal = {
         ~delay=Time.zero,
         ~easing=Easing.linear,
         ~initialValue=?,
+        ~name,
         specifiedTargetValue,
       ) => {
     let initialValue =
@@ -71,7 +73,8 @@ module Internal = {
       |> Animation.ease(easing)
       |> Animation.tween(startValue, targetValue);
 
-    let%hook (value, _animationState, resetTimer) = animation(~active, anim);
+    let%hook (value, _animationState, resetTimer) =
+      animation(~name, ~active, anim);
 
     let value = active ? value : specifiedTargetValue;
 

--- a/src/UI_Hooks/Spring.re
+++ b/src/UI_Hooks/Spring.re
@@ -2,7 +2,14 @@ module Time = Revery_Core.Time;
 module Spring = Revery_UI.Spring;
 
 let spring =
-    (~enabled=true, ~target, ~initialState=?, ~restThreshold=0.1, options) => {
+    (
+      ~enabled=true,
+      ~name,
+      ~target,
+      ~initialState=?,
+      ~restThreshold=0.1,
+      options,
+    ) => {
   let initialState =
     switch (initialState) {
     | Some(state) => state
@@ -18,7 +25,7 @@ let spring =
       || Float.abs(target -. previousState^.value) > restThreshold
     );
 
-  let%hook (time, _) = Timer.timer(~active=isActive, ());
+  let%hook (time, _) = Timer.timer(~name, ~active=isActive, ());
 
   let state = Spring.tick(target, previousState^, options, time);
   previousState := state;

--- a/src/UI_Hooks/Tick.re
+++ b/src/UI_Hooks/Tick.re
@@ -3,7 +3,7 @@ module Tick = Revery_Core.Tick;
 
 module Hooks = Revery_UI.React.Hooks;
 
-let tick = (~tickRate=Time.seconds(1), onTick) => {
+let tick = (~tickRate=Time.seconds(1), ~name, onTick) => {
   // Because Tick.interval is only called once, initiallly, with the initial
   // onTick function, to execute the latest onTick function we either have to
   // dispose and recreate it for every call, or use a mutable variable to replace
@@ -15,7 +15,7 @@ let tick = (~tickRate=Time.seconds(1), onTick) => {
     Hooks.effect(
       OnMount,
       () => {
-        let dispose = Tick.interval(t => onTickRef^(t), tickRate);
+        let dispose = Tick.interval(~name, t => onTickRef^(t), tickRate);
 
         Some(dispose);
       },

--- a/src/UI_Hooks/Tick.rei
+++ b/src/UI_Hooks/Tick.rei
@@ -5,6 +5,7 @@ module Time = Revery_Core.Time;
 let tick:
   (
     ~tickRate: Time.t=?,
+    ~name: string,
     Time.t => unit,
     t((ref(Time.t => unit), Effect.t(Effect.onMount)) => 'a, 'b)
   ) =>

--- a/src/UI_Hooks/Timer.re
+++ b/src/UI_Hooks/Timer.re
@@ -2,14 +2,14 @@ open Effect;
 open Reducer;
 open Tick;
 
-let time = (~tickRate=Time.zero, ()) => {
+let time = (~tickRate=Time.zero, ~name, ()) => {
   let%hook (time, setTime) = reducer(~initialState=Time.now(), t => t);
-  let%hook () = tick(~tickRate, _dt => setTime(_t => Time.now()));
+  let%hook () = tick(~tickRate, ~name, _dt => setTime(_t => Time.now()));
 
   time;
 };
 
-let timer = (~tickRate=Time.zero, ~active=true, ()) => {
+let timer = (~tickRate=Time.zero, ~active=true, ~name, ()) => {
   let%hook (time, setTime) = reducer(~initialState=Time.now(), t => t);
   let%hook startTime = Ref.ref(time);
 
@@ -43,7 +43,7 @@ let timer = (~tickRate=Time.zero, ~active=true, ()) => {
 
         Option.iter(dispose => dispose(), lastDispose^);
 
-        let stopInterval = Revery_Core.Tick.interval(onTick, tickRate);
+        let stopInterval = Revery_Core.Tick.interval(~name, onTick, tickRate);
         lastDispose := Some(stopInterval);
 
         Some(stopInterval);

--- a/test/Core/TickTest.re
+++ b/test/Core/TickTest.re
@@ -18,7 +18,12 @@ describe("Ticker", ({describe, _}) => {
   describe("timeout", ({test, _}) => {
     test("calls once after tick time", ({expect, _}) => {
       let callCount = ref(0);
-      let _ignore = Tick.timeout(() => incr(callCount), Time.seconds(1));
+      let _ignore: unit => unit =
+        Tick.timeout(
+          ~name="Test timeout",
+          () => incr(callCount),
+          Time.seconds(1),
+        );
       TestTicker.incrementTime(Time.ms(1010));
       Tick.pump();
 
@@ -36,12 +41,17 @@ describe("Ticker", ({describe, _}) => {
       let outerCallCount = ref(0);
       let innerCallCount = ref(0);
 
-      let _ignore =
+      let _: unit => unit =
         Tick.timeout(
+          ~name="Outer timeout",
           () => {
             incr(outerCallCount);
-            let _ignore =
-              Tick.timeout(() => incr(innerCallCount), Time.ms(110));
+            let _: unit => unit =
+              Tick.timeout(
+                ~name="Inner timeout",
+                () => incr(innerCallCount),
+                Time.ms(110),
+              );
             ();
           },
           Time.zero,
@@ -67,7 +77,12 @@ describe("Ticker", ({describe, _}) => {
     });
     test("doesn't call if canceled", ({expect, _}) => {
       let callCount = ref(0);
-      let cancel = Tick.timeout(() => incr(callCount), Time.seconds(1));
+      let cancel =
+        Tick.timeout(
+          ~name="TestTick",
+          () => incr(callCount),
+          Time.seconds(1),
+        );
       TestTicker.incrementTime(Time.ms(500));
       Tick.pump();
 
@@ -82,8 +97,12 @@ describe("Ticker", ({describe, _}) => {
     test("calls after tick time", ({expect, _}) => {
       let callCount = ref(0);
 
-      let _ignore =
-        Tick.interval(_ => callCount := callCount^ + 1, Time.seconds(1));
+      let _: unit => unit =
+        Tick.interval(
+          ~name="TestInterval",
+          _ => callCount := callCount^ + 1,
+          Time.seconds(1),
+        );
 
       TestTicker.incrementTime(Time.ms(1010));
 
@@ -106,8 +125,12 @@ describe("Ticker", ({describe, _}) => {
     test("disposing tick subscription stops the tick", ({expect, _}) => {
       let callCount = ref(0);
 
-      let stop =
-        Tick.interval(_ => callCount := callCount^ + 1, Time.seconds(1));
+      let stop: unit => unit =
+        Tick.interval(
+          ~name="TestTick",
+          _ => callCount := callCount^ + 1,
+          Time.seconds(1),
+        );
 
       TestTicker.incrementTime(Time.ms(1010));
 

--- a/test/UI/HooksTest.re
+++ b/test/UI/HooksTest.re
@@ -11,7 +11,8 @@ describe("Hooks", ({describe, _}) => {
   describe("Timer", ({test, _}) => {
     module SingleTimer = {
       let%component make = (~timerActive, ()) => {
-        let%hook (_dt, _reset) = Hooks.timer(~active=timerActive, ());
+        let%hook (_dt, _reset) =
+          Hooks.timer(~name="SingleTimer", ~active=timerActive, ());
 
         <View />;
       };
@@ -19,8 +20,10 @@ describe("Hooks", ({describe, _}) => {
 
     module DoubleTimer = {
       let%component make = (~timer1Active, ~timer2Active, ()) => {
-        let%hook (_dt, _reset) = Hooks.timer(~active=timer1Active, ());
-        let%hook (_dt, _reset) = Hooks.timer(~active=timer2Active, ());
+        let%hook (_dt, _reset) =
+          Hooks.timer(~name="DoubleTimer1", ~active=timer1Active, ());
+        let%hook (_dt, _reset) =
+          Hooks.timer(~name="DoubleTimer2", ~active=timer2Active, ());
         <View />;
       };
     };
@@ -118,7 +121,7 @@ describe("Hooks", ({describe, _}) => {
   describe("Tick", ({test, _}) => {
     module Ticker = {
       let%component make = (~f, ()) => {
-        let%hook () = Hooks.tick(~tickRate=Time.zero, f);
+        let%hook () = Hooks.tick(~name="Ticker", ~tickRate=Time.zero, f);
 
         <View />;
       };


### PR DESCRIPTION
In Onivim, there is a case where we are stuck rendering in a loop, every frame (which will peg the CPU) - based on the trace logs that I've seen, it looks like a timer is constantly running - likely related to an animation, or a hook that isn't disposed properly.

This adds additional tracing for animations and timers, such that when the app is running with trace logging enabled, it will output the various named timers that are active - hopefully giving us enough information to get to the next round of fixes.