### PR TITLE
fix(notifications): remove startup prompt on macOS

### DIFF
--- a/src/Native/cocoa/ReveryAppDelegate.c
+++ b/src/Native/cocoa/ReveryAppDelegate.c
@@ -39,7 +39,6 @@
 */
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
     [_sdlDelegate applicationDidFinishLaunching:notification];
-    [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:self];
 }
 
 /* didActivateNotification


### PR DESCRIPTION
This addresses onivim/oni2#2705. Before we were needlessly setting the notification delegate on start, which would prompt the user if they wanted to allow notifications. Now the prompt is shown on first attempt at showing notifications.