### PR TITLE
fix(hooks): Spring - bug when active is toggled

### DIFF
--- a/src/UI_Hooks/Spring.re
+++ b/src/UI_Hooks/Spring.re
@@ -27,7 +27,13 @@ let spring =
 
   let%hook (time, _) = Timer.timer(~name, ~active=isActive, ());
 
-  let state = Spring.tick(target, previousState^, options, time);
+  let state =
+    if (enabled) {
+      Spring.tick(target, previousState^, options, time);
+    } else {
+      Spring.setPosition(target, previousState^);
+    };
+
   previousState := state;
 
   let setImmediately = position =>


### PR DESCRIPTION
__Issue:__ When the spring hook is used, and the enabled flag is toggled, there can be a 'bounce' when the enabled flag is set back to true.

__Defect:__ The spring is only tracking positions when enabled - so if the position changes while the spring is disabled, the spring will bounce from the last position set while enabled, to the current position.

__Fix:__ When the spring is disabled, always set the current position to the target.