### PR TITLE
onBeforeQuit: allow subscribers to prevent immediate quit

### DIFF
--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -306,7 +306,10 @@ let init = app => {
 
   App.onIdle(app, () => prerr_endline("Idle!"))
   |> (ignore: Revery.App.unsubscribe => unit);
-  App.onBeforeQuit(app, () => prerr_endline("Quitting!"))
+  App.onBeforeQuit(app, (_code: int) => {
+    prerr_endline("Quitting!");
+    App.AllowQuit
+  })
   |> (ignore: Revery.App.unsubscribe => unit);
 
   let initialExample = ref("Layer");

--- a/examples/Examples.re
+++ b/examples/Examples.re
@@ -306,10 +306,13 @@ let init = app => {
 
   App.onIdle(app, () => prerr_endline("Idle!"))
   |> (ignore: Revery.App.unsubscribe => unit);
-  App.onBeforeQuit(app, (_code: int) => {
-    prerr_endline("Quitting!");
-    App.AllowQuit
-  })
+  App.onBeforeQuit(
+    app,
+    (_code: int) => {
+      prerr_endline("Quitting!");
+      App.AllowQuit;
+    },
+  )
   |> (ignore: Revery.App.unsubscribe => unit);
 
   let initialExample = ref("Layer");

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -14,9 +14,9 @@ type quitResponse =
   | PreventQuit;
 
 let mergeQuitResponse = (a: quitResponse, b: quitResponse) => {
-  switch (a,b) {
-    | (AllowQuit, AllowQuit) => AllowQuit
-    | _ => PreventQuit
+  switch (a, b) {
+  | (AllowQuit, AllowQuit) => AllowQuit
+  | _ => PreventQuit
   };
 };
 
@@ -68,16 +68,21 @@ let quit = (~askNicely=false, ~code=0, app: t) => {
     if (!app.isQuitting) {
       Log.info("onBeforeQuit");
       app.isQuitting = true;
-      let quitResponse = Event.Fanout.dispatch(app.onBeforeQuit, mergeQuitResponse, AllowQuit, code);
+      let quitResponse =
+        Event.Fanout.dispatch(
+          app.onBeforeQuit,
+          mergeQuitResponse,
+          AllowQuit,
+          code,
+        );
       app.isQuitting = false;
 
       switch (quitResponse) {
-        | AllowQuit =>
-          Log.info("Quitting");
-          exit(code);
-        | PreventQuit =>
-          Log.info("Quit prevented by event handler");
-      }
+      | AllowQuit =>
+        Log.info("Quitting");
+        exit(code);
+      | PreventQuit => Log.info("Quit prevented by event handler")
+      };
     };
   };
 };

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -9,13 +9,24 @@ module Log = AppLog;
 type delegatedFunc = unit => unit;
 type unsubscribe = unit => unit;
 
+type quitResponse =
+  | AllowQuit
+  | PreventQuit;
+
+let mergeQuitResponse = (a: quitResponse, b: quitResponse) => {
+  switch (a,b) {
+    | (AllowQuit, AllowQuit) => AllowQuit
+    | _ => PreventQuit
+  };
+};
+
 type t = {
   mutable idleCount: int,
   mutable isFirstRender: bool,
   mutable isQuitting: bool,
   windows: Hashtbl.t(int, Window.t),
   onIdle: Event.t(unit),
-  onBeforeQuit: Event.t(unit),
+  onBeforeQuit: Event.Fanout.t(int, quitResponse),
   onFileOpen: Event.t(string),
   mutable canIdle: unit => bool,
 };
@@ -57,12 +68,17 @@ let quit = (~askNicely=false, ~code=0, app: t) => {
     if (!app.isQuitting) {
       Log.info("onBeforeQuit");
       app.isQuitting = true;
-      let _: unit = Event.dispatch(app.onBeforeQuit, ());
+      let quitResponse = Event.Fanout.dispatch(app.onBeforeQuit, mergeQuitResponse, AllowQuit, code);
       app.isQuitting = false;
-    };
 
-    Log.info("Quitting");
-    exit(code);
+      switch (quitResponse) {
+        | AllowQuit =>
+          Log.info("Quitting");
+          exit(code);
+        | PreventQuit =>
+          Log.info("Quit prevented by event handler");
+      }
+    };
   };
 };
 
