### PR TITLE
fix(linux): Fix crash on resize with wayland

### DIFF
--- a/packages/reason-sdl2/src/sdl2_wrapper.cpp
+++ b/packages/reason-sdl2/src/sdl2_wrapper.cpp
@@ -1645,7 +1645,13 @@ extern "C" {
                             SDL_GetError());
         }
 
+// Only add the resize-event-watcher for OSX, since it's the platform that requires this to get
+// real-time resize notifications + re-renders.
+// This change caused a crash in Linux + Wayland: https://github.com/onivim/oni2/issues/3646
+// (with the crash callstack pointing to an error acquiring runtime lock after rendering)
+#ifdef __APPLE__
         SDL_AddEventWatch(resdl_eventWatcher, NULL);
+#endif
 
         vWindow = resdl_wrapPointer(win);
         CAMLreturn(vWindow);


### PR DESCRIPTION
__Issue:__ Revery / Onivim can crash when starting under wayland.

From Revery, this can be reproduced by running under `sway` and running the example with:
```
SDL_VIDEODRIVER=wayland esy '@examples' run
```

The application will hang after the first couple renders. Same issue as described in: https://github.com/onivim/oni2/issues/3646

__Defect:__ Based on my testing - it seems this is a regression from https://github.com/revery-ui/revery/pull/1077 However, in pulling the callstack from the hanging app, the application is hanging when trying to re-acquire the runtime after calling `SDL_GL_SwapWindows`. My hypothesis is that there is a timing issue - the time where those SDL_AddEventWatcher events are dispatched might be different per platform, and could be being dispatched while the runtime lock isn't acquired, which would cause a variety of problems like this hang.

__Fix:__ Scope the `AddEventWatcher` addition to OSX, where it was more thoroughly tested. A further fix may be to remove the release/acquire runtime aroud the swap windows call.