### PR TITLE
feat(audio): Add Wav File Playback to SDL

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -190,6 +190,11 @@ let examples = [
     render: _ => ImageQualityExample.render(),
     source: "ImageQualityExample.re",
   },
+  {
+    name: "WavFilePlayback",
+    render: _ => WavFilePlaybackExample.render(),
+    source: "WavFilePlaybackExample.re",
+  },
 ];
 
 let getExampleByName = name =>

--- a/examples/WavFilePlaybackExample.re
+++ b/examples/WavFilePlaybackExample.re
@@ -135,7 +135,7 @@ module WavFilePlaybackExamples = {
 
     let play = () => {
       switch (audioData, audioDevice) {
-      | (Some((spec, buf, len)), Some(device)) =>
+      | (Some((_spec, buf, len)), Some(device)) =>
         if (audioQueuedBytes > 0.) {
           Sdl2.Audio.Device.pause(device, false);
         } else {

--- a/examples/WavFilePlaybackExample.re
+++ b/examples/WavFilePlaybackExample.re
@@ -1,0 +1,238 @@
+open Revery;
+open Revery.UI;
+open Revery.UI.Components;
+open Revery.Native;
+
+module AudioHelpers = {
+  let getBitsPerSample =
+    fun
+    | Sdl2.Audio.Format.U8
+    | S8 => 8
+    | S16LSB
+    | S16MSB
+    | U16LSB
+    | U16MSB => 16
+    | S32LSB
+    | S32MSB
+    | F32LSB
+    | F32MSB => 32;
+
+  let getAudioDuration = (spec: Sdl2.Audio.Spec.t, bytes) => {
+    bytes / (spec.freq * spec.channels * (getBitsPerSample(spec.format) / 8));
+  };
+};
+
+module Styles = {
+  let container =
+    Style.[
+      position(`Absolute),
+      top(0),
+      bottom(0),
+      left(0),
+      right(0),
+      alignItems(`Center),
+      justifyContent(`Center),
+      flexDirection(`Column),
+    ];
+  let text = Style.[color(Colors.white), margin(14)];
+  let audioPlayerTrack =
+    Style.[
+      width(200),
+      marginBottom(14),
+      padding(2),
+      borderRadius(8.),
+      backgroundColor(Colors.dimGrey),
+      alignItems(`Center),
+      flexDirection(`Row),
+      justifyContent(`Center),
+    ];
+};
+
+module WavFilePlaybackExamples = {
+  let%component make = () => {
+    let%hook (filename, setFilename) = Hooks.state("");
+    let%hook (audioData, setAudioData) = Hooks.state(None);
+    let%hook (audioDevice, setAudioDevice) = Hooks.state(None);
+    let%hook (audioDeviceStatus, setAudioDeviceStatus) =
+      Hooks.state(Sdl2.Audio.Device.Status.Stopped);
+    let%hook (audioQueuedBytes, setAudioQueuedBytes) = Hooks.state(0);
+    let%hook () =
+      Hooks.tick(~name="", ~tickRate=Time.milliseconds(50), _ => {
+        switch (audioDevice) {
+        | Some(device) =>
+          let status = Sdl2.Audio.Device.getStatus(device);
+          setAudioDeviceStatus(_ => status);
+          let bytes = Sdl2.Audio.getQueuedSize(device);
+          setAudioQueuedBytes(_ => bytes);
+        | _ => ()
+        }
+      });
+
+    let audioQueuedBytes = float(audioQueuedBytes);
+    let audioTotalBytes =
+      switch (audioData) {
+      | Some((_, _, len)) => float(len)
+      | _ => 0.
+      };
+    let audioPlayedBytes =
+      audioQueuedBytes > 0. ? audioTotalBytes -. audioQueuedBytes : 0.;
+    let audioPlaybackProgress = audioPlayedBytes /. audioTotalBytes;
+    let audioDuration =
+      switch (audioData) {
+      | Some((spec: Sdl2.Audio.Spec.t, _, bytes)) =>
+        AudioHelpers.getAudioDuration(spec, bytes)
+      | _ => 0
+      };
+    let audioElapsed =
+      int_of_float(float(audioDuration) *. audioPlaybackProgress);
+
+    let openAudioDevice = desiredSpec => {
+      switch (audioDevice) {
+      | Some(device) => Sdl2.Audio.Device.close(device)
+      | _ => ()
+      };
+      switch (
+        Sdl2.Audio.Device.open_(
+          None,
+          false,
+          desiredSpec,
+          Sdl2.Audio.Device.AllowedChanges.none,
+        )
+      ) {
+      | Error(err) => Console.error(err)
+      | Ok((device, _obstainedSpec)) => setAudioDevice(_ => Some(device))
+      };
+    };
+
+    let loadWavFile = filename => {
+      switch (Sdl2.Audio.Wav.load(filename)) {
+      | Error(err) => Console.error(err)
+      | Ok(data) =>
+        setAudioData(_ => Some(data));
+        let (spec, _, _) = data;
+        openAudioDevice(spec);
+      };
+    };
+
+    let openFile = () => {
+      let files =
+        Dialog.openFiles(
+          ~fileTypes=[|"wav", "wave"|],
+          ~allowMultiple=false,
+          ~canChooseDirectories=false,
+          ~showHidden=false,
+          ~title="Revery Open File Example",
+          ~buttonText="Open file in Revery",
+          (),
+        );
+      switch (files) {
+      | Some([|path|]) =>
+        setFilename(_ => path |> Filename.basename);
+        loadWavFile(path);
+      | _ => ()
+      };
+    };
+
+    let play = () => {
+      switch (audioData, audioDevice) {
+      | (Some((spec, buf, len)), Some(device)) =>
+        if (audioQueuedBytes > 0.) {
+          Sdl2.Audio.Device.pause(device, false);
+        } else {
+          switch (Sdl2.Audio.queue(device, buf, len)) {
+          | Error(err) => Console.error(err)
+          | Ok(_) => Sdl2.Audio.Device.pause(device, false)
+          };
+        }
+      | _ => ()
+      };
+    };
+
+    let pause = () => {
+      switch (audioDevice) {
+      | Some(device) => Sdl2.Audio.Device.pause(device, true)
+      | _ => ()
+      };
+    };
+
+    if (filename == "") {
+      <View style=Styles.container>
+        <Text style=Styles.text fontSize=20. text="WAV File Playback" />
+        <Button
+          title="Open File"
+          fontSize=12.
+          height=50
+          width=100
+          onClick=openFile
+        />
+      </View>;
+    } else {
+      <View style=Styles.container>
+        <Row>
+          <Text style=Styles.text fontSize=20. text="Audio Loaded" />
+        </Row>
+        <Row> <Text fontSize=12. style=Styles.text text=filename /> </Row>
+        <Row>
+          <View style=Styles.audioPlayerTrack>
+            <Text
+              fontSize=12.
+              style=Styles.text
+              text=Time.(seconds(audioElapsed) |> toString)
+            />
+            <Slider
+              value=audioPlayedBytes
+              minimumValue=0.
+              maximumValue=audioTotalBytes
+              thumbThickness=0
+              thumbLength=0
+              thumbColor={Color.hex("#90f7ff")}
+            />
+            <Text
+              fontSize=12.
+              style=Styles.text
+              text=Time.(seconds(audioDuration) |> toString)
+            />
+          </View>
+        </Row>
+        <Row>
+          {switch (audioDeviceStatus) {
+           | Stopped
+           | Paused =>
+             <Button
+               title="Play"
+               fontSize=12.
+               height=50
+               width=100
+               onClick=play
+             />
+           | Playing =>
+             audioPlaybackProgress == 1.
+               ? <Button
+                   title="Play"
+                   fontSize=12.
+                   height=50
+                   width=100
+                   onClick=play
+                 />
+               : <Button
+                   title="Pause"
+                   fontSize=12.
+                   height=50
+                   width=100
+                   onClick=pause
+                 />
+           }}
+          <Button
+            title="Open File"
+            fontSize=12.
+            height=50
+            width=100
+            onClick=openFile
+          />
+        </Row>
+      </View>;
+    };
+  };
+};
+
+let render = () => <WavFilePlaybackExamples />;

--- a/examples/WavFilePlaybackExample.re
+++ b/examples/WavFilePlaybackExample.re
@@ -206,7 +206,7 @@ module WavFilePlaybackExamples = {
                onClick=play
              />
            | Playing =>
-             audioPlaybackProgress == 1.
+             audioQueuedBytes == 0.
                ? <Button
                    title="Play"
                    fontSize=12.

--- a/packages/reason-sdl2/src/sdl2.re
+++ b/packages/reason-sdl2/src/sdl2.re
@@ -32,6 +32,34 @@ module Surface = {
     "resdl_SDL_CreateRGBSurfaceFromImage";
 };
 
+module Audio = {
+  module Buffer {
+    type t;
+  }
+  module Spec = {
+    type t = {
+      freq: int,
+      format: int,
+      channels: int,
+      silence: int,
+      samples: int,
+      padding: int,
+      size: int,
+    };
+  }
+  module WAV = {
+    external load: string => result((Spec.t, Buffer.t, int), string) = "resdl_SDL_LoadWAV"
+  }
+  module Device = {
+    type t;
+    external open_: Spec.t => t = "resdl_SDL_OpenAudioDevice"
+    external close: t => unit = "resdl_SDL_CloseAudioDevice"
+    external pause: (t, bool) => unit = "resdl_SDL_PauseAudioDevice"
+  }
+  external queue: (Device.t, Buffer.t, int) => result(unit, string) = "resdl_SDL_QueueAudio"
+  external clearQueued: (Device.t) => unit = "resdl_SDL_ClearQueuedAudio"
+}
+
 module Clipboard = {
   external getText: unit => option(string) = "resdl_SDL_GetClipboardText";
   external setText: string => unit = "resdl_SDL_SetClipboardText";

--- a/packages/reason-sdl2/src/sdl2.re
+++ b/packages/reason-sdl2/src/sdl2.re
@@ -33,9 +33,9 @@ module Surface = {
 };
 
 module Audio = {
-  module Buffer {
+  module Buffer = {
     type t;
-  }
+  };
   module Spec = {
     type t = {
       freq: int,
@@ -46,19 +46,21 @@ module Audio = {
       padding: int,
       size: int,
     };
-  }
-  module WAV = {
-    external load: string => result((Spec.t, Buffer.t, int), string) = "resdl_SDL_LoadWAV"
-  }
+  };
+  module Wav = {
+    external load: string => result((Spec.t, Buffer.t, int), string) =
+      "resdl_SDL_LoadWAV";
+  };
   module Device = {
     type t;
-    external open_: Spec.t => t = "resdl_SDL_OpenAudioDevice"
-    external close: t => unit = "resdl_SDL_CloseAudioDevice"
-    external pause: (t, bool) => unit = "resdl_SDL_PauseAudioDevice"
-  }
-  external queue: (Device.t, Buffer.t, int) => result(unit, string) = "resdl_SDL_QueueAudio"
-  external clearQueued: (Device.t) => unit = "resdl_SDL_ClearQueuedAudio"
-}
+    external open_: Spec.t => t = "resdl_SDL_OpenAudioDevice";
+    external close: t => unit = "resdl_SDL_CloseAudioDevice";
+    external pause: (t, bool) => unit = "resdl_SDL_PauseAudioDevice";
+  };
+  external queue: (Device.t, Buffer.t, int) => result(unit, string) =
+    "resdl_SDL_QueueAudio";
+  external clearQueued: Device.t => unit = "resdl_SDL_ClearQueuedAudio";
+};
 
 module Clipboard = {
   external getText: unit => option(string) = "resdl_SDL_GetClipboardText";

--- a/packages/reason-sdl2/src/sdl2_wrapper.cpp
+++ b/packages/reason-sdl2/src/sdl2_wrapper.cpp
@@ -20,7 +20,6 @@
 #include <SDL2/SDL_config.h>
 #include <SDL2/SDL_syswm.h>
 
-
 #ifdef SDL_VIDEO_DRIVER_COCOA
 #import <Cocoa/Cocoa.h>
 #endif

--- a/packages/reason-sdl2/src/sdl2_wrapper.cpp
+++ b/packages/reason-sdl2/src/sdl2_wrapper.cpp
@@ -1255,17 +1255,28 @@ extern "C" {
 
     static SDL_AudioFormat SDL_AudioFormat_val(value tag) {
         switch (Int_val(tag)) {
-            case 0: return AUDIO_S8;
-            case 1: return AUDIO_U8;
-            case 2: return AUDIO_S16LSB;
-            case 3: return AUDIO_S16MSB;
-            case 4: return AUDIO_U16LSB;
-            case 5: return AUDIO_U16MSB;
-            case 6: return AUDIO_S32LSB;
-            case 7: return AUDIO_S32MSB;
-            case 8: return AUDIO_F32LSB;
-            case 9: return AUDIO_F32MSB;
-            default: return 0;
+        case 0:
+            return AUDIO_S8;
+        case 1:
+            return AUDIO_U8;
+        case 2:
+            return AUDIO_S16LSB;
+        case 3:
+            return AUDIO_S16MSB;
+        case 4:
+            return AUDIO_U16LSB;
+        case 5:
+            return AUDIO_U16MSB;
+        case 6:
+            return AUDIO_S32LSB;
+        case 7:
+            return AUDIO_S32MSB;
+        case 8:
+            return AUDIO_F32LSB;
+        case 9:
+            return AUDIO_F32MSB;
+        default:
+            return 0;
         }
     }
 
@@ -1273,16 +1284,36 @@ extern "C" {
         CAMLparam0();
         int tag;
         switch (format) {
-            case AUDIO_S8: tag = 0; break;
-            case AUDIO_U8: tag = 1; break;
-            case AUDIO_S16LSB: tag = 2; break;
-            case AUDIO_S16MSB: tag = 3; break;
-            case AUDIO_U16LSB: tag = 4; break;
-            case AUDIO_U16MSB: tag = 5; break;
-            case AUDIO_S32LSB: tag = 6; break;
-            case AUDIO_S32MSB: tag = 7; break;
-            case AUDIO_F32LSB: tag = 8; break;
-            case AUDIO_F32MSB: tag = 9; break;
+        case AUDIO_S8:
+            tag = 0;
+            break;
+        case AUDIO_U8:
+            tag = 1;
+            break;
+        case AUDIO_S16LSB:
+            tag = 2;
+            break;
+        case AUDIO_S16MSB:
+            tag = 3;
+            break;
+        case AUDIO_U16LSB:
+            tag = 4;
+            break;
+        case AUDIO_U16MSB:
+            tag = 5;
+            break;
+        case AUDIO_S32LSB:
+            tag = 6;
+            break;
+        case AUDIO_S32MSB:
+            tag = 7;
+            break;
+        case AUDIO_F32LSB:
+            tag = 8;
+            break;
+        case AUDIO_F32MSB:
+            tag = 9;
+            break;
         }
         CAMLreturn(Val_int(tag));
     }
@@ -1323,14 +1354,14 @@ extern "C" {
 
     CAMLprim value resdl_SDL_OpenAudioDevice(
         value vDeviceNameOpt,
-        value vIsCapture, 
+        value vIsCapture,
         value vWant,
         value vAllowedChanges) {
         CAMLparam4(vDeviceNameOpt, vIsCapture, vWant, vAllowedChanges);
         CAMLlocal3(ret, vHave, vTup2);
         const char *deviceName = Is_block(vDeviceNameOpt)
-            ? String_val(Field(vDeviceNameOpt, 0))
-            : NULL;
+                                 ? String_val(Field(vDeviceNameOpt, 0))
+                                 : NULL;
         int isCapture = Bool_val(vIsCapture);
         SDL_AudioSpec want = {0};
         want.freq = Int_val(Field(vWant, 0));
@@ -1343,11 +1374,11 @@ extern "C" {
         SDL_AudioSpec have = {0};
         int allowedChanges = Int_val(vAllowedChanges);
         SDL_AudioDeviceID device = SDL_OpenAudioDevice(
-            deviceName,
-            isCapture,
-            &want,
-            &have,
-            allowedChanges);
+                                       deviceName,
+                                       isCapture,
+                                       &want,
+                                       &have,
+                                       allowedChanges);
         if (device == 0) {
             ret = Val_error(caml_copy_string(SDL_GetError()));
             CAMLreturn(ret);

--- a/packages/reason-sdl2/src/sdl2_wrapper.cpp
+++ b/packages/reason-sdl2/src/sdl2_wrapper.cpp
@@ -1331,26 +1331,6 @@ extern "C" {
         CAMLreturn(Val_unit);
     }
 
-    /* external play: string => result(unit, string) = "resdl_SDL_PlayWAV" */
-    // CAMLprim value resdl_SDL_PlayWAV(value vPath) {
-    //     CAMLparam1(vPath);
-    //     CAMLlocal1(ret);
-    //     SDL_AudioSpec wavSpec;
-    //     Uint32 wavLength;
-    //     Uint8 *wavBuffer;        
-    //     SDL_LoadWAV(String_val(vPath), &wavSpec, &wavBuffer, &wavLength);
-    //     SDL_AudioDeviceID deviceId = SDL_OpenAudioDevice(NULL, 0, &wavSpec, NULL, 0);
-    //     if (SDL_QueueAudio(deviceId, wavBuffer, wavLength) >= 0) {
-    //         SDL_PauseAudioDevice(deviceId, 0);
-    //         // SDL_CloseAudioDevice(deviceId); ???
-    //         ret = Val_ok(Val_unit);
-    //     } else {
-    //         ret = Val_error(caml_copy_string(SDL_GetError()));
-    //     }
-    //     SDL_FreeWAV(wavBuffer);
-    //     CAMLreturn(ret);
-    // }
-
     CAMLprim value resdl_SDL_CreateRGBSurfaceFromImage(value vPath) {
         CAMLparam1(vPath);
         CAMLlocal1(ret);


### PR DESCRIPTION
After seeing it mentioned in the roadmap, [this issue](https://github.com/revery-ui/revery/pull/555), and wanting it for my own personal Revery project, I added some WAV file playback support.

The interface exposed is a fairly straightforward mapping to a subset of SDL's Audio API. If we want to expose more of the SDL Audio API or would like to work on a higher-level Revery Audio API, I'd be happy to help out there.

Example Usage:
```re
open Revery.Sdl2.Audio;

/* 1. Load the WAV file spec and audio buffer */
let (desiredSpec, buf, len) =
  switch (Wav.load("audio.wav")) {
  | Ok(data) => data
  | Error(err) => failwith(err)
  };

/* 2. Open the audio device */
let (device, _obtainedSpec) =
  switch(Device.open_(None, false, desiredSpec, Device.AllowedChanges.none)) {
  | Ok(data) => data
  | Error(err) => failwith(err)
  };

/* 3. Play the audio buffer */
switch (queue(device, buf, len)) {
| Ok(_) => Device.pause(device, false)
| Error(err) => failwith(err)
};
```

I wasn't exactly sure what the best approach for testing and web support was, so I'd appreciate some direction.
Cheers! 🎉 