### PR TITLE
feat(macOS): add API to get titlebar size

### DIFF
--- a/packages/reason-sdl2/src/sdl2.re
+++ b/packages/reason-sdl2/src/sdl2.re
@@ -236,6 +236,7 @@ module Window = {
   external setMacTitlebarHidden: t => unit = "resdl_SDL_SetMacTitlebarHidden";
   external setMacBackgroundColor: (t, float, float, float, float) => unit =
     "resdl_SDL_SetMacBackgroundColor";
+  external getMacTitlebarHeight: t => float = "resdl_SDL_GetMacTitlebarHeight";
 };
 
 module Gl = {

--- a/packages/reason-sdl2/src/sdl2_wrapper.cpp
+++ b/packages/reason-sdl2/src/sdl2_wrapper.cpp
@@ -353,6 +353,25 @@ extern "C" {
         CAMLreturn(Val_unit);
     }
 
+    CAMLprim value resdl_SDL_GetMacTitlebarHeight(value vWin) {
+        CAMLparam1(vWin);
+        double titlebarHeight = 0.0;
+
+#ifdef SDL_VIDEO_DRIVER_COCOA
+        SDL_Window *win = (SDL_Window *)vWin;
+        SDL_SysWMinfo wmInfo;
+        SDL_VERSION(&wmInfo.version);
+        SDL_GetWindowWMInfo(win, &wmInfo);
+        NSWindow *nWindow = wmInfo.info.cocoa.window;
+
+        // Sourced from: https://stackoverflow.com/a/59323932/12701512
+        CGFloat windowFrameHeight = CGRectGetHeight([nWindow contentView].frame);
+        CGFloat contentLayoutRectHeight = CGRectGetHeight([nWindow contentLayoutRect]);
+        titlebarHeight = (double)(windowFrameHeight - contentLayoutRectHeight);
+#endif
+        CAMLreturn(caml_copy_double(titlebarHeight));
+    }
+
     CAMLprim value resdl_SDL_SetMacBackgroundColor(value vWin, value r, value g,
             value b, value a) {
         CAMLparam5(vWin, r, g, b, a);

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -357,6 +357,9 @@ let setTitle = (v: t, title: string) => {
   Sdl2.Window.setTitle(v.sdlWindow, title);
 };
 
+let getTitlebarHeight = (v: t) =>
+  Sdl2.Window.getMacTitlebarHeight(v.sdlWindow);
+
 let setSize = (~width: int, ~height: int, win: t) => {
   Log.tracef(m => m("setSize - calling with: %ux%u", width, height));
   // On platforms that return a non-unit scale factor (Windows and Linux),

--- a/src/Core/Window.rei
+++ b/src/Core/Window.rei
@@ -97,6 +97,8 @@ let setVsync: (t, Vsync.t) => unit;
 let render: t => unit;
 let handleEvent: (Sdl2.Event.t, t) => unit;
 
+let getTitlebarHeight: t => float;
+
 /**
   [create(name, options)] creates a new Revery application window.
 

--- a/src/Native/config/discover.re
+++ b/src/Native/config/discover.re
@@ -96,7 +96,7 @@ let get_ios_config = () => {
 };
 let get_mac_config = () => {
   features: [COCOA],
-  cflags: ["-I", ".", "-x", "objective-c"],
+  cflags: ["-I", ".", "-x", "objective-c", "-Wno-deprecated-declarations"],
   libs: [],
   flags: [],
 };


### PR DESCRIPTION
Since macOS Big Sur changes the size of the titlebar by default, it can lead to things looking kind of strange when you roll your own titlebar (like in Oni). This adds an API to get the size of the titlebar from Cocoa itself, so we don't have to make guesses from the version of macOS or something like that.