### PR TITLE
fix(sdl2): Fix FFI for Display* functions

### DIFF
--- a/packages/reason-sdl2/src/sdl2_wrapper.cpp
+++ b/packages/reason-sdl2/src/sdl2_wrapper.cpp
@@ -486,9 +486,9 @@ extern "C" {
 
         ret = caml_alloc(4, 0);
         Store_field(ret, 0, Val_int(current.format));
-        Store_field(ret, 1, current.w);
-        Store_field(ret, 2, current.h);
-        Store_field(ret, 3, current.refresh_rate);
+        Store_field(ret, 1, Val_int(current.w));
+        Store_field(ret, 2, Val_int(current.h));
+        Store_field(ret, 3, Val_int(current.refresh_rate));
         CAMLreturn(ret);
     };
 
@@ -503,9 +503,9 @@ extern "C" {
 
         ret = caml_alloc(4, 0);
         Store_field(ret, 0, Val_int(current.format));
-        Store_field(ret, 1, current.w);
-        Store_field(ret, 2, current.h);
-        Store_field(ret, 3, current.refresh_rate);
+        Store_field(ret, 1, Val_int(current.w));
+        Store_field(ret, 2, Val_int(current.h));
+        Store_field(ret, 3, Val_int(current.refresh_rate));
         CAMLreturn(ret);
     };
 


### PR DESCRIPTION
__Issue:__ I had observed a new, intermittent crash in Onivim 2 when running on Windows. It was a pretty obscure crash, because it only reproduced with `esy run -f`, and not with `esy run` or `esy run -f --trace`. This suggested it was likely a GC / FFI issue.

After spending time bisecting, and checking new changes to our C FFI, I realized it went fairly far back... and I had just added a second monitor to my Windows machine. I realized if I unhooked the new monitor, it no longer reproduced. I suspected it may have to do with the FFI relating to the SDL_GetDisplay* functions - so I took a pass over it, and realized we were missing some `Val_int`s when passing the display width, height, and refresh rate.

This seems innocuous, but without a proper tag bit (https://dev.realworldocaml.org/runtime-memory-layout.html), these values would be treated as _pointers_ by the garbage collector, rather than integers.

__Fix:__ Use `Val_int` when sending these values back, so they are treated properly by the garbage collector. 