### PR TITLE
fix(build): shell.c depends utilities.h on mobile

### DIFF
--- a/src/Native/shell.c
+++ b/src/Native/shell.c
@@ -15,6 +15,7 @@
 #elif USE_GTK
 #include "ReveryGtk.h"
 #endif
+#include "utilities.h"
 
 CAMLprim value revery_openURL(value vURL) {
     CAMLparam1(vURL);


### PR DESCRIPTION
This is an error that appears if you don't have `GTK`, `COCOA` or `WIN32` available. Like if you don't have gtk-dev installed or you're on mobile like Android and iOS