### PR TITLE
fix(window): Use SDL2's centering strategy for create window

### DIFF
--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -560,22 +560,6 @@ let create = (name: string, options: WindowCreateOptions.t) => {
        )
      });
 
-  // Calculate the total bounds of all displays
-  let screenBounds =
-    displays
-    |> List.fold_left(
-         (acc: Sdl2.Rect.t, display) => {
-           let bounds = Sdl2.Display.getBounds(display);
-           Sdl2.Rect.{
-             x: min(acc.x, bounds.x),
-             y: min(acc.y, bounds.y),
-             width: max(acc.width, bounds.x + bounds.width),
-             height: max(acc.height, bounds.y + bounds.height),
-           };
-         },
-         Sdl2.Rect.{x: 0, y: 0, width: 0, height: 0},
-       );
-
   let width = options.width == 0 ? 800 : options.width;
   let height = options.height == 0 ? 480 : options.height;
 

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -560,35 +560,11 @@ let create = (name: string, options: WindowCreateOptions.t) => {
        )
      });
 
-  // Calculate the total bounds of all displays
-  let screenBounds =
-    displays
-    |> List.fold_left(
-         (acc: Sdl2.Rect.t, display) => {
-           let bounds = Sdl2.Display.getBounds(display);
-           Sdl2.Rect.{
-             x: min(acc.x, bounds.x),
-             y: min(acc.y, bounds.y),
-             width: max(acc.width, bounds.x + bounds.width),
-             height: max(acc.height, bounds.y + bounds.height),
-           };
-         },
-         Sdl2.Rect.{x: 0, y: 0, width: 0, height: 0},
-       );
-
   let width = options.width == 0 ? 800 : options.width;
   let height = options.height == 0 ? 480 : options.height;
 
-  let x =
-    switch (options.x) {
-    | `Centered => `Absolute((screenBounds.width - width) / 2)
-    | x => x
-    };
-  let y =
-    switch (options.y) {
-    | `Centered => `Absolute((screenBounds.height - height) / 2)
-    | x => x
-    };
+  let x = options.x;
+  let y = options.x;
 
   Log.infof(m =>
     m("Creating window %s width: %u height: %u", name, width, height)

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -560,11 +560,35 @@ let create = (name: string, options: WindowCreateOptions.t) => {
        )
      });
 
+  // Calculate the total bounds of all displays
+  let screenBounds =
+    displays
+    |> List.fold_left(
+         (acc: Sdl2.Rect.t, display) => {
+           let bounds = Sdl2.Display.getBounds(display);
+           Sdl2.Rect.{
+             x: min(acc.x, bounds.x),
+             y: min(acc.y, bounds.y),
+             width: max(acc.width, bounds.x + bounds.width),
+             height: max(acc.height, bounds.y + bounds.height),
+           };
+         },
+         Sdl2.Rect.{x: 0, y: 0, width: 0, height: 0},
+       );
+
   let width = options.width == 0 ? 800 : options.width;
   let height = options.height == 0 ? 480 : options.height;
 
   let x = options.x;
-  let y = options.x;
+    // switch (options.x) {
+    // | `Centered => `Absolute((screenBounds.width - width) / 2)
+    // | x => x
+    // };
+  let y = options.y;
+    // switch (options.y) {
+    // | `Centered => `Absolute((screenBounds.height - height) / 2)
+    // | x => x
+    // };
 
   Log.infof(m =>
     m("Creating window %s width: %u height: %u", name, width, height)

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -580,15 +580,7 @@ let create = (name: string, options: WindowCreateOptions.t) => {
   let height = options.height == 0 ? 480 : options.height;
 
   let x = options.x;
-    // switch (options.x) {
-    // | `Centered => `Absolute((screenBounds.width - width) / 2)
-    // | x => x
-    // };
   let y = options.y;
-    // switch (options.y) {
-    // | `Centered => `Absolute((screenBounds.height - height) / 2)
-    // | x => x
-    // };
 
   Log.infof(m =>
     m("Creating window %s width: %u height: %u", name, width, height)


### PR DESCRIPTION
__Issue:__ Came from https://github.com/onivim/oni2/issues/3349 - the centering strategy implemented in https://github.com/revery-ui/revery/commit/08c21312e21f02dd33a074c0d9e67a46b4a9d381 does not handle multi-monitor setups well (it will place the application window in between multiple monitors, if there are 2)

__Fix:__ Just use SDL2's centering strategy, which will center on the relevant monitor based on where the application was started