### PR TITLE
feat(environment): add kernel version info on Linux

### DIFF
--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -22,8 +22,17 @@ type os =
     | IOS
     | Windows
     | Browser
-    | Mac(int, int, int)
-    | Linux(int, int, int, int);
+    | Mac({
+        major: int,
+        minor: int,
+        bugfix: int,
+      })
+    | Linux({
+        kernel: int,
+        major: int,
+        minor: int,
+        patch: int,
+      });
 
 let os = {
   webGL ? Browser : Revery_Native.Environment.getOS();
@@ -31,9 +40,9 @@ let os = {
 
 let osString =
   switch (os) {
-  | Mac(major, minor, bugfix) =>
+  | Mac({major, minor, bugfix}) =>
     Printf.sprintf("macOS %d.%d.%d", major, minor, bugfix)
-  | Linux(kernel, major, minor, patch) =>
+  | Linux({kernel, major, minor, patch}) =>
     Printf.sprintf("Linux %d.%d.%d-%d", kernel, major, minor, patch)
   | Windows => "Windows"
   | Android => "Android"

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -20,10 +20,10 @@ type os =
     | Unknown
     | Android
     | IOS
-    | Linux
     | Windows
     | Browser
-    | Mac(int, int, int);
+    | Mac(int, int, int)
+    | Linux(int, int, int, int);
 
 let os = {
   webGL ? Browser : Revery_Native.Environment.getOS();
@@ -33,8 +33,9 @@ let osString =
   switch (os) {
   | Mac(major, minor, bugfix) =>
     Printf.sprintf("macOS %d.%d.%d", major, minor, bugfix)
+  | Linux(kernel, major, minor, patch) =>
+    Printf.sprintf("Linux %d.%d.%d-%d", kernel, major, minor, patch)
   | Windows => "Windows"
-  | Linux => "Linux"
   | Android => "Android"
   | Browser => "Browser"
   | IOS => "iOS"
@@ -46,6 +47,11 @@ let isMac =
   | Mac(_) => true
   | _ => false
   };
+let isLinux =
+  switch (os) {
+  | Linux(_) => true
+  | _ => false
+  };
 let isIOS = {
   os == IOS;
 };
@@ -54,9 +60,6 @@ let isWindows = {
 };
 let isAndroid = {
   os == Android;
-};
-let isLinux = {
-  os == Linux;
 };
 let isBrowser = {
   os == Browser;

--- a/src/Core/Environment.rei
+++ b/src/Core/Environment.rei
@@ -50,10 +50,10 @@ type os =
   | Unknown
   | Android
   | IOS
-  | Linux
   | Windows
   | Browser
-  | Mac(int, int, int);
+  | Mac(int, int, int)
+  | Linux(int, int, int, int);
 
 let os: os;
 let osString: string;

--- a/src/Core/Environment.rei
+++ b/src/Core/Environment.rei
@@ -52,8 +52,17 @@ type os =
   | IOS
   | Windows
   | Browser
-  | Mac(int, int, int)
-  | Linux(int, int, int, int);
+  | Mac({
+      major: int,
+      minor: int,
+      bugfix: int,
+    })
+  | Linux({
+      kernel: int,
+      major: int,
+      minor: int,
+      patch: int,
+    });
 
 let os: os;
 let osString: string;

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -86,7 +86,7 @@ module WindowMetrics: {
         //     https://github.com/mosra/magnum/commit/ae31c3cd82ba53454b8ab49d3f9d8ca385560d4b
         //     https://github.com/glfw/glfw/blob/250b94cd03e6f947ba516869c7f3b277f8d0cacc/src/x11_init.c#L938
         //     https://wiki.archlinux.org/index.php/HiDPI
-        | Linux =>
+        | Linux(_) =>
           switch (Rench.Environment.getEnvironmentVariable("GDK_SCALE")) {
           | None => 1.0
           | Some(v) =>
@@ -248,7 +248,7 @@ module Internal = {
     | Browser
     // NOTE: may work for IOS?
     | IOS
-    | Linux
+    | Linux(_)
     | Unknown
     | Windows => ()
     };

--- a/src/Font/FontFamily.re
+++ b/src/Font/FontFamily.re
@@ -81,7 +81,7 @@ let fromFile = (fileName, ~italic as _, _) => {
 
 let default =
   switch (Revery_Core.Environment.os) {
-  | Linux => system("Liberation Sans")
+  | Linux(_) => system("Liberation Sans")
   | Mac(_) => system("System Font")
   | _ => system("Arial")
   };
@@ -96,7 +96,7 @@ let defaultMono =
 let defaultSerif =
   switch (Revery_Core.Environment.os) {
   | Mac(_) => system("Palatino")
-  | Linux => system("Liberation Serif")
+  | Linux(_) => system("Liberation Serif")
   | _ => system("Times New Roman")
   };
 

--- a/src/Native/Environment.re
+++ b/src/Native/Environment.re
@@ -4,10 +4,10 @@ type os =
   | Unknown // 0
   | Android // 1
   | IOS // 2
-  | Linux // 3
-  | Windows // 4
-  | Browser // 5
+  | Windows // 3
+  | Browser // 4
   /* Block values */
-  | Mac(int, int, int); // 0
+  | Mac(int, int, int) // 0
+  | Linux(int, int, int, int); // 1
 
 external getOS: unit => os = "revery_getOperatingSystem";

--- a/src/Native/Environment.re
+++ b/src/Native/Environment.re
@@ -7,7 +7,16 @@ type os =
   | Windows // 3
   | Browser // 4
   /* Block values */
-  | Mac(int, int, int) // 0
-  | Linux(int, int, int, int); // 1
+  | Mac({
+      major: int,
+      minor: int,
+      bugfix: int,
+    }) // 0
+  | Linux({
+      kernel: int,
+      major: int,
+      minor: int,
+      patch: int,
+    }); // 1
 
 external getOS: unit => os = "revery_getOperatingSystem";

--- a/src/Native/ReveryLinux.h
+++ b/src/Native/ReveryLinux.h
@@ -1,0 +1,4 @@
+#pragma once
+
+/* Environment functions */
+void getOperatingSystemVersion_linux(int *kernel, int *major, int *minor, int *patch);

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -9,7 +9,7 @@
         Revery_Native
         dialog dialog_cocoa dialog_win32 dialog_gtk
         notification notification_cocoa
-        environment environment_mac
+        environment environment_mac environment_linux
         icon icon_cocoa icon_win32
         shell shell_cocoa shell_gtk shell_win32
         locale locale_cocoa locale_win32

--- a/src/Native/environment.c
+++ b/src/Native/environment.c
@@ -13,6 +13,8 @@
 #include "config.h"
 #ifdef IS_MACOS
 #import "ReveryMac.h"
+#elif IS_LINUX
+#include "ReveryLinux.h"
 #endif
 
 CAMLprim value revery_getOperatingSystem() {
@@ -23,9 +25,15 @@ CAMLprim value revery_getOperatingSystem() {
 #elif IS_IOS
     vOS = Val_int(2);
 #elif IS_LINUX
-    vOS = Val_int(3);
+    int kernel, major, minor, patch;
+    getOperatingSystemVersion_linux(&kernel, &major, &minor, &patch);
+    vOS = caml_alloc(4, 1);
+    Store_field(vOS, 0, Val_int(kernel));
+    Store_field(vOS, 1, Val_int(major));
+    Store_field(vOS, 2, Val_int(minor));
+    Store_field(vOS, 3, Val_int(patch));
 #elif IS_WINDOWS
-    vOS = Val_int(4);
+    vOS = Val_int(3);
 #elif IS_MACOS
     int major, minor, bugfix;
     getOperatingSystemVersion_mac(&major, &minor, &bugfix);

--- a/src/Native/environment_linux.c
+++ b/src/Native/environment_linux.c
@@ -1,0 +1,30 @@
+#include "config.h"
+#ifdef IS_LINUX
+#include <sys/utsname.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+
+void getOperatingSystemVersion_linux(int *kernel, int *major, int *minor, int *patch) {
+    long ver[16];
+    struct utsname unameInfo;
+    uname(&unameInfo);
+
+    char *cursor = unameInfo.release;
+    int i = 0;
+    while (*cursor) {
+        if (isdigit(*cursor)) {
+            ver[i] = strtol(cursor, &cursor, 10);
+            i++;
+        } else {
+            cursor++;
+        }
+    }
+
+    *kernel = (int)ver[0];
+    *major = (int)ver[1];
+    *minor = (int)ver[2];
+    *patch = (int)ver[3];
+}
+
+#endif


### PR DESCRIPTION
This extends #1030 to add the same sort of information on Linux. Now the constructor has four arguments: `Linux(kernel, major, minor, patch)`.