### PR TITLE
fix(osx): Crash when selecting a UTF-8 folder name

### DIFF
--- a/src/Native/dialog_cocoa.c
+++ b/src/Native/dialog_cocoa.c
@@ -86,6 +86,7 @@ const char **revery_open_files_cocoa(
             We NULL terminate it so we can get the size in the main function
         */
         int size = [urls count];
+        int actualSize = 0;
         const char **ret = malloc((size + 1) * sizeof(char *));
         // Copy the NSArray to the C-array
         for (int i = 0; i < size; i++) {
@@ -96,10 +97,13 @@ const char **revery_open_files_cocoa(
             // the [NSString]:
             // https://developer.apple.com/documentation/foundation/nsstring/1408489-cstringusingencoding?language=objc
             // So we need to make a copy here...
-            ret[i] = strdup(sz);
+            if (sz != NULL) {
+                ret[actualSize] = strdup(sz);
+                actualSize++;
+            }
         }
         [urls release];
-        ret[size] = NULL;
+        ret[actualSize] = NULL;
         [keyWindow makeKeyWindow];
         return ret;
     } else {

--- a/src/Native/dialog_cocoa.c
+++ b/src/Native/dialog_cocoa.c
@@ -90,7 +90,7 @@ const char **revery_open_files_cocoa(
         // Copy the NSArray to the C-array
         for (int i = 0; i < size; i++) {
             NSString *tmp = [[urls objectAtIndex:i] path];
-            const char *sz= [tmp cStringUsingEncoding:NSASCIIStringEncoding];
+            const char *sz= [tmp cStringUsingEncoding:NSUTF8StringEncoding];
             // According to the Objective-C docs, the returned string
             // is only guaranteed to be valid for the lifetime of
             // the [NSString]:


### PR DESCRIPTION
From https://github.com/onivim/oni2/issues/3519

__Issue:__ When selecting a folder on OSX with Unicode characters, Revery crashes.

__Defect:__ We were converting the returned string using:
```
cStringUsingEncoding:NSASCIIStringEncoding
```

That API returns `NULL` if the string cannot be losslessly encoded in the target format. In the case of a folder with Unicode characters, this API would return null, and the API was assuming that we'd always get a valid string.

__Fix:__ Two fixes:
1) Use UTF-8 encoding instead of ASCII, so that the API can handle Unicode
2) Handle the NULL case more reliably - if there happens to be a folder we can't convert, don't segfault, skip it.