### PR TITLE
feat(native): add `Input.openEmojiPanel` on macOS

### DIFF
--- a/examples/InputExample.re
+++ b/examples/InputExample.re
@@ -70,6 +70,13 @@ module Example = {
           title="Set value"
           onClick={() => setValue(state => {...state, first: "New value"})}
         />
+        <Button
+          height=50
+          width=100
+          fontSize=15.
+          title="Emoji"
+          onClick={() => Native.Input.openEmojiPanel()}
+        />
       </View>
       <Padding padding=20>
         <View

--- a/src/Native/Input.re
+++ b/src/Native/Input.re
@@ -84,3 +84,5 @@ module Button = {
 
   [%%endif];
 };
+
+external openEmojiPanel: unit => unit = "revery_openEmojiPanel";

--- a/src/Native/Input.rei
+++ b/src/Native/Input.rei
@@ -18,3 +18,5 @@ module Button: {
   let displayIn: (t, Sdl2.Window.t) => unit;
   let remove: t => unit;
 };
+
+let openEmojiPanel: unit => unit;

--- a/src/Native/ReveryCocoa.h
+++ b/src/Native/ReveryCocoa.h
@@ -46,6 +46,7 @@ void revery_menuItemSetVisible_cocoa(void *menuItem, int truth);
 /* Input functions */
 void *revery_buttonCreate_cocoa(const char *title);
 void revery_buttonSetColor_cocoa(void *nsButton, double red, double green, double blue, double alpha);
+void revery_openEmojiPanel_cocoa(void);
 
 /* Window functions */
 void revery_windowSetUnsavedWork_cocoa(void *memory, int truth);

--- a/src/Native/input.c
+++ b/src/Native/input.c
@@ -56,3 +56,13 @@ CAMLprim value revery_buttonSetColor(value vButton, value vRed, value vGreen, va
 
     CAMLreturn(Val_unit);
 }
+
+CAMLprim value revery_openEmojiPanel() {
+    CAMLparam0();
+
+#ifdef USE_COCOA
+    revery_openEmojiPanel_cocoa();
+#endif
+
+    CAMLreturn(Val_unit);
+}

--- a/src/Native/input_cocoa.c
+++ b/src/Native/input_cocoa.c
@@ -34,4 +34,8 @@ void revery_buttonSetColor_cocoa(NSButton *nsButton, double red, double green, d
     [nsButton setAttributedTitle:styledTitle];
 }
 
+void revery_openEmojiPanel_cocoa() {
+    [NSApp orderFrontCharacterPalette:nil];
+}
+
 #endif


### PR DESCRIPTION
One thing I've missed using Oni as my daily driver is the Emoji picker that is usually triggered by <kbd>Edit</kbd> -> <kbd>Emoji & Symbols</kbd>. This binds to that in `Revery_Native.Input`.


https://user-images.githubusercontent.com/4527949/119004996-0b713e00-b95d-11eb-8535-5f4be97e505f.mov

