### PR TITLE
fix(osx): Fix idle bug + enable smooth scroll events

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -222,6 +222,7 @@ let start = init => {
   let _ = Sdl2.ScreenSaver.enable();
 
   let _handleEvent = evt => {
+    appInstance.idleCount = 0;
     let handleEvent = windowID => {
       let window = getWindowById(appInstance, windowID);
       switch (window) {

--- a/src/Native/cocoa/ReveryAppDelegate.c
+++ b/src/Native/cocoa/ReveryAppDelegate.c
@@ -22,6 +22,7 @@
 
     NSString *valueToSave = @"true";
     [[NSUserDefaults standardUserDefaults] setObject:valueToSave forKey:@"ApplePressAndHoldEnabled"];
+    [[NSUserDefaults standardUserDefaults] setObject:valueToSave forKey:@"AppleMomentumScrollSupported"];
     [[NSUserDefaults standardUserDefaults] synchronize];
 
     return self;


### PR DESCRIPTION
Related https://github.com/onivim/oni2/pull/2880

- Turn on 'AppleSmoothScrollMomentumEnabled' flag
- Fix bug where the app would intermittently go idle during a smooth-scroll gesture