### PR TITLE
fix(osx): Link failure in Onivim

### DIFF
--- a/src/Native/ReveryNSObject.c
+++ b/src/Native/ReveryNSObject.c
@@ -7,6 +7,8 @@
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
 
+#include "utilities.h"
+
 CAMLprim value revery_NSObject_equal(value vNSObjA, value vNSObjB) {
     CAMLparam2(vNSObjA, vNSObjB);
     NSObject *nsObjA = (NSObject *)revery_unwrapPointer(vNSObjA);

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -16,6 +16,7 @@
         utilities
         ReveryGtk ReveryGtk_Widget
         ReveryAppDelegate ReveryAppDelegate_func
+        ReveryNSObject
         ReveryProgressBar)
     (c_flags :standard -Wall -Wextra -Werror (:include c_flags.sexp))
     (c_library_flags (:include c_library_flags.sexp))


### PR DESCRIPTION
In trying to bring Onivim up-to-date with latest Revery, this link error was being hit when running inline tests:
```
clang: error: linker command failed with exit code 1 (use -v to see invocation)
File "caml_startup", line 1:
Error: Error during linking
    ocamlopt src/Feature/Layout/.Feature_Layout.inline-tests/run.exe (exit 2)
(cd /Users/runner/work/1/s/_esy/default/store/b/oni2-a5340e6c/default && /Users/runner/.esy/3__________________________________________________________________/i/ocaml-4.10.0-f28f0ffe/bin/ocamlopt.opt -w -24 -g -o src/Feature/Layout/.Feature_Layout.inline-tests/run.exe -linkall /Users/runner/.esy/3__________________________________________________________________/i/opam__s__easy_format-opam__c__1.3.2-b4cb22c6/lib/easy-format/easy_format.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__biniou-opam__c__1.2.1-adad683c/lib/biniou/biniou.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__yojson-cfd0cf3f/lib/yojson/yojson.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__result-opam__c__1.5-dd8b9b28/lib/result/result.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ppx__deriving-opam__c__5.1-2d252a77/lib/ppx_deriving/runtime/ppx_deriving_runtime.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ppx__deriving__yojson-opam__c__3.6.1-aef28daf/lib/ppx_deriving_yojson/runtime/ppx_deriving_yojson_runtime.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__react-opam__c__1.2.1-fef0971b/lib/react/react.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__uucp-opam__c__13.0.0-154f9494/lib/uucp/uucp.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__uutf-opam__c__1.0.2-d7f12a22/lib/uutf/uutf.cmxa /Users/runner/.esy/3__________________________________________________________________/i/ocaml-4.10.0-f28f0ffe/lib/ocaml/unix.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/ocaml-4.10.0-f28f0ffe/lib/ocaml /Users/runner/.esy/3__________________________________________________________________/i/ocaml-4.10.0-f28f0ffe/lib/ocaml/bigarray.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/ocaml-4.10.0-f28f0ffe/lib/ocaml /Users/runner/.esy/3__________________________________________________________________/i/opam__s__camomile-opam__c__1.0.2-8f410579/lib/camomile/default_config/camomileDefaultConfig.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__camomile-opam__c__1.0.2-8f410579/lib/camomile/library/camomileLibrary.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__camomile-opam__c__1.0.2-8f410579/lib/camomile/lib_default/camomileLibraryDefault.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__camomile-opam__c__1.0.2-8f410579/lib/camomile/dyn/camomileLibraryDyn.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__camomile-opam__c__1.0.2-8f410579/lib/camomile/camomile_yuge.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__charinfo__width-opam__c__1.1.0-4c72ebd2/lib/charInfo_width/charInfo_width.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/zed/Revery_Zed.cmxa /Users/runner/.esy/3__________________________________________________________________/i/ocaml-4.10.0-f28f0ffe/lib/ocaml/threads/threads.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/ocaml-4.10.0-f28f0ffe/lib/ocaml src/editor-core-types/EditorCoreTypes.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__stdlib_shims-opam__c__0.1.0-c47cc6fe/lib/stdlib-shims/stdlib_shims.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__fmt-opam__c__0.8.9-d83b35e0/lib/fmt/fmt.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__fmt-opam__c__0.8.9-d83b35e0/lib/fmt/fmt_tty.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__logs-opam__c__0.7.0-88127958/lib/logs/logs.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__logs-opam__c__0.7.0-88127958/lib/logs/logs_fmt.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__re-opam__c__1.9.0-5d131480/lib/re/re.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery__s__timber-2.0.0-c18ecd35/lib/timber/Timber.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/revery__s__timber-2.0.0-c18ecd35/lib/timber /Users/runner/.esy/3__________________________________________________________________/i/opam__s__lwt-opam__c__4.5.0-3b418287/lib/lwt/lwt.cmxa src/Core/Kernel/Kernel.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__base-opam__c__v0.14.0-5a677e73/lib/base/base_internalhash_types/base_internalhash_types.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/opam__s__base-opam__c__v0.14.0-5a677e73/lib/base/base_internalhash_types /Users/runner/.esy/3__________________________________________________________________/i/opam__s__base-opam__c__v0.14.0-5a677e73/lib/base/caml/caml.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__sexplib0-opam__c__v0.14.0-ef56fd03/lib/sexplib0/sexplib0.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__base-opam__c__v0.14.0-5a677e73/lib/base/shadow_stdlib/shadow_stdlib.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__base-opam__c__v0.14.0-5a677e73/lib/base/base.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/opam__s__base-opam__c__v0.14.0-5a677e73/lib/base src/reason-libvim/vim.cmxa -I src/reason-libvim src/reason-oniguruma/oniguruma.cmxa -I src/reason-oniguruma /Users/runner/.esy/3__________________________________________________________________/i/ocaml-4.10.0-f28f0ffe/lib/ocaml/str.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/ocaml-4.10.0-f28f0ffe/lib/ocaml /Users/runner/.esy/3__________________________________________________________________/i/opam__s__integers-opam__c__0.4.0-fe13d2cf/lib/integers/integers.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/opam__s__integers-opam__c__0.4.0-fe13d2cf/lib/integers /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ctypes-opam__c__0.15.1-8cabe8f3/lib/ctypes/ctypes.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ctypes-opam__c__0.15.1-8cabe8f3/lib/ctypes /Users/runner/.esy/3__________________________________________________________________/i/opam__s__luv-abb52d1b/lib/luv/c_type_descriptions/luv_c_type_descriptions.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__luv-abb52d1b/lib/luv/c_function_descriptions/luv_c_function_descriptions.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__luv-abb52d1b/lib/luv/c/luv_c.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/opam__s__luv-abb52d1b/lib/luv/c /Users/runner/.esy/3__________________________________________________________________/i/opam__s__luv-abb52d1b/lib/luv/luv.cmxa /Users/runner/.esy/3__________________________________________________________________/i/reason_native__s__console-0.1.0-792672db/lib/console/lib/Console.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/reason_native__s__console-0.1.0-792672db/lib/console/lib /Users/runner/.esy/3__________________________________________________________________/i/opam__s__mmap-opam__c__1.1.0-6ce33abc/lib/mmap/mmap.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ocplib_endian-opam__c__1.1-7d24f565/lib/ocplib-endian/ocplib_endian.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ocplib_endian-opam__c__1.1-7d24f565/lib/ocplib-endian/bigstring/ocplib_endian_bigstring.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__lwt-opam__c__4.5.0-3b418287/lib/lwt/unix/lwt_unix.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/opam__s__lwt-opam__c__4.5.0-3b418287/lib/lwt/unix /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/reason-sdl2/sdl2.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/reason-sdl2 /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/reason-skia/wrapped/types/SkiaWrappedTypes.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/reason-skia/wrapped/c/skia_wrapped_c.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/reason-skia/wrapped/c /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ctypes-opam__c__0.15.1-8cabe8f3/lib/ctypes/cstubs.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ctypes-opam__c__0.15.1-8cabe8f3/lib/ctypes /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/reason-skia/wrapped/bindings/SkiaWrappedBindings.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/reason-skia/wrapped/SkiaWrapped.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/reason-skia/wrapped /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/reason-skia/skia.cmxa /Users/runner/.esy/3__________________________________________________________________/i/flex-ff15f77c/lib/flex/Flex.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__astring-opam__c__0.8.5-47cfc0e4/lib/astring/astring.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__fpath-opam__c__0.7.3-31f8882f/lib/fpath/fpath.cmxa /Users/runner/.esy/3__________________________________________________________________/i/rench-96b2a148/lib/Rench/Rench.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/rench-96b2a148/lib/Rench /Users/runner/.esy/3__________________________________________________________________/i/opam__s__psq-opam__c__0.2.0-5dff7fcd/lib/psq/psq.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__lru-e90a169f/lib/lru/lru.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/Native/Revery_Native.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/Native /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/text-wrap/Revery_TextWrap.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/Core/Revery_Core.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/reason-harfbuzz/harfbuzz.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/reason-harfbuzz /Users/runner/.esy/3__________________________________________________________________/i/rebez-72a0ed17/lib/rebez/lib/Rebez.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/Math/Revery_Math.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/Font/Revery_Font.cmxa /Users/runner/.esy/3__________________________________________________________________/i/brisk__s__brisk_reconciler-39aede79/lib/brisk-reconciler/brisk_reconciler.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/Draw/Revery_Draw.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/UI/Revery_UI.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__omd-a0a9415b/lib/omd/omd.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__rresult-opam__c__0.6.0-55488aad/lib/rresult/rresult.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__bos-opam__c__0.2.0-b27b8899/lib/bos/bos.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/IO/Revery_IO.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/UI_Primitives/Revery_UI_Primitives.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/UI_Hooks/Revery_UI_Hooks.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__markup-opam__c__0.8.2-6bbe96c5/lib/markup/markup.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/SVG/Revery_SVG.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/UI_Components/Revery_UI_Components.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/Utility/Revery_Utility.cmxa /Users/runner/.esy/3__________________________________________________________________/i/revery-9ceea054/lib/Revery/Revery.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ppx__inline__test-opam__c__v0.14.1-bcda8221/lib/ppx_inline_test/config/inline_test_config.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__jane_street_headers-opam__c__v0.14.0-72092fca/lib/jane-street-headers/jane_street_headers.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ppx__sexp__conv-opam__c__v0.14.1-1addc8c1/lib/ppx_sexp_conv/runtime-lib/ppx_sexp_conv_lib.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ppx__compare-opam__c__v0.14.0-3ea9c028/lib/ppx_compare/runtime-lib/ppx_compare_lib.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ppx__enumerate-opam__c__v0.14.0-afaebb64/lib/ppx_enumerate/runtime-lib/ppx_enumerate_lib.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ppx__hash-opam__c__v0.14.0-7d1b9681/lib/ppx_hash/runtime-lib/ppx_hash_lib.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__time__now-opam__c__v0.14.0-fac4a40f/lib/time_now/time_now.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/opam__s__time__now-opam__c__v0.14.0-fac4a40f/lib/time_now /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ppx__inline__test-opam__c__v0.14.1-bcda8221/lib/ppx_inline_test/runtime-lib/ppx_inline_test_lib.cmxa src/Core/Utility/Utility.cmxa src/Core/WhenExpr/WhenExpr.cmxa /Users/runner/.esy/3__________________________________________________________________/i/isolinear-c8630e78/lib/isolinear/isolinear.cmxa /Users/runner/.esy/3__________________________________________________________________/i/reason_fzy-9283839c/lib/Fzy/Fzy.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/reason_fzy-9283839c/lib/Fzy /Users/runner/.esy/3__________________________________________________________________/i/opam__s__decoders-opam__c__0.5.0-041f6d9b/lib/decoders/decoders.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__decoders_yojson-opam__c__0.4.0-3ff445b2/lib/decoders-yojson/decoders_yojson.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__bigarray_compat-opam__c__1.0.0-5dd9d5ef/lib/bigarray-compat/bigarray_compat.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__bigstringaf-opam__c__0.6.1-ba14ee0b/lib/bigstringaf/bigstringaf.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/opam__s__bigstringaf-opam__c__0.6.1-ba14ee0b/lib/bigstringaf /Users/runner/.esy/3__________________________________________________________________/i/opam__s__angstrom-opam__c__0.15.0-8f5b6186/lib/angstrom/angstrom.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__fp-91148360/lib/fp/Fp.cmxa src/Core/Oni_Core.cmxa src/Feature/Commands/Feature_Commands.cmxa src/Service/Time/Service_Time.cmxa src/editor-input/EditorInput.cmxa src/Feature/Input/Feature_Input.cmxa src/Input/Oni_Input.cmxa src/Exthost/Extension/Exthost_Extension.cmxa src/Exthost/Transport/Exthost_Transport.cmxa src/Exthost/Protocol/Exthost_Protocol.cmxa src/Service/OS/Service_OS.cmxa src/Service/Net/Service_Net.cmxa src/Exthost/Exthost.cmxa src/reason-textmate/textmate.cmxa src/reason-tree-sitter/treesitter.cmxa -I src/reason-tree-sitter src/Syntax/Oni_Syntax.cmxa src/Service/Font/Service_Font.cmxa src/Feature/Theme/Feature_Theme.cmxa src/Feature/Sneak/Feature_Sneak.cmxa src/Components/Oni_Components.cmxa src/Components/Animation/Component_Animation.cmxa src/Service/Vim/Service_Vim.cmxa src/Feature/Vim/Feature_Vim.cmxa src/Feature/Configuration/Feature_Configuration.cmxa src/Components/InputText/Component_InputText.cmxa src/Service/Exthost/Service_Exthost.cmxa src/Feature/Diagnostics/Feature_Diagnostics.cmxa src/Components/VimList/Component_VimList.cmxa src/Components/VimTree/Component_VimTree.cmxa src/Components/Accordion/Component_Accordion.cmxa src/Components/VimWindows/Component_VimWindows.cmxa src/Feature/SCM/Feature_SCM.cmxa src/Feature/Keywords/Feature_Keywords.cmxa src/Feature/LanguageSupport/Feature_LanguageSupport.cmxa src/Syntax_Client/Oni_Syntax_Client.cmxa src/Service/Syntax/Service_Syntax.cmxa src/Feature/Syntax/Feature_Syntax.cmxa src/Feature/Editor/Feature_Editor.cmxa src/Feature/Layout/Feature_Layout.cmxa /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ppx__inline__test-opam__c__v0.14.1-bcda8221/lib/ppx_inline_test/runner/lib/ppx_inline_test_runner_lib.cmxa -I /Users/runner/.esy/3__________________________________________________________________/i/opam__s__ppx__inline__test-opam__c__v0.14.1-bcda8221/lib/ppx_inline_test/runner/lib src/Feature/Layout/.Feature_Layout.inline-tests/.Feature_Layout.inline-tests.eobjs/native/dune__exe__Run.cmx)
Undefined symbols for architecture x86_64:
  "_revery_NSObject_className", referenced from:
      _camlRevery_Native__NSObject__gc_roots in Revery_Native.a(revery_Native__NSObject.o)
  "_revery_NSObject_equal", referenced from:
      _camlRevery_Native__NSObject__gc_roots in Revery_Native.a(revery_Native__NSObject.o)
  "_revery_NSObject_hash", referenced from:
      _camlRevery_Native__NSObject__gc_roots in Revery_Native.a(revery_Native__NSObject.o)
  "_revery_NSObject_toString", referenced from:
      _camlRevery_Native__NSObject__gc_roots in Revery_Native.a(revery_Native__NSObject.o)
```
(https://dev.azure.com/onivim/oni2/_build/results?buildId=14518&view=logs&j=a5e52b91-c83f-5429-4a68-c246fc63a4f7&t=f2d23d6a-8ed6-5c11-212e-1dfd6a197291&l=409)

This fixes the errors - explicitly including the `ReveryNSObject.c` file in the `dune` config, and bringing in `utilites.h` so that `revery_unwrapPointer`/`revery_wrapPointer` are not implicitly defined.