### PR TITLE
fix(windows): HitTest - Fix missed CAMLreturn in hit test function

### DIFF
--- a/packages/reason-sdl2/src/sdl2_wrapper.cpp
+++ b/packages/reason-sdl2/src/sdl2_wrapper.cpp
@@ -148,7 +148,7 @@ extern "C" {
             break;
         }
 
-        return result;
+        CAMLreturnT(SDL_HitTestResult, result);
     };
 
     CAMLprim value resdl_SDL_EnableHitTest(value vWin) {


### PR DESCRIPTION
__Issue:__ Mouse gestures could potentially cause a crash - ie, https://github.com/onivim/oni2/issues/2919

__Defect:__ In our SDL2 hit test callback, there was an `CAMLparam` and `CAMLlocal` without a matching `CAMLreturn` - breaking the OCaml GC rules. This issue had been around for awhile, but it seems that the extra allocation via wrapping in a caml-managed value helped expose it (https://github.com/revery-ui/revery/commit/5fe4207630eb392d4882fe0f2853bf5f7a907b01)

__Fix:__ Add `CAMLreturnT` to properly wrap the function for the GC