### PR TITLE
fix(text): Allow ellipsis style w/o needing a width property

### DIFF
--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -232,9 +232,6 @@ class textNode (text: string) = {
        */
     (
       switch (_super#getStyle()) {
-      | {width: textWidth, _} as style
-          when textWidth == Layout.Encoding.cssUndefined =>
-        _this#handleTextWrapping(width, style)
       | {textOverflow: Ellipsis | UserDefined(_), _} =>
         _this#textOverflow(float_of_int(width))
       | style => _this#handleTextWrapping(width, style)


### PR DESCRIPTION
__Issue:__ If `textOverflow(Ellipsis)` is specified without a `width(..)` style, it is ignored.

__Fix:__ Allow `textOverflow(Ellipsis)`, using the available node width from` flex`, if `width(..)` style is not specified.