@@ -90,7 +106,7 @@ let setCanIdle = (f, app: t) => {
   app.canIdle = f;
 };
 
-let onBeforeQuit = app => Event.subscribe(app.onBeforeQuit);
+let onBeforeQuit = app => Event.Fanout.subscribe(app.onBeforeQuit);
 let onIdle = app => Event.subscribe(app.onIdle);
 let onFileOpen = app => Event.subscribe(app.onFileOpen);
 

--- a/src/Core/App.rei
+++ b/src/Core/App.rei
@@ -51,8 +51,12 @@ let setCanIdle: (unit => bool, t) => unit;
 
 type unsubscribe = unit => unit;
 
+type quitResponse =
+  | AllowQuit
+  | PreventQuit;
+
 /** [onBeforeQuit(app, f) registers a callback [f] that is called prior to quitting] */
-let onBeforeQuit: (t, unit => unit) => unsubscribe;
+let onBeforeQuit: (t, int => quitResponse) => unsubscribe;
 
 /** [onIdle(app, f) registers a callback [f] that is called when the application is idle.
 

--- a/src/Core/Event.re
+++ b/src/Core/Event.re
@@ -1,7 +1,7 @@
 /* Event.re */
 
 module Fanout = {
-  /* An event where subsccribers can respond with a value */
+  /* An event where subscribers can respond with a value */
   type cb('a, 'b) = 'a => 'b;
 
   type t('a, 'b) = ref(list(cb('a, 'b)));

--- a/src/Core/Event.re
+++ b/src/Core/Event.re
@@ -1,5 +1,26 @@
 /* Event.re */
 
+module Fanout = {
+  /* An event where subsccribers can respond with a value */
+  type cb('a, 'b) = 'a => 'b;
+
+  type t('a, 'b) = ref(list(cb('a, 'b)));
+
+  let dispatch = (evt: t('a, 'b), merge: ('b, 'b) => 'b, zero: 'b, v: 'a) => {
+    List.fold_left((acc, listener) => merge(acc, listener(v)), zero, evt^);
+  };
+
+  let subscribe = (evt: t('a, 'b), f: cb('a, 'b)) => {
+    evt := List.append(evt^, [f]);
+    let unsubscribe = () => {
+      evt := List.filter(f => f !== f, evt^);
+    };
+    unsubscribe;
+  };
+};
+
+/* an event is just a fanout with a `unit` return type, but we duplicate the definition for simpler type errors */
+
 type cb('a) = 'a => unit;
 
 type t('a) = ref(list(cb('a)));
@@ -7,11 +28,7 @@ type t('a) = ref(list(cb('a)));
 let create = () => ref([]);
 
 let subscribe = (evt: t('a), f: cb('a)) => {
-  evt := List.append(evt^, [f]);
-  let unsubscribe = () => {
-    evt := List.filter(f => f !== f, evt^);
-  };
-  unsubscribe;
+  Fanout.subscribe(evt, f);
 };
 
 let dispatch = (evt: t('a), v: 'a) => List.iter(c => c(v), evt^);


### PR DESCRIPTION
Implements the API change discussed in https://github.com/onivim/oni2/issues/3270

I decided to make a `Fanout` submodule of Event to represent "events with return values", but am very open to alternative structures. It seemed unnecessary to add another type paramater for `Event.t` when it's almost always going to be `unit`.

Since this changes the onBeforeQuit signature anyway, I included the exit code since it seems like that might be useful, but I don't have a specific use case in mind.

I didn't make it backwards compatible. It would be possible by instead adding a new `onBeforeQuitFanout` (or something) function that exposes the ability to suppress the response, but I don't know what your plans are in general for backwards compat, so I went with the simplest version first.