### PR TITLE
feat(menu): add more menu item features

### DIFF
--- a/examples/NativeMenuExample.re
+++ b/examples/NativeMenuExample.re
@@ -70,6 +70,8 @@ module View = {
           (),
         );
 
+      Menu.Item.setEnabled(item312, false);
+
       Menu.addItem(subMenu31, item311);
       Menu.addItem(subMenu31, separator);
       Menu.addItem(subMenu31, item312);

--- a/examples/NativeMenuExample.re
+++ b/examples/NativeMenuExample.re
@@ -72,9 +72,19 @@ module View = {
 
       Menu.Item.setEnabled(item312, false);
 
+      let item313 =
+        Menu.Item.create(
+          ~title="Item 3.1.3",
+          ~onClick=menuCallback("Item 1.5"),
+          (),
+        );
+
+      Menu.Item.setVisible(item313, false); // Shouldn't show up
+
       Menu.addItem(subMenu31, item311);
       Menu.addItem(subMenu31, separator);
       Menu.addItem(subMenu31, item312);
+      Menu.addItem(subMenu31, item313);
 
       let endTime = Time.now();
       let delta = Time.(endTime - startTime) |> Time.toFloatSeconds;

--- a/examples/NativeMenuExample.re
+++ b/examples/NativeMenuExample.re
@@ -61,7 +61,18 @@ module View = {
           (),
         );
 
+      let separator = Menu.Item.createSeparator();
+
+      let item312 =
+        Menu.Item.create(
+          ~title="Item 3.1.2",
+          ~onClick=menuCallback("Item 1.4"),
+          (),
+        );
+
       Menu.addItem(subMenu31, item311);
+      Menu.addItem(subMenu31, separator);
+      Menu.addItem(subMenu31, item312);
 
       let endTime = Time.now();
       let delta = Time.(endTime - startTime) |> Time.toFloatSeconds;

--- a/src/Native/Menu.re
+++ b/src/Native/Menu.re
@@ -65,6 +65,7 @@ module Item = {
   Callback.register("revery_callbackForMenuItem", callbackForMenuItem);
 
   external createSeparator: unit => t = "revery_menuItemCreateSeparator";
+  external setEnabled: (t, bool) => unit = "revery_menuItemSetEnabled";
 
   %if
   defined(USE_COCOA);

--- a/src/Native/Menu.re
+++ b/src/Native/Menu.re
@@ -64,6 +64,8 @@ module Item = {
 
   Callback.register("revery_callbackForMenuItem", callbackForMenuItem);
 
+  external createSeparator: unit => t = "revery_menuItemCreateSeparator";
+
   %if
   defined(USE_COCOA);
 

--- a/src/Native/Menu.re
+++ b/src/Native/Menu.re
@@ -66,6 +66,7 @@ module Item = {
 
   external createSeparator: unit => t = "revery_menuItemCreateSeparator";
   external setEnabled: (t, bool) => unit = "revery_menuItemSetEnabled";
+  external setVisible: (t, bool) => unit = "revery_menuItemSetVisible";
 
   %if
   defined(USE_COCOA);

--- a/src/Native/Menu.rei
+++ b/src/Native/Menu.rei
@@ -29,6 +29,7 @@ module Item: {
     ) =>
     t;
   let createSeparator: unit => t;
+  let setEnabled: (t, bool) => unit;
 
   let getSubmenu: t => option(menu);
 };

--- a/src/Native/Menu.rei
+++ b/src/Native/Menu.rei
@@ -28,6 +28,8 @@ module Item: {
       unit
     ) =>
     t;
+  let createSeparator: unit => t;
+
   let getSubmenu: t => option(menu);
 };
 

--- a/src/Native/Menu.rei
+++ b/src/Native/Menu.rei
@@ -30,6 +30,7 @@ module Item: {
     t;
   let createSeparator: unit => t;
   let setEnabled: (t, bool) => unit;
+  let setVisible: (t, bool) => unit;
 
   let getSubmenu: t => option(menu);
 };

--- a/src/Native/ReveryCocoa.h
+++ b/src/Native/ReveryCocoa.h
@@ -40,6 +40,7 @@ void revery_menuInsertItemAt_cocoa(void *nsMenu, void *nsMenuItem, int idx);
 void revery_menuInsertSubmenuAt_cocoa(void *parent, void *child, int idx);
 void revery_menuClear_cocoa(void *nsMenu);
 void *revery_menuItemCreateSeparator_cocoa();
+void revery_menuItemSetEnabled_cocoa(void *menuItem, int truth);
 
 /* Window functions */
 void revery_windowSetUnsavedWork_cocoa(void *memory, int truth);

--- a/src/Native/ReveryCocoa.h
+++ b/src/Native/ReveryCocoa.h
@@ -41,6 +41,7 @@ void revery_menuInsertSubmenuAt_cocoa(void *parent, void *child, int idx);
 void revery_menuClear_cocoa(void *nsMenu);
 void *revery_menuItemCreateSeparator_cocoa();
 void revery_menuItemSetEnabled_cocoa(void *menuItem, int truth);
+void revery_menuItemSetVisible_cocoa(void *menuItem, int truth);
 
 /* Window functions */
 void revery_windowSetUnsavedWork_cocoa(void *memory, int truth);

--- a/src/Native/ReveryCocoa.h
+++ b/src/Native/ReveryCocoa.h
@@ -39,6 +39,7 @@ void revery_menuRemoveItem_cocoa(void *nsMenu, void *nsMenuItem);
 void revery_menuInsertItemAt_cocoa(void *nsMenu, void *nsMenuItem, int idx);
 void revery_menuInsertSubmenuAt_cocoa(void *parent, void *child, int idx);
 void revery_menuClear_cocoa(void *nsMenu);
+void *revery_menuItemCreateSeparator_cocoa();
 
 /* Window functions */
 void revery_windowSetUnsavedWork_cocoa(void *memory, int truth);

--- a/src/Native/menu.c
+++ b/src/Native/menu.c
@@ -261,3 +261,19 @@ CAMLprim value revery_menuItemSetEnabled(value vMenuItem, value vTruth) {
 
     CAMLreturn(Val_unit);
 }
+
+CAMLprim value revery_menuItemSetVisible(value vMenuItem, value vTruth) {
+    CAMLparam2(vMenuItem, vTruth);
+
+    void *menuItem = revery_unwrapPointer(vMenuItem);
+    int truth = Bool_val(vTruth);
+
+#ifdef USE_COCOA
+    revery_menuItemSetVisible_cocoa(menuItem, truth);
+#else
+    UNUSED(menuItem);
+    UNUSED(truth);
+#endif
+
+    CAMLreturn(Val_unit);
+}

--- a/src/Native/menu.c
+++ b/src/Native/menu.c
@@ -230,3 +230,18 @@ CAMLprim value revery_menuClear(value vMenu) {
 
     CAMLreturn(Val_unit);
 }
+
+CAMLprim value revery_menuItemCreateSeparator() {
+    CAMLparam0();
+    CAMLlocal1(vSeparator);
+
+    void *separator;
+#ifdef USE_COCOA
+    separator = revery_menuItemCreateSeparator_cocoa();
+#else
+    separator = NULL;
+#endif
+    vSeparator = revery_wrapPointer(separator);
+
+    CAMLreturn(vSeparator);
+}

--- a/src/Native/menu.c
+++ b/src/Native/menu.c
@@ -245,3 +245,19 @@ CAMLprim value revery_menuItemCreateSeparator() {
 
     CAMLreturn(vSeparator);
 }
+
+CAMLprim value revery_menuItemSetEnabled(value vMenuItem, value vTruth) {
+    CAMLparam2(vMenuItem, vTruth);
+
+    void *menuItem = revery_unwrapPointer(vMenuItem);
+    int truth = Bool_val(vTruth);
+
+#ifdef USE_COCOA
+    revery_menuItemSetEnabled_cocoa(menuItem, truth);
+#else
+    UNUSED(menuItem);
+    UNUSED(truth);
+#endif
+
+    CAMLreturn(Val_unit);
+}

--- a/src/Native/menu_cocoa.c
+++ b/src/Native/menu_cocoa.c
@@ -14,7 +14,9 @@ NSMenu *revery_getMenuBarHandle_cocoa() {
 
 NSMenu *revery_menuCreate_cocoa(const char *title) {
     NSString *nsTitle = [NSString stringWithUTF8String:title];
-    return [[NSMenu alloc] initWithTitle:nsTitle];
+    NSMenu *nsMenu = [[NSMenu alloc] initWithTitle:nsTitle];
+    [nsMenu setAutoenablesItems:NO];
+    return nsMenu;
 }
 
 NSMenuItem *revery_menuItemCreate_cocoa(const char *title, struct KeyEquivalent *keyEquivalent) {
@@ -104,5 +106,9 @@ void revery_menuClear_cocoa(NSMenu *nsMenu) {
 
 NSMenuItem *revery_menuItemCreateSeparator_cocoa() {
     return [NSMenuItem separatorItem];
+}
+
+void revery_menuItemSetEnabled_cocoa(NSMenuItem *nsMenuItem, int truth) {
+    [nsMenuItem setEnabled:truth];
 }
 #endif

--- a/src/Native/menu_cocoa.c
+++ b/src/Native/menu_cocoa.c
@@ -101,4 +101,8 @@ void revery_menuInsertSubmenuAt_cocoa(NSMenu *parent, NSMenu *child, int idx) {
 void revery_menuClear_cocoa(NSMenu *nsMenu) {
     [nsMenu removeAllItems];
 }
+
+NSMenuItem *revery_menuItemCreateSeparator_cocoa() {
+    return [NSMenuItem separatorItem];
+}
 #endif

--- a/src/Native/menu_cocoa.c
+++ b/src/Native/menu_cocoa.c
@@ -111,4 +111,8 @@ NSMenuItem *revery_menuItemCreateSeparator_cocoa() {
 void revery_menuItemSetEnabled_cocoa(NSMenuItem *nsMenuItem, int truth) {
     [nsMenuItem setEnabled:truth];
 }
+
+void revery_menuItemSetVisible_cocoa(NSMenuItem *nsMenuItem, int truth) {
+    [nsMenuItem setHidden:!truth];
+}
 #endif


### PR DESCRIPTION
I totally forgot this in the original menu PR, but @bryphe mentioned it in onivim/oni2#2969.

This just adds `Menu.Item.createSeparator`, which creates a separator item.

On macOS, it looks like this:
<img width="273" alt="image" src="https://user-images.githubusercontent.com/4527949/104097222-27a3f680-526a-11eb-91e6-b6399e02ecda.png">
