### PR TITLE
fix(OSX): Add flag to indicate if menu item is from key press or not

### DIFF
--- a/examples/NativeMenuExample.re
+++ b/examples/NativeMenuExample.re
@@ -20,8 +20,15 @@ module View = {
       let menu1 = Menu.create("Test 1");
       Menu.addSubmenu(~parent=menuBar, ~child=menu1);
 
-      let menuCallback = (str, ()) => {
-        print_endline(Printf.sprintf("%s clicked: %d", str, currentNonce));
+      let menuCallback = (str, ~fromKeyPress, ()) => {
+        print_endline(
+          Printf.sprintf(
+            "%s clicked: %d (from key press: %b)",
+            str,
+            currentNonce,
+            fromKeyPress,
+          ),
+        );
       };
 
       let item11 =

--- a/src/Native/Menu.re
+++ b/src/Native/Menu.re
@@ -54,10 +54,10 @@ module Item = {
 
   let callbackTbl = CallbackTbl.create(32);
 
-  let callbackForMenuItem = item => {
+  let callbackForMenuItem = (fromKeyPress, item) => {
     let callback = CallbackTbl.find_opt(callbackTbl, item);
     switch (callback) {
-    | Some(cb) => cb()
+    | Some(cb) => cb(~fromKeyPress, ())
     | None => ()
     };
   };

--- a/src/Native/Menu.rei
+++ b/src/Native/Menu.rei
@@ -23,7 +23,7 @@ module Item: {
   let create:
     (
       ~title: string,
-      ~onClick: unit => unit,
+      ~onClick: (~fromKeyPress: bool, unit) => unit,
       ~keyEquivalent: KeyEquivalent.t=?,
       unit
     ) =>

--- a/src/Native/cocoa/ReveryMenuItemTarget.c
+++ b/src/Native/cocoa/ReveryMenuItemTarget.c
@@ -28,10 +28,23 @@ static const camlValue *callbackForMenuItem;
     CAMLparam0();
     CAMLlocal1(vMenuItem);
 
+    // Whether the menu item 'click' was due to a shortcut key
+    int fDueToKeyPress = 0;
+
+    switch (NSApp.currentEvent.type) {
+    case NSEventTypeKeyDown:
+    case NSEventTypeKeyUp:
+        fDueToKeyPress = 1;
+        break;
+    default:
+        fDueToKeyPress = 0;
+        break;
+    }
+
     if (callbackForMenuItem != NULL) {
         vMenuItem = revery_wrapPointer(sender);
-        camlValue args[] = {vMenuItem};
-        revery_caml_call_n(*callbackForMenuItem, 1, args);
+        camlValue args[] = {Val_int(fDueToKeyPress), vMenuItem};
+        revery_caml_call_n(*callbackForMenuItem, 2, args);
     } else {
         NSLog(@"Unable to acquire menu item callback!");
     }


### PR DESCRIPTION
__Issue:__ In Onivim, when pressing a keyboard shortcut for a menu item, the command gets triggered twice - once via the input handler, and once via the menu callback.

From the menu callback, currently, we don't know whether this came from a keyboard command (which can be ignored, since the keyboard-input pipeline handles it), or if it came from a click / other gesture, in which case we should run it.

__Fix:__ Add a flag to indicate if this callback is due to a keypress or not.