### PR TITLE
feat(sdl2): bring back continuous resize patch

### DIFF
--- a/packages/reason-sdl2/src/sdl2.re
+++ b/packages/reason-sdl2/src/sdl2.re
@@ -905,6 +905,7 @@ let _nativeLoop = renderFn => {
 };
 
 let renderLoop = (renderFunction: renderFunction) => {
+  Callback.register("__sdl2_caml_resize__", renderFunction);
   switch (Sys.backend_type) {
   | Native => _nativeLoop(renderFunction)
   | Bytecode => _nativeLoop(renderFunction)

--- a/packages/reason-sdl2/src/sdl2_wrapper.cpp
+++ b/packages/reason-sdl2/src/sdl2_wrapper.cpp
@@ -1553,6 +1553,24 @@ extern "C" {
         CAMLreturn(Val_unit);
     }
 
+    int resdl_eventWatcher(void *data, SDL_Event *event) {
+        if (event->type == SDL_WINDOWEVENT &&
+                event->window.event == SDL_WINDOWEVENT_RESIZED) {
+            value args[] = {Val_unit};
+
+            static const value *resizeCallback = NULL;
+            if (resizeCallback == NULL) {
+                resizeCallback = caml_named_value("__sdl2_caml_resize__");
+            }
+
+            if (resizeCallback) {
+                caml_callbackN(*resizeCallback, 1, args);
+            }
+        }
+
+        return 0;
+    }
+
     CAMLprim value resdl_SDL_CreateWindow(value vName, value vX, value vY,
                                           value vWidth, value vHeight, value vAcceleration) {
         CAMLparam5(vName, vX, vY, vWidth, vHeight);
@@ -1626,6 +1644,8 @@ extern "C" {
             SDL_LogCritical(SDL_LOG_CATEGORY_ERROR, "SDL_CreateWindow failed: %s\n",
                             SDL_GetError());
         }
+
+        SDL_AddEventWatch(resdl_eventWatcher, NULL);
 
         vWindow = resdl_wrapPointer(win);
         CAMLreturn(vWindow);


### PR DESCRIPTION
This seems to consistently work now (after #1072), and here is why I think that's the case:

Before, we would release the runtime lock before flushing events. These events would include things like mouse clicks, keyboard input, **window resizes**, etc. This meant that in the old patch, *most* resizes would require us to acquire the runtime lock since they were being "committed" in an event flush. However, last time we bumped up against a problematic resize: *synchronous* resizes, like `Window.maximize`. In this case, we already had the runtime lock when the event handler is called, so trying to acquire it again caused a deadlock.

*Now* we no longer release the runtime lock on event flushes 🎉. This means that in every case that we resize the window, the runtime lock is already acquired, so we don't have to acquire it.

@bryphe please let me know if you can think of another scenario where resizes would be triggered without the runtime lock, or if any of my reasoning sounds funny/wrong. 