### PR TITLE
feat(environment): macOS version

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -374,6 +374,12 @@ let init = app => {
       Console.log(Printf.sprintf("Moved: %d x %d", x, y))
     );
 
+  switch (Environment.os) {
+  | Mac(major, minor, bugfix) =>
+    Printf.printf("MacOS: %d.%d.%d\n", major, minor, bugfix)
+  | _ => ()
+  };
+
   let _renderFunction =
     UI.start(window, <ExampleHost window initialExample />);
   ();

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -373,7 +373,7 @@ let init = app => {
     Window.onMoved(window, ((x, y)) =>
       Console.log(Printf.sprintf("Moved: %d x %d", x, y))
     );
-  
+
   Console.log(Printf.sprintf("Operating system: %s", Environment.osString));
 
   let _renderFunction =

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -373,12 +373,8 @@ let init = app => {
     Window.onMoved(window, ((x, y)) =>
       Console.log(Printf.sprintf("Moved: %d x %d", x, y))
     );
-
-  switch (Environment.os) {
-  | Mac(major, minor, bugfix) =>
-    Printf.printf("MacOS: %d.%d.%d\n", major, minor, bugfix)
-  | _ => ()
-  };
+  
+  Console.log(Printf.sprintf("Operating system: %s", Environment.osString));
 
   let _renderFunction =
     UI.start(window, <ExampleHost window initialExample />);

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -41,6 +41,27 @@ let osString =
   | Unknown => "Unknown"
   };
 
+let isMac =
+  switch (os) {
+  | Mac(_) => true
+  | _ => false
+  };
+let isIOS = {
+  os == IOS;
+};
+let isWindows = {
+  os == Windows;
+};
+let isAndroid = {
+  os == Android;
+};
+let isLinux = {
+  os == Linux;
+};
+let isBrowser = {
+  os == Browser;
+};
+
 module Internal = {
   let addTrailingSlash = dir => {
     let len = String.length(dir);

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -29,8 +29,10 @@ let os = {
   webGL ? Browser : Revery_Native.Environment.getOS();
 };
 
-let osString = switch (os) {
-  | Mac(major, minor, bugfix) => Printf.sprintf("macOS %d.%d.%d", major, minor, bugfix)
+let osString =
+  switch (os) {
+  | Mac(major, minor, bugfix) =>
+    Printf.sprintf("macOS %d.%d.%d", major, minor, bugfix)
   | Windows => "Windows"
   | Linux => "Linux"
   | Android => "Android"

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -16,27 +16,17 @@ let sleep = (t: Time.t) =>
 external yield: unit => unit = "caml_thread_yield";
 
 type os =
-  | Android
-  | IOS
-  | Linux
-  | Mac
-  | Windows
-  | Browser
-  | Unknown;
+  Revery_Native.Environment.os =
+    | Unknown
+    | Android
+    | IOS
+    | Linux
+    | Windows
+    | Browser
+    | Mac(int, int, int);
 
 let os = {
-  webGL
-    ? Browser
-    : (
-      switch (Revery_Native.Environment.get_os()) {
-      | `Android => Android
-      | `IOS => IOS
-      | `Linux => Linux
-      | `Mac => Mac
-      | `Windows => Windows
-      | _ => Unknown
-      }
-    );
+  webGL ? Browser : Revery_Native.Environment.getOS();
 };
 
 module Internal = {
@@ -65,7 +55,7 @@ let getExecutingDirectory = () =>
        * the symlink destination - this causes problems when trying to load assets
        * relative to the binary location when symlinked.
        */
-      | Mac =>
+      | Mac(_) =>
         switch (
           String.rindex_opt(Sys.executable_name, '/'),
           String.rindex_opt(Sys.executable_name, '\\'),

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -29,6 +29,16 @@ let os = {
   webGL ? Browser : Revery_Native.Environment.getOS();
 };
 
+let osString = switch (os) {
+  | Mac(major, minor, bugfix) => Printf.sprintf("macOS %d.%d.%d", major, minor, bugfix)
+  | Windows => "Windows"
+  | Linux => "Linux"
+  | Android => "Android"
+  | Browser => "Browser"
+  | IOS => "iOS"
+  | Unknown => "Unknown"
+  };
+
 module Internal = {
   let addTrailingSlash = dir => {
     let len = String.length(dir);

--- a/src/Core/Environment.rei
+++ b/src/Core/Environment.rei
@@ -47,13 +47,13 @@ let getAssetPath: string => string;
 let getTempDirectory: unit => string;
 
 type os =
+  | Unknown
   | Android
   | IOS
   | Linux
-  | Mac
   | Windows
   | Browser
-  | Unknown;
+  | Mac(int, int, int);
 
 let os: os;
 

--- a/src/Core/Environment.rei
+++ b/src/Core/Environment.rei
@@ -56,6 +56,7 @@ type os =
   | Mac(int, int, int);
 
 let os: os;
+let osString: string;
 
 /**
 [getUserLocale] returns the current user locale. Note that on some platforms

--- a/src/Core/Environment.rei
+++ b/src/Core/Environment.rei
@@ -58,6 +58,13 @@ type os =
 let os: os;
 let osString: string;
 
+let isMac: bool;
+let isIOS: bool;
+let isWindows: bool;
+let isAndroid: bool;
+let isLinux: bool;
+let isBrowser: bool;
+
 /**
 [getUserLocale] returns the current user locale. Note that on some platforms
 (including macOS) the locale can change during runtime

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -68,7 +68,7 @@ module WindowMetrics: {
         // Mac and iOS is easy... there isn't any scaling factor.  The window is automatically
         // proportioned for us. The scaling is handled by the ratio of size / framebufferSize.
         | IOS
-        | Mac => 1.0
+        | Mac(_) => 1.0
         // On Windows, we need to try a Win32 API to get the scale factor
         | Windows =>
           let scale = Sdl2.Window.getWin32ScaleFactor(sdlWindow);
@@ -238,7 +238,7 @@ type t = {
 module Internal = {
   let setTitlebarStyle = (w: Sdl2.Window.t, style: WindowStyles.titlebar) => {
     switch (Environment.os) {
-    | Mac =>
+    | Mac(_) =>
       switch (style) {
       | Transparent => Sdl2.Window.setMacTitlebarTransparent(w)
       | Hidden => Sdl2.Window.setMacTitlebarHidden(w)

--- a/src/Font/FontFamily.re
+++ b/src/Font/FontFamily.re
@@ -82,20 +82,20 @@ let fromFile = (fileName, ~italic as _, _) => {
 let default =
   switch (Revery_Core.Environment.os) {
   | Linux => system("Liberation Sans")
-  | Mac => system("System Font")
+  | Mac(_) => system("System Font")
   | _ => system("Arial")
   };
 
 let defaultMono =
   switch (Revery_Core.Environment.os) {
-  | Mac => system("Menlo")
+  | Mac(_) => system("Menlo")
   | Windows => system("Consolas")
   | _ => fromFile("Inconsolata.otf")
   };
 
 let defaultSerif =
   switch (Revery_Core.Environment.os) {
-  | Mac => system("Palatino")
+  | Mac(_) => system("Palatino")
   | Linux => system("Liberation Serif")
   | _ => system("Times New Roman")
   };

--- a/src/Native/Environment.re
+++ b/src/Native/Environment.re
@@ -1,10 +1,13 @@
-external get_os: unit => string = "revery_getOperatingSystem";
-let get_os = () =>
-  switch (get_os()) {
-  | "android" => `Android
-  | "ios" => `IOS
-  | "linux" => `Linux
-  | "mac" => `Mac
-  | "windows" => `Windows
-  | _ => `Unknown
-  };
+/* If you change these you *must* keep environment.c up to date. */
+type os =
+  /* Int values */
+  | Unknown // 0
+  | Android // 1
+  | IOS // 2
+  | Linux // 3
+  | Windows // 4
+  | Browser // 5
+  /* Block values */
+  | Mac(int, int, int); // 0
+
+external getOS: unit => os = "revery_getOperatingSystem";

--- a/src/Native/ReveryCocoa.h
+++ b/src/Native/ReveryCocoa.h
@@ -39,3 +39,4 @@ void revery_menuRemoveItem_cocoa(void *nsMenu, void *nsMenuItem);
 void revery_menuInsertItemAt_cocoa(void *nsMenu, void *nsMenuItem, int idx);
 void revery_menuInsertSubmenuAt_cocoa(void *parent, void *child, int idx);
 void revery_menuClear_cocoa(void *nsMenu);
+

--- a/src/Native/ReveryMac.h
+++ b/src/Native/ReveryMac.h
@@ -1,0 +1,4 @@
+#pragma once
+
+/* Environment functions */
+void getOperatingSystemVersion_mac(int *major, int *minor, int *bugfix);

--- a/src/Native/config/discover.re
+++ b/src/Native/config/discover.re
@@ -68,6 +68,7 @@ let gen_config_header = (conf, features) => {
     | Windows => "windows"
     };
   };
+  let is_os = os => get_os(conf) == os ? Value.Int(1) : Value.Switch(false);
 
   gen_header_file(
     conf,
@@ -77,6 +78,11 @@ let gen_config_header = (conf, features) => {
       ("USE_GTK", includes(GTK)),
       ("USE_UIKIT", includes(UIKIT)),
       ("USE_WIN32", includes(WIN32)),
+      ("IS_IOS", is_os(IOS)),
+      ("IS_MACOS", is_os(Mac)),
+      ("IS_ANDROID", is_os(Android)),
+      ("IS_LINUX", is_os(Linux)),
+      ("IS_WINDOWS", is_os(Windows)),
     ],
   );
 };

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -9,7 +9,7 @@
         Revery_Native
         dialog dialog_cocoa dialog_win32 dialog_gtk
         notification notification_cocoa
-        environment
+        environment environment_mac
         icon icon_cocoa icon_win32
         shell shell_cocoa shell_gtk shell_win32
         locale locale_cocoa locale_win32

--- a/src/Native/environment.c
+++ b/src/Native/environment.c
@@ -11,8 +11,31 @@
 #include <caml/mlvalues.h>
 
 #include "config.h"
+#ifdef IS_MACOS
+#import "ReveryMac.h"
+#endif
 
 CAMLprim value revery_getOperatingSystem() {
     CAMLparam0();
-    CAMLreturn(caml_copy_string(PLATFORM_NAME));
+    CAMLlocal1(vOS);
+#ifdef IS_ANDROID
+    vOS = Val_int(1);
+#elif IS_IOS
+    vOS = Val_int(2);
+#elif IS_LINUX
+    vOS = Val_int(3);
+#elif IS_WINDOWS
+    vOS = Val_int(4);
+#elif IS_MACOS
+    int major, minor, bugfix;
+    getOperatingSystemVersion_mac(&major, &minor, &bugfix);
+    vOS = caml_alloc(3, 0);
+    Store_field(vOS, 0, Val_int(major));
+    Store_field(vOS, 1, Val_int(minor));
+    Store_field(vOS, 2, Val_int(bugfix));
+#else
+    vOS = Val_int(0);
+#endif
+
+    CAMLreturn(vOS);
 }

--- a/src/Native/environment_mac.c
+++ b/src/Native/environment_mac.c
@@ -1,0 +1,12 @@
+#include "config.h"
+#ifdef IS_MACOS
+#import <Foundation/Foundation.h>
+
+void getOperatingSystemVersion_mac(int *major, int *minor, int *bugfix) {
+    NSOperatingSystemVersion nsOSVersion = [[NSProcessInfo processInfo] operatingSystemVersion];
+    *major = nsOSVersion.majorVersion;
+    *minor = nsOSVersion.minorVersion;
+    *bugfix = nsOSVersion.patchVersion;
+}
+
+#endif

--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -320,7 +320,11 @@ let%component make =
     onKeyDown(event);
 
     let code = event.keycode;
-    let mac = Environment.os === Mac;
+    let mac =
+      switch (Environment.os) {
+      | Mac(_) => true
+      | _ => false
+      };
     let super = Sdl2.Keymod.isGuiDown(event.keymod);
     let ctrl = Sdl2.Keymod.isControlDown(event.keymod);
 

--- a/src/UI_Components/Input.re
+++ b/src/UI_Components/Input.re
@@ -320,11 +320,6 @@ let%component make =
     onKeyDown(event);
 
     let code = event.keycode;
-    let mac =
-      switch (Environment.os) {
-      | Mac(_) => true
-      | _ => false
-      };
     let super = Sdl2.Keymod.isGuiDown(event.keymod);
     let ctrl = Sdl2.Keymod.isControlDown(event.keymod);
 
@@ -345,7 +340,7 @@ let%component make =
     } else if (code == Keycode.escape) {
       Focus.loseFocus();
     } else if (code == Keycode.v) {
-      if (mac && super || !mac && ctrl) {
+      if (Environment.isMac && super || !Environment.isMac && ctrl) {
         paste(value, cursorPosition);
       };
     };

--- a/src/UI_Components/ScrollView.re
+++ b/src/UI_Components/ScrollView.re
@@ -13,7 +13,11 @@ let empty = React.empty;
 
 let scrollTrackColor = Color.rgba(0.0, 0.0, 0.0, 0.4);
 let scrollThumbColor = Color.rgba(0.5, 0.5, 0.5, 0.4);
-let isMac = Environment.os === Mac;
+let isMac =
+  switch (Environment.os) {
+  | Mac(_) => true
+  | _ => false
+  };
 
 type action =
   | ScrollUpdated(int);

--- a/src/UI_Components/ScrollView.re
+++ b/src/UI_Components/ScrollView.re
@@ -13,11 +13,6 @@ let empty = React.empty;
 
 let scrollTrackColor = Color.rgba(0.0, 0.0, 0.0, 0.4);
 let scrollThumbColor = Color.rgba(0.5, 0.5, 0.5, 0.4);
-let isMac =
-  switch (Environment.os) {
-  | Mac(_) => true
-  | _ => false
-  };
 
 type action =
   | ScrollUpdated(int);
@@ -102,7 +97,7 @@ let%component make =
                 ~style,
                 ~scrollLeft=0,
                 ~scrollTop=0,
-                ~bounce=isMac,
+                ~bounce=Environment.isMac,
                 ~children=React.empty,
                 (),
               ) => {
@@ -230,7 +225,7 @@ let%component make =
 
         if (horizontalScroll) {
           if (isHorizontalScrollBarVisible) {
-            let horizontalScrollMultiplier = isMac ? (-1.) : 1.;
+            let horizontalScrollMultiplier = Environment.isMac ? (-1.) : 1.;
             handeScroll(
               ~deltaValue=
                 abs_float(wheelEvent.deltaX) > 0.


### PR DESCRIPTION
This restructures the `Revery_Native.Environment.getOS` function and the `os` type to include the operating system version on macOS. The main change is that the `Mac` variant now contains three constructors: `Mac(major, minor, bugfix)`

I plan on extending this to other OS's as well (i.e. Linux could contain the kernel version (same format: major, minor, bugfix), Windows could use [`RtlGetVersion`](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlgetversion?redirectedfrom=MSDN), etc.)

This is immediately to fix the problem with differing design constraints on different macOS versions in onivim/oni2#2876