### PR TITLE
fix(osx): Fix acquire/release runtime OSX callbacks

### DIFF
--- a/src/Native/utilities.c
+++ b/src/Native/utilities.c
@@ -12,9 +12,14 @@
 */
 void revery_caml_call_n(camlValue f, int argCount, camlValue *args) {
     caml_c_thread_register();
-    caml_acquire_runtime_system();
+    // With the change to remove the acquire/release runtime calls in:
+    // https://github.com/revery-ui/revery/pull/1072
+    // it seems that this acquire/release pair is no longer required
+    // (...and will crash).
+
+    // caml_acquire_runtime_system();
     caml_callbackN(f, argCount, args);
-    caml_release_runtime_system();
+    //caml_release_runtime_system();
 }
 
 void revery_caml_call(camlValue f) {


### PR DESCRIPTION
__Issue:__ In Onivim 2, after removing the acquire/release runtime calls in https://github.com/revery-ui/revery/pull/1072, I saw the native menu was crashing

This actually reproduces in the example app in a couple ways:
- Clicking on a native menu item
- Clicking on a native button

__Defect:__ The native menu callbacks assume the runtime will be released, but that's not the case anymore after #1072 

__Fix:__ Remove the release/acquire runtime pairs in the callback helper