### PR TITLE
fix(sdl2): Remove some unsafe acquire/release calls

### DIFF
--- a/packages/reason-sdl2/src/sdl2_wrapper.cpp
+++ b/packages/reason-sdl2/src/sdl2_wrapper.cpp
@@ -1026,9 +1026,7 @@ extern "C" {
         CAMLlocal2(ret, evt);
         SDL_Event e;
 
-        caml_release_runtime_system();
         int result = SDL_PollEvent(&e);
-        caml_acquire_runtime_system();
 
         if (result == 0) {
             ret = Val_none;
@@ -1045,9 +1043,7 @@ extern "C" {
         CAMLlocal2(ret, evt);
         SDL_Event e;
 
-        caml_release_runtime_system();
         int result = SDL_WaitEvent(&e);
-        caml_acquire_runtime_system();
 
         if (result == 1) {
             evt = Val_SDL_Event(&e);
@@ -1075,9 +1071,7 @@ extern "C" {
         int timeout = Int_val(vTimeout);
         SDL_Event e;
 
-        caml_release_runtime_system();
         int result = SDL_WaitEventTimeout(&e, timeout);
-        caml_acquire_runtime_system();
 
         if (result == 1) {
             evt = Val_SDL_Event(&e);


### PR DESCRIPTION
__Issue:__ From investigating https://github.com/ocaml/ocaml/issues/10422 - it looks like there are some uses of `caml_acquire_runtime`/`caml_release_runtime` that are actually unsafe - some callbacks, like the log or hit test callbacks, can actually be dispatched from these in certain platforms.

__Fix:__ Remove these unsafe release/acquire pairs around the SDL2 functions that can dispatch events.