### PR TITLE
feat(environment): add version information on Windows

### DIFF
--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -20,7 +20,6 @@ type os =
     | Unknown
     | Android
     | IOS
-    | Windows
     | Browser
     | Mac({
         major: int,
@@ -32,6 +31,11 @@ type os =
         major: int,
         minor: int,
         patch: int,
+      })
+    | Windows({
+        major: int,
+        minor: int,
+        build: int,
       });
 
 let os = {
@@ -44,7 +48,8 @@ let osString =
     Printf.sprintf("macOS %d.%d.%d", major, minor, bugfix)
   | Linux({kernel, major, minor, patch}) =>
     Printf.sprintf("Linux %d.%d.%d-%d", kernel, major, minor, patch)
-  | Windows => "Windows"
+  | Windows({major, minor, build}) =>
+    Printf.sprintf("Windows %d.%d Build %d", major, minor, build)
   | Android => "Android"
   | Browser => "Browser"
   | IOS => "iOS"
@@ -61,11 +66,13 @@ let isLinux =
   | Linux(_) => true
   | _ => false
   };
+let isWindows =
+  switch (os) {
+  | Windows(_) => true
+  | _ => false
+  };
 let isIOS = {
   os == IOS;
-};
-let isWindows = {
-  os == Windows;
 };
 let isAndroid = {
   os == Android;

--- a/src/Core/Environment.rei
+++ b/src/Core/Environment.rei
@@ -50,7 +50,6 @@ type os =
   | Unknown
   | Android
   | IOS
-  | Windows
   | Browser
   | Mac({
       major: int,
@@ -62,6 +61,11 @@ type os =
       major: int,
       minor: int,
       patch: int,
+    })
+  | Windows({
+      major: int,
+      minor: int,
+      build: int,
     });
 
 let os: os;

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -70,7 +70,7 @@ module WindowMetrics: {
         | IOS
         | Mac(_) => 1.0
         // On Windows, we need to try a Win32 API to get the scale factor
-        | Windows =>
+        | Windows(_) =>
           let scale = Sdl2.Window.getWin32ScaleFactor(sdlWindow);
           Log.tracef(m =>
             m("_getScaleFactor - from getWin32ScaleFactor: %f", scale)
@@ -250,7 +250,7 @@ module Internal = {
     | IOS
     | Linux(_)
     | Unknown
-    | Windows => ()
+    | Windows(_) => ()
     };
   };
 

--- a/src/Font/FontFamily.re
+++ b/src/Font/FontFamily.re
@@ -89,7 +89,7 @@ let default =
 let defaultMono =
   switch (Revery_Core.Environment.os) {
   | Mac(_) => system("Menlo")
-  | Windows => system("Consolas")
+  | Windows(_) => system("Consolas")
   | _ => fromFile("Inconsolata.otf")
   };
 

--- a/src/Native/Environment.re
+++ b/src/Native/Environment.re
@@ -4,7 +4,6 @@ type os =
   | Unknown // 0
   | Android // 1
   | IOS // 2
-  | Windows // 3
   | Browser // 4
   /* Block values */
   | Mac({
@@ -17,6 +16,11 @@ type os =
       major: int,
       minor: int,
       patch: int,
-    }); // 1
+    }) // 1
+  | Windows({
+      major: int,
+      minor: int,
+      build: int,
+    }); // 2
 
 external getOS: unit => os = "revery_getOperatingSystem";

--- a/src/Native/ReveryWindows.h
+++ b/src/Native/ReveryWindows.h
@@ -1,0 +1,4 @@
+#pragma once
+
+/* Environment functions */
+void getOperatingSystemVersion_windows(int *major, int *minor, int *build);

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -9,7 +9,7 @@
         Revery_Native
         dialog dialog_cocoa dialog_win32 dialog_gtk
         notification notification_cocoa
-        environment environment_mac environment_linux
+        environment environment_mac environment_linux environment_windows
         icon icon_cocoa icon_win32
         shell shell_cocoa shell_gtk shell_win32
         locale locale_cocoa locale_win32

--- a/src/Native/environment.c
+++ b/src/Native/environment.c
@@ -15,6 +15,8 @@
 #import "ReveryMac.h"
 #elif IS_LINUX
 #include "ReveryLinux.h"
+#elif IS_WINDOWS
+#include "ReveryWindows.h"
 #endif
 
 CAMLprim value revery_getOperatingSystem() {
@@ -33,7 +35,12 @@ CAMLprim value revery_getOperatingSystem() {
     Store_field(vOS, 2, Val_int(minor));
     Store_field(vOS, 3, Val_int(patch));
 #elif IS_WINDOWS
-    vOS = Val_int(3);
+    int major, minor, build;
+    getOperatingSystemVersion_windows(&major, &minor, &build);
+    vOS = caml_alloc(3, 2);
+    Store_field(vOS, 0, Val_int(major));
+    Store_field(vOS, 1, Val_int(minor));
+    Store_field(vOS, 2, Val_int(build));
 #elif IS_MACOS
     int major, minor, bugfix;
     getOperatingSystemVersion_mac(&major, &minor, &bugfix);

--- a/src/Native/environment_windows.c
+++ b/src/Native/environment_windows.c
@@ -1,0 +1,33 @@
+#include "config.h"
+#ifdef IS_WINDOWS
+#include <windows.h>
+#include <stdio.h>
+
+void getOperatingSystemVersion_windows(int *major, int *minor, int *build) {
+    OSVERSIONINFOW osVersion;
+    ZeroMemory(&osVersion, sizeof(OSVERSIONINFOW));
+    osVersion.dwOSVersionInfoSize = sizeof(OSVERSIONINFOW);
+
+    NTSTATUS (WINAPI *rtlGetVersion)(PRTL_OSVERSIONINFOW lpVersionInformation) = NULL;
+    HINSTANCE hNtDll = LoadLibrary("ntdll.dll");
+
+    if (hNtDll != NULL) {
+        rtlGetVersion = (NTSTATUS (WINAPI *)(PRTL_OSVERSIONINFOW))GetProcAddress(hNtDll, "RtlGetVersion");
+
+        if (rtlGetVersion != NULL) {
+            rtlGetVersion(&osVersion);
+        }
+
+        FreeLibrary(hNtDll);
+    }
+
+    if (rtlGetVersion == NULL) {
+        GetVersionEx((OSVERSIONINFO*)&osVersion);
+    }
+
+    *major = (int)osVersion.dwMajorVersion;
+    *minor = (int)osVersion.dwMinorVersion;
+    *build = (int)osVersion.dwBuildNumber;
+}
+
+#endif


### PR DESCRIPTION
Extends both #1030 #1031 to include the version information on Windows. Now the constructor looks like `Windows({major: int, minor: int, build: int})`