### PR TITLE
feat(window): add function to set unsaved work

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -376,8 +376,6 @@ let init = app => {
 
   Console.log(Printf.sprintf("Operating system: %s", Environment.osString));
 
-  Revery_Native.Window.setUnsavedWork(window |> Window.getSdlWindow, true);
-
   let _renderFunction =
     UI.start(window, <ExampleHost window initialExample />);
   ();

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -376,6 +376,8 @@ let init = app => {
 
   Console.log(Printf.sprintf("Operating system: %s", Environment.osString));
 
+  Revery_Native.Window.setUnsavedWork(window |> Window.getSdlWindow, true);
+
   let _renderFunction =
     UI.start(window, <ExampleHost window initialExample />);
   ();

--- a/examples/NativeIconExample.re
+++ b/examples/NativeIconExample.re
@@ -4,6 +4,8 @@ open Revery.UI.Components;
 
 open Revery.Native;
 
+module Window = Revery.Window;
+
 module NativeFileExamples = {
   let%component make = (~window as w, ()) => {
     let%hook (maybeIcon, setMaybeIcon) = Hooks.state(None);

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -382,6 +382,10 @@ let setZoom = (window, zoom) => {
   window.metrics = WindowMetrics.setZoom(max(zoom, 0.1), window.metrics);
 };
 
+let setUnsavedWork = (window, truth) => {
+  Revery_Native.Window.setUnsavedWork(window.sdlWindow, truth);
+};
+
 let render = window => {
   Internal.resizeIfNecessary(window);
 

--- a/src/Core/Window.rei
+++ b/src/Core/Window.rei
@@ -93,6 +93,7 @@ let setPosition: (t, int, int) => unit;
 let setTitle: (t, string) => unit;
 let setZoom: (t, float) => unit;
 let setVsync: (t, Vsync.t) => unit;
+let setUnsavedWork: (t, bool) => unit;
 
 let render: t => unit;
 let handleEvent: (Sdl2.Event.t, t) => unit;

--- a/src/Native/ReveryCocoa.h
+++ b/src/Native/ReveryCocoa.h
@@ -40,3 +40,5 @@ void revery_menuInsertItemAt_cocoa(void *nsMenu, void *nsMenuItem, int idx);
 void revery_menuInsertSubmenuAt_cocoa(void *parent, void *child, int idx);
 void revery_menuClear_cocoa(void *nsMenu);
 
+/* Window functions */
+void revery_windowSetUnsavedWork_cocoa(void *memory, int truth);

--- a/src/Native/Revery_Native.re
+++ b/src/Native/Revery_Native.re
@@ -6,5 +6,6 @@ module Shell = Shell;
 module Locale = Locale;
 module Gtk = Gtk;
 module Menu = Menu;
+module Window = Window;
 
 include Initialization;

--- a/src/Native/Window.re
+++ b/src/Native/Window.re
@@ -1,0 +1,9 @@
+open {
+       type t = Sdl2.Window.nativeWindow;
+
+       external c_setUnsavedWork: (t, bool) => unit =
+         "revery_windowSetUnsavedWork";
+     };
+
+let setUnsavedWork = (window, truth) =>
+  c_setUnsavedWork(window |> Sdl2.Window.getNativeWindow, truth);

--- a/src/Native/dune
+++ b/src/Native/dune
@@ -14,6 +14,7 @@
         shell shell_cocoa shell_gtk shell_win32
         locale locale_cocoa locale_win32
         menu menu_cocoa
+        window window_cocoa
         utilities
         ReveryGtk ReveryGtk_Widget
         ReveryAppDelegate ReveryAppDelegate_func

--- a/src/Native/window.c
+++ b/src/Native/window.c
@@ -1,0 +1,33 @@
+#include <caml/alloc.h>
+#include <caml/callback.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <string.h>
+
+#include "caml_values.h"
+
+#include "config.h"
+#ifdef USE_WIN32
+#include "ReveryWin32.h"
+#elif USE_COCOA
+#include "ReveryCocoa.h"
+#import <Cocoa/Cocoa.h>
+#elif USE_GTK
+#include "ReveryGtk.h"
+#endif
+#include "utilities.h"
+
+CAMLprim value revery_windowSetUnsavedWork(value vWindow, value vTruth) {
+    CAMLparam2(vWindow, vTruth);
+
+    void *window = revery_unwrapPointer(vWindow);
+    int truth = Bool_val(vTruth);
+#ifdef USE_COCOA
+    revery_windowSetUnsavedWork_cocoa(window, truth);
+#else
+    UNUSED(window);
+    UNUSED(truth);
+#endif
+
+    CAMLreturn(Val_unit);
+}

--- a/src/Native/window_cocoa.c
+++ b/src/Native/window_cocoa.c
@@ -1,0 +1,10 @@
+#include "config.h"
+#ifdef USE_COCOA
+
+#import <Cocoa/Cocoa.h>
+
+void revery_windowSetUnsavedWork_cocoa(NSWindow *window, int truth) {
+    [window setDocumentEdited:truth];
+}
+
+#endif


### PR DESCRIPTION
This adds a function in a newly created `Revery_Native.Window` and in `Revery_Core.Window` to mark a window as having unsaved work. All this means as of now is that on macOS, the exit button has a little dot in it, i.e.:
![image](https://user-images.githubusercontent.com/4527949/103419314-85e12300-4b60-11eb-8d53-f6e0e6ce2287.png)
This would be a nice little thing to add to Oni, I think 😃 