### PR TITLE
fix(osx): Add release/acquire around dialog, since it may trigger callbacks

### DIFF
--- a/src/Native/dialog.c
+++ b/src/Native/dialog.c
@@ -4,6 +4,7 @@
 #include <caml/callback.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
+#include <caml/threads.h>
 
 #include "caml_values.h"
 
@@ -110,9 +111,11 @@ CAMLprim value revery_alertOpenFiles_native(
     (void)showHidden;
     (void)buttonText;
 #elif USE_COCOA
+    caml_release_runtime_system();
     fileList = revery_open_files_cocoa(
                    startDirectory, fileTypes, fileTypesSize, allowMultiple, canChooseFiles,
                    canChooseDirectories, showHidden, buttonText, title);
+    caml_acquire_runtime_system();
 #elif USE_GTK
     fileList = revery_open_files_gtk(
                    startDirectory, fileTypes, fileTypesSize, allowMultiple, canChooseFiles,


### PR DESCRIPTION
__Issue:__ A crash in Onivim 2 was discovered - there could be crashes in notification handlers triggered by opening a dialog - https://github.com/onivim/oni2/pull/2967

__Defect:__ The notification handlers expect that the runtime is not acquired when they are called, however, there was a case in `runModal` that could trigger notification callbacks while the runtime is acquired

__Fix:__ Release / acquire the runtime around `runModal`