### PR TITLE
Allow '`Undefined' WindowCreateOption for initial window position

### DIFF
--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -582,12 +582,12 @@ let create = (name: string, options: WindowCreateOptions.t) => {
   let x =
     switch (options.x) {
     | `Centered => `Absolute((screenBounds.width - width) / 2)
-    | `Absolute(x) => `Absolute(x)
+    | x => x
     };
   let y =
     switch (options.y) {
     | `Centered => `Absolute((screenBounds.height - height) / 2)
-    | `Absolute(y) => `Absolute(y)
+    | x => x
     };
 
   Log.infof(m =>

--- a/src/Core/WindowCreateOptions.re
+++ b/src/Core/WindowCreateOptions.re
@@ -35,13 +35,13 @@ type t = {
     or [`Absolute(x)], where [x] is the horizontal pixel coordinate of the left
     edge of the [Window]
     */
-  x: [ | `Centered | `Absolute(int)],
+  x: [ | `Undefined | `Centered | `Absolute(int)],
   /**
     [y] is the initial horizontal position of the [Window], either [`Centered]
     or [`Absolute(x)], where [y] is the vertical pixel coordinate of the top
     edge of the [Window]
     */
-  y: [ | `Centered | `Absolute(int)],
+  y: [ | `Undefined | `Centered | `Absolute(int)],
   /**
     [width] is the initial horizontal size of the [Window], with display scaling applied.
     */


### PR DESCRIPTION
Passing the `Undefined` variant to SDL allows the OS to choose the window position, which seems preferable to picking a location (`Absolute`) or spawning right in the middle of the desktop, across my two monitors (`Centered`).
Works fine from my testing.

Cool project btw